### PR TITLE
Changed minSdkVersion to 8 for MPChartExample

### DIFF
--- a/MPChartExample/build.gradle
+++ b/MPChartExample/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 19
     buildToolsVersion '19.1.0'
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 8
         targetSdkVersion 19
         versionCode 29
         versionName '1.7.4'


### PR DESCRIPTION
I changed the minSdkVersion of MPChartExample to 8 so I can run it directly to older device.