### PR TITLE
Added stroke line ratio for LineChart

### DIFF
--- a/MPChartLib/src/com/github/mikephil/charting/charts/LineChart.java
+++ b/MPChartLib/src/com/github/mikephil/charting/charts/LineChart.java
@@ -445,7 +445,7 @@ public class LineChart extends BarLineChartBase<LineData> {
                     mDrawCanvas.drawCircle(positions[j], positions[j + 1], dataSet.getCircleSize(),
                             mRenderPaint);
                     mDrawCanvas.drawCircle(positions[j], positions[j + 1],
-                            dataSet.getCircleSize() / 2f,
+                            dataSet.getCircleSize() * (1 - dataSet.getCircleStrokeRatio()),
                             mCirclePaintInner);
                 }
             } // else do nothing

--- a/MPChartLib/src/com/github/mikephil/charting/data/LineDataSet.java
+++ b/MPChartLib/src/com/github/mikephil/charting/data/LineDataSet.java
@@ -117,17 +117,22 @@ public class LineDataSet extends LineRadarDataSet<Entry> {
 
     /**
      * Sets the circle stroke ratio
-     * @param mCircleStrokeRatio the ratio of the circle stroke. Default value is 0.5f, meaning that
+     * @param circleStrokeRatio the ratio of the circle stroke. Default value is 0.5f, meaning that
      * the stoke is half of the total circle diameter. It should be between 0f (no stroke) and 1f
      * (circle is filled)
      */
-    public void setCircleStrokeRatio(float mCircleStrokeRatio) {
-        this.mCircleStrokeRatio = mCircleStrokeRatio;
+    public void setCircleStrokeRatio(float circleStrokeRatio) {
+        // We don't allow negative values
+        if (circleStrokeRatio < 0f) mCircleStrokeRatio = 0f;
+        // Ratio can't be above 1 (already fully filled)
+        else if (circleStrokeRatio > 1f) mCircleStrokeRatio = 1f;
+        // Else we just set the value
+        else mCircleStrokeRatio = circleStrokeRatio;
     }
 
     /**
      * Circle stroke ratio getter
-     * @return Returns the ratio of the stroke for the circle
+     * @return Returns the ratio of the stroke for the circle.
      */
     public float getCircleStrokeRatio() {
         return mCircleStrokeRatio;

--- a/MPChartLib/src/com/github/mikephil/charting/data/LineDataSet.java
+++ b/MPChartLib/src/com/github/mikephil/charting/data/LineDataSet.java
@@ -18,6 +18,12 @@ public class LineDataSet extends LineRadarDataSet<Entry> {
     /** the radius of the circle-shaped value indicators */
     private float mCircleSize = 4f;
 
+    /**
+     * the ratio of the circle stroke. Default value is 0.5f, meaning that the stoke is half of the
+     * total circle diameter. It should be between 0f (no stroke) and 1f (circle is filled)
+     */
+    private float mCircleStrokeRatio = 0.5f;
+
     /** sets the intensity of the cubic lines */
     private float mCubicIntensity = 0.2f;
 
@@ -56,6 +62,7 @@ public class LineDataSet extends LineRadarDataSet<Entry> {
         LineDataSet copied = new LineDataSet(yVals, getLabel());
         copied.mColors = mColors;
         copied.mCircleSize = mCircleSize;
+        copied.mCircleStrokeRatio = mCircleStrokeRatio;
         copied.mCircleColors = mCircleColors;
         copied.mDashPathEffect = mDashPathEffect;
         copied.mDrawCircles = mDrawCircles;
@@ -105,6 +112,25 @@ public class LineDataSet extends LineRadarDataSet<Entry> {
      */
     public float getCircleSize() {
         return mCircleSize;
+    }
+
+
+    /**
+     * Sets the circle stroke ratio
+     * @param mCircleStrokeRatio the ratio of the circle stroke. Default value is 0.5f, meaning that
+     * the stoke is half of the total circle diameter. It should be between 0f (no stroke) and 1f
+     * (circle is filled)
+     */
+    public void setCircleStrokeRatio(float mCircleStrokeRatio) {
+        this.mCircleStrokeRatio = mCircleStrokeRatio;
+    }
+
+    /**
+     * Circle stroke ratio getter
+     * @return Returns the ratio of the stroke for the circle
+     */
+    public float getCircleStrokeRatio() {
+        return mCircleStrokeRatio;
     }
 
     /**


### PR DESCRIPTION
Currently, the width of the stroke of the circle is hard coded as being half of the total circle size. I propose to leave the option for the user to set this ratio. You can set this ratio between 0f (no stroke at all) and 1f (circle completely filled). If nothing is set it stays like before (ratio of 0.5f)