### PR TITLE
Added android-maven plugin

### DIFF
--- a/MPChartLib/build.gradle
+++ b/MPChartLib/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.library'
+apply plugin: 'android-maven'
 
 android {
     compileSdkVersion 19

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:1.0.0'
+        classpath 'com.github.dcendents:android-maven-plugin:1.2'
     }
 }
 


### PR DESCRIPTION
With android-maven plugin MPAndroidChart can now be installed in the local maven repository:

    gradle install

In addition its now possible to get it as a maven dependency: https://jitpack.io/#jitpack/MPAndroidChart/v1.7.5 : )


