### PR TITLE
Fix wrong position of linear legend form

### DIFF
--- a/MPChartLib/src/com/github/mikephil/charting/utils/Legend.java
+++ b/MPChartLib/src/com/github/mikephil/charting/utils/Legend.java
@@ -344,7 +344,7 @@ public class Legend {
                 c.drawRect(x, y, x + mFormSize, y + mFormSize, p);
                 break;
             case LINE:
-                c.drawLine(x - half, y + half, x + half, y + half, p);
+                c.drawLine(x, y + half, x + mFormSize, y + half, p);
                 break;
         }
     }


### PR DESCRIPTION
The (x, y) is start point of the form, but not center