### PR TITLE
Fixes a NullPointerException in Chart.java when enable/disable scroll.

### DIFF
--- a/MPChartLib/src/com/github/mikephil/charting/charts/Chart.java
+++ b/MPChartLib/src/com/github/mikephil/charting/charts/Chart.java
@@ -1798,7 +1798,11 @@ public abstract class Chart<T extends ChartData<? extends DataSet<? extends Entr
      */
     public void disableScroll() {
         ViewParent parent = getParent();
-        parent.requestDisallowInterceptTouchEvent(true);
+        try {
+            parent.requestDisallowInterceptTouchEvent(true);
+        } catch (NullPointerException e) {
+            Log.w(LOG_TAG, "NullPointerException of parent in disableScroll");
+        }
     }
 
     /**
@@ -1806,7 +1810,11 @@ public abstract class Chart<T extends ChartData<? extends DataSet<? extends Entr
      */
     public void enableScroll() {
         ViewParent parent = getParent();
-        parent.requestDisallowInterceptTouchEvent(false);
+        try {
+            parent.requestDisallowInterceptTouchEvent(false);
+        } catch (NullPointerException e) {
+            Log.w(LOG_TAG, "NullPointerException of parent in enableScroll.");
+        }
     }
 
     /** paint for the grid lines (only line and barchart) */


### PR DESCRIPTION
While working in my project with this (awesome) library I encountered a NullPointerException in the enableScroll-method in the Chart.java. 

It occurred in the following situation: I had a BarChart displayed in the header of a ListView, then I updated the ListView adapter at run-time in response to an OnChartValueSelectedListener of the bar chart. Thereafter the error occurs, i.e. the ViewParent-object was null.

Adding this try-catch structure fixed the problems for me and I didn't see any strange behavior. I also added this try-catch structure to the disableScroll method, because the two methods are very identical.

Do you think this try-catch structure is sufficient ? Or are there extra changes necessary because the enableScroll method 'fails'.

You can also check this behaviour in my project : https://github.com/MPieter/Notification-Analyser . Comment these changes and then see what happens.

And thanks for this good library ! 