### PR TITLE
PieChart highlight pop out math error for highlight pie slice

### DIFF
--- a/MPChartLib/src/com/github/mikephil/charting/charts/PieChart.java
+++ b/MPChartLib/src/com/github/mikephil/charting/charts/PieChart.java
@@ -239,12 +239,13 @@ public class PieChart extends PieRadarChartBase<PieData> {
                     continue;
 
                 float shift = set.getSelectionShift();
-                float xShift = shift * (float) Math.cos(shiftangle);
-                float yShift = shift * (float) Math.sin(shiftangle);
-
-                RectF highlighted = new RectF(mCircleBox.left + xShift, mCircleBox.top + yShift,
-                        mCircleBox.right
-                                + xShift, mCircleBox.bottom + yShift);
+                // make the box containing current arc larger equally
+                // in every dimension, to preserve shape of arc
+                RectF highlighted = new RectF(mCircleBox.left - shift,
+                                              mCircleBox.top - shift,
+                                              mCircleBox.right + shift,
+                                              mCircleBox.bottom + shift);
+               
 
                 mRenderPaint.setColor(set.getColor(xIndex));
 

--- a/Projects_using_MPAndroidChart.txt
+++ b/Projects_using_MPAndroidChart.txt
@@ -17,3 +17,6 @@ https://play.google.com/store/apps/details?id=com.armsoft.mtrade
 
 Notification Analyser
 https://play.google.com/store/apps/details?id=com.tierep.notificationanalyser
+
+RescueTime
+https://play.google.com/store/apps/details?id=com.rescuetime.android


### PR DESCRIPTION
The shape of the popup pie slice gets wonky when the size changes. Not sure what the goal there was using the sin / cos values to adjust size of arc, but it becomes an oval due to the math.

I have patched my fork to just equally enlarge the arc's box in every dimension so the shape of the original arc is preserved, rather than changed in ovoid manner.

This issue becomes especially apparent when pie slices exceed 90 degrees.
