### PR TITLE
PieChart transparent hole

### DIFF
--- a/MPChartExample/res/menu/pie.xml
+++ b/MPChartExample/res/menu/pie.xml
@@ -1,41 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
-<menu xmlns:android="http://schemas.android.com/apk/res/android" >
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item
         android:id="@+id/actionToggleValues"
-        android:title="Toggle Y-Values">
-    </item>
+        android:title="Toggle Y-Values"></item>
     <item
         android:id="@+id/actionToggleXVals"
-        android:title="Toggle X-Values">
-    </item>
+        android:title="Toggle X-Values"></item>
     <item
         android:id="@+id/actionTogglePercent"
-        android:title="Toggle Percent">
-    </item>
+        android:title="Toggle Percent"></item>
     <item
         android:id="@+id/actionToggleHole"
-        android:title="Toggle Hole">
-    </item>
+        android:title="Toggle Hole"></item>
+    <item
+        android:id="@+id/actionHoleTransparent"
+        android:title="Transparent Hole"></item>
     <item
         android:id="@+id/animateX"
-        android:title="Animate X">
-    </item>
+        android:title="Animate X"></item>
     <item
         android:id="@+id/animateY"
-        android:title="Animate Y">
-    </item>
-        <item
+        android:title="Animate Y"></item>
+    <item
         android:id="@+id/animateXY"
-        android:title="Animate XY">
-    </item>
+        android:title="Animate XY"></item>
     <item
         android:id="@+id/actionDrawCenter"
-        android:title="Draw CenterText">
-    </item>
+        android:title="Draw CenterText"></item>
     <item
         android:id="@+id/actionSave"
-        android:title="Save to Gallery">
-    </item>
+        android:title="Save to Gallery"></item>
 
 </menu>

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/PieChartActivity.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/PieChartActivity.java
@@ -52,7 +52,7 @@ public class PieChartActivity extends DemoBase implements OnSeekBarChangeListene
         mChart = (PieChart) findViewById(R.id.chart1);
 
         // change the color of the center-hole
-        mChart.setHoleColor(Color.rgb(235, 235, 235));
+        mChart.setHoleColor(Color.WHITE);
 
         Typeface tf = Typeface.createFromAsset(getAssets(), "OpenSans-Regular.ttf");
 
@@ -133,6 +133,11 @@ public class PieChartActivity extends DemoBase implements OnSeekBarChangeListene
                 mChart.invalidate();
                 break;
             }
+            case R.id.actionHoleTransparent: {
+                mChart.setHoleTransparent(!mChart.isHoleTransparent());
+                mChart.invalidate();
+                break;
+            }
             case R.id.actionDrawCenter: {
                 if (mChart.isDrawCenterTextEnabled())
                     mChart.setDrawCenterText(false);
@@ -199,7 +204,7 @@ public class PieChartActivity extends DemoBase implements OnSeekBarChangeListene
 
         PieDataSet set1 = new PieDataSet(yVals1, "Election Results");
         set1.setSliceSpace(3f);
-        
+
         // add a lot of colors
 
         ArrayList<Integer> colors = new ArrayList<Integer>();
@@ -215,10 +220,10 @@ public class PieChartActivity extends DemoBase implements OnSeekBarChangeListene
 
         for (int c : ColorTemplate.LIBERTY_COLORS)
             colors.add(c);
-        
+
         for (int c : ColorTemplate.PASTEL_COLORS)
             colors.add(c);
-        
+
         colors.add(ColorTemplate.getHoloBlue());
 
         set1.setColors(colors);

--- a/MPChartLib/src/com/github/mikephil/charting/charts/PieChart.java
+++ b/MPChartLib/src/com/github/mikephil/charting/charts/PieChart.java
@@ -7,6 +7,8 @@ import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.Paint.Align;
 import android.graphics.PointF;
+import android.graphics.PorterDuff;
+import android.graphics.PorterDuffXfermode;
 import android.graphics.RectF;
 import android.graphics.Typeface;
 import android.util.AttributeSet;
@@ -21,7 +23,7 @@ import java.util.ArrayList;
 
 /**
  * View that represents a pie chart. Draws cake like slices.
- * 
+ *
  * @author Philipp Jahoda
  */
 public class PieChart extends PieRadarChartBase<PieData> {
@@ -32,13 +34,19 @@ public class PieChart extends PieRadarChartBase<PieData> {
      */
     private RectF mCircleBox = new RectF();
 
-    /** array that holds the width of each pie-slice in degrees */
+    /**
+     * array that holds the width of each pie-slice in degrees
+     */
     private float[] mDrawAngles;
 
-    /** array that holds the absolute angle in degrees of each slice */
+    /**
+     * array that holds the absolute angle in degrees of each slice
+     */
     private float[] mAbsoluteAngles;
 
-    /** if true, the white hole inside the chart will be drawn */
+    /**
+     * if true, the white hole inside the chart will be drawn
+     */
     private boolean mDrawHole = true;
 
     /**
@@ -58,7 +66,9 @@ public class PieChart extends PieRadarChartBase<PieData> {
      */
     private float mTransparentCircleRadius = 55f;
 
-    /** if enabled, centertext is drawn */
+    /**
+     * if enabled, centertext is drawn
+     */
     private boolean mDrawCenterText = true;
 
     /**
@@ -77,6 +87,12 @@ public class PieChart extends PieRadarChartBase<PieData> {
      * circle
      */
     private Paint mHolePaint;
+
+    /**
+     * {@link android.graphics.PorterDuffXfermode} used to display a transparent hole by applying
+     * {@link android.graphics.PorterDuff.Mode#DST_OUT} mode.
+     */
+    private PorterDuffXfermode mTransparentHoleMode;
 
     /**
      * paint object for the text that can be displayed in the center of the
@@ -304,7 +320,7 @@ public class PieChart extends PieRadarChartBase<PieData> {
     /**
      * checks if the given index in the given DataSet is set for highlighting or
      * not
-     * 
+     *
      * @param xIndex
      * @param dataSetIndex
      * @return
@@ -338,6 +354,10 @@ public class PieChart extends PieRadarChartBase<PieData> {
             PointF c = getCenterCircleBox();
 
             int color = mHolePaint.getColor();
+
+            // if transparent hole has been enable, Porter-Duff DEST_OUT mode will be set
+            // to "clear" the hole, otherwise, null will be passed to erase the previous mode.
+            mHolePaint.setXfermode(mTransparentHoleMode);
 
             // draw the hole-circle
             mDrawCanvas.drawCircle(c.x, c.y,
@@ -385,7 +405,7 @@ public class PieChart extends PieRadarChartBase<PieData> {
                 String line = lines[lines.length - i - 1];
 
                 mDrawCanvas.drawText(line, c.x, y
-                        + lineHeight * cnt - totalheight / 2f,
+                                + lineHeight * cnt - totalheight / 2f,
                         mCenterTextPaint);
                 cnt--;
                 y -= linespacing;
@@ -430,10 +450,10 @@ public class PieChart extends PieRadarChartBase<PieData> {
                 // calculate the text position
                 float x = (float) (r
                         * Math.cos(Math.toRadians((mRotationAngle + mAbsoluteAngles[cnt] - offset)
-                                * mPhaseY)) + center.x);
+                        * mPhaseY)) + center.x);
                 float y = (float) (r
                         * Math.sin(Math.toRadians((mRotationAngle + mAbsoluteAngles[cnt] - offset)
-                                * mPhaseY)) + center.y);
+                        * mPhaseY)) + center.y);
 
                 String val = "";
                 float value = entries.get(j).getVal();
@@ -481,7 +501,7 @@ public class PieChart extends PieRadarChartBase<PieData> {
 
     /**
      * calculates the needed angle for a given value
-     * 
+     *
      * @param value
      * @return
      */
@@ -505,7 +525,7 @@ public class PieChart extends PieRadarChartBase<PieData> {
 
     /**
      * Returns the index of the DataSet this x-index belongs to.
-     * 
+     *
      * @param xIndex
      * @return
      */
@@ -525,7 +545,7 @@ public class PieChart extends PieRadarChartBase<PieData> {
      * returns an integer array of all the different angles the chart slices
      * have the angles in the returned array determine how much space (of 360°)
      * each slice takes
-     * 
+     *
      * @return
      */
     public float[] getDrawAngles() {
@@ -535,7 +555,7 @@ public class PieChart extends PieRadarChartBase<PieData> {
     /**
      * returns the absolute angles of the different chart slices (where the
      * slices end)
-     * 
+     *
      * @return
      */
     public float[] getAbsoluteAngles() {
@@ -545,7 +565,7 @@ public class PieChart extends PieRadarChartBase<PieData> {
     /**
      * Sets the color for the hole that is drawn in the center of the piechart
      * (if enabled).
-     * 
+     *
      * @param color
      */
     public void setHoleColor(int color) {
@@ -553,8 +573,30 @@ public class PieChart extends PieRadarChartBase<PieData> {
     }
 
     /**
+     * Set the hole transparency policy.
+     *
+     * @param enable true to enable transparency and display widget or background under pie chart.
+     */
+    public void setHoleTransparent(boolean enable) {
+        if (enable) {
+            mTransparentHoleMode = new PorterDuffXfermode(PorterDuff.Mode.DST_OUT);
+        } else {
+            mTransparentHoleMode = null;
+        }
+    }
+
+    /**
+     * Use to know is hole transparency has been enable.
+     *
+     * @return true if hole is transparent.
+     */
+    public boolean isHoleTransparent() {
+        return mTransparentHoleMode != null;
+    }
+
+    /**
      * set this to true to draw the pie center empty
-     * 
+     *
      * @param enabled
      */
     public void setDrawHoleEnabled(boolean enabled) {
@@ -564,7 +606,7 @@ public class PieChart extends PieRadarChartBase<PieData> {
     /**
      * returns true if the hole in the center of the pie-chart is set to be
      * visible, false if not
-     * 
+     *
      * @return
      */
     public boolean isDrawHoleEnabled() {
@@ -574,7 +616,7 @@ public class PieChart extends PieRadarChartBase<PieData> {
     /**
      * sets the text that is displayed in the center of the pie-chart. By
      * default, the text is "Total Value + sumofallvalues"
-     * 
+     *
      * @param text
      */
     public void setCenterText(String text) {
@@ -583,7 +625,7 @@ public class PieChart extends PieRadarChartBase<PieData> {
 
     /**
      * returns the text that is drawn in the center of the pie-chart
-     * 
+     *
      * @return
      */
     public String getCenterText() {
@@ -593,7 +635,7 @@ public class PieChart extends PieRadarChartBase<PieData> {
     /**
      * set this to true to draw the text that is displayed in the center of the
      * pie chart
-     * 
+     *
      * @param enabled
      */
     public void setDrawCenterText(boolean enabled) {
@@ -602,7 +644,7 @@ public class PieChart extends PieRadarChartBase<PieData> {
 
     /**
      * returns true if drawing the center text is enabled
-     * 
+     *
      * @return
      */
     public boolean isDrawCenterTextEnabled() {
@@ -611,7 +653,7 @@ public class PieChart extends PieRadarChartBase<PieData> {
 
     /**
      * set this to true to draw percent values instead of the actual values
-     * 
+     *
      * @param enabled
      */
     public void setUsePercentValues(boolean enabled) {
@@ -620,7 +662,7 @@ public class PieChart extends PieRadarChartBase<PieData> {
 
     /**
      * returns true if drawing percent values is enabled
-     * 
+     *
      * @return
      */
     public boolean isUsePercentValuesEnabled() {
@@ -629,7 +671,7 @@ public class PieChart extends PieRadarChartBase<PieData> {
 
     /**
      * set this to true to draw the x-value text into the pie slices
-     * 
+     *
      * @param enabled
      */
     public void setDrawXValues(boolean enabled) {
@@ -638,7 +680,7 @@ public class PieChart extends PieRadarChartBase<PieData> {
 
     /**
      * returns true if drawing x-values is enabled, false if not
-     * 
+     *
      * @return
      */
     public boolean isDrawXValuesEnabled() {
@@ -665,7 +707,7 @@ public class PieChart extends PieRadarChartBase<PieData> {
 
     /**
      * returns the circlebox, the boundingbox of the pie-chart slices
-     * 
+     *
      * @return
      */
     public RectF getCircleBox() {
@@ -674,7 +716,7 @@ public class PieChart extends PieRadarChartBase<PieData> {
 
     /**
      * returns the center of the circlebox
-     * 
+     *
      * @return
      */
     public PointF getCenterCircleBox() {
@@ -683,7 +725,7 @@ public class PieChart extends PieRadarChartBase<PieData> {
 
     /**
      * sets the typeface for the center-text paint
-     * 
+     *
      * @param t
      */
     public void setCenterTextTypeface(Typeface t) {
@@ -692,7 +734,7 @@ public class PieChart extends PieRadarChartBase<PieData> {
 
     /**
      * Sets the size of the center text of the piechart.
-     * 
+     *
      * @param size
      */
     public void setCenterTextSize(float size) {
@@ -702,8 +744,8 @@ public class PieChart extends PieRadarChartBase<PieData> {
     /**
      * sets the radius of the hole in the center of the piechart in percent of
      * the maximum radius (max = the radius of the whole chart), default 50%
-     * 
-     * @param size
+     *
+     * @param percent
      */
     public void setHoleRadius(final float percent) {
         mHoleRadiusPercent = percent;
@@ -714,7 +756,7 @@ public class PieChart extends PieRadarChartBase<PieData> {
      * in the piechart in percent of the maximum radius (max = the radius of the
      * whole chart), default 55% -> means 5% larger than the center-hole by
      * default
-     * 
+     *
      * @param percent
      */
     public void setTransparentCircleRadius(final float percent) {

--- a/MPChartLib/src/com/github/mikephil/charting/charts/PieChart.java
+++ b/MPChartLib/src/com/github/mikephil/charting/charts/PieChart.java
@@ -89,12 +89,6 @@ public class PieChart extends PieRadarChartBase<PieData> {
     private Paint mHolePaint;
 
     /**
-     * {@link android.graphics.PorterDuffXfermode} used to display a transparent hole by applying
-     * {@link android.graphics.PorterDuff.Mode#DST_OUT} mode.
-     */
-    private PorterDuffXfermode mTransparentHoleMode;
-
-    /**
      * paint object for the text that can be displayed in the center of the
      * chart
      */
@@ -355,10 +349,6 @@ public class PieChart extends PieRadarChartBase<PieData> {
 
             int color = mHolePaint.getColor();
 
-            // if transparent hole has been enable, Porter-Duff DEST_OUT mode will be set
-            // to "clear" the hole, otherwise, null will be passed to erase the previous mode.
-            mHolePaint.setXfermode(mTransparentHoleMode);
-
             // draw the hole-circle
             mDrawCanvas.drawCircle(c.x, c.y,
                     radius / 100 * mHoleRadiusPercent, mHolePaint);
@@ -579,9 +569,9 @@ public class PieChart extends PieRadarChartBase<PieData> {
      */
     public void setHoleTransparent(boolean enable) {
         if (enable) {
-            mTransparentHoleMode = new PorterDuffXfermode(PorterDuff.Mode.DST_OUT);
+            mHolePaint.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.DST_OUT));
         } else {
-            mTransparentHoleMode = null;
+            mHolePaint.setXfermode(null);
         }
     }
 
@@ -591,7 +581,7 @@ public class PieChart extends PieRadarChartBase<PieData> {
      * @return true if hole is transparent.
      */
     public boolean isHoleTransparent() {
-        return mTransparentHoleMode != null;
+        return mHolePaint.getXfermode() != null;
     }
 
     /**

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.12.+'
+        classpath 'com.android.tools.build:gradle:0.14.0'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 10 15:27:10 PDT 2013
+#Wed Nov 05 12:17:34 CET 2014
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.12-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.1-all.zip


### PR DESCRIPTION
First of all, thanks a lot for your awesome works on charts!

Here is a small tweak I add to PieChart in order to enable transparent hole. 

In my case, I used a textured background that's why I decided to add this feature.

![piechart](https://cloud.githubusercontent.com/assets/4211470/4919331/55f24d3a-64f9-11e4-8a15-26f3f08d1e4d.png)
