### PR TITLE
Change Rendeder's access level modifiers for extra draw methods

### DIFF
--- a/MPChartExample/build.gradle
+++ b/MPChartExample/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 19
-    buildToolsVersion '19.1.0'
+    buildToolsVersion '21.1.1'
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 19

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/LineChartRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/LineChartRenderer.java
@@ -357,7 +357,7 @@ public class LineChartRenderer extends DataRenderer {
         drawCircles(c);
     }
 
-    private void drawCircles(Canvas c) {
+    protected void drawCircles(Canvas c) {
         mRenderPaint.setStyle(Paint.Style.FILL);
 
         ArrayList<LineDataSet> dataSets = mChart.getLineData().getDataSets();

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/PieChartRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/PieChartRenderer.java
@@ -200,7 +200,7 @@ public class PieChartRenderer extends DataRenderer {
      * draws the hole in the center of the chart and the transparent circle /
      * hole
      */
-    private void drawHole(Canvas c) {
+    protected void drawHole(Canvas c) {
 
         if (mChart.isDrawHoleEnabled()) {
 
@@ -234,7 +234,7 @@ public class PieChartRenderer extends DataRenderer {
      * draws the description text in the center of the pie chart makes most
      * sense when center-hole is enabled
      */
-    private void drawCenterText(Canvas c) {
+    protected void drawCenterText(Canvas c) {
 
         String centerText = mChart.getCenterText();
 

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/RadarChartRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/RadarChartRenderer.java
@@ -141,7 +141,7 @@ public class RadarChartRenderer extends DataRenderer {
         drawWeb(c);
     }
     
-    private void drawWeb(Canvas c) {
+    protected void drawWeb(Canvas c) {
         
         float sliceangle = mChart.getSliceAngle();
 


### PR DESCRIPTION
I want to override how PieChartRenderer's center text is drawn, but since drawCenterText is private, I can't do anything.

I've modified all *drawXXX()* invoked from *drawExtras()*, which were the ones declared as private.

Also, I've upgraded the example buildTools, which was still set to 19.0.0, whereas the library was already using 21.1.1