### PR TITLE
Implement VisibleEntry enum for the YAxis class

### DIFF
--- a/MPChartLib/src/com/github/mikephil/charting/components/YAxis.java
+++ b/MPChartLib/src/com/github/mikephil/charting/components/YAxis.java
@@ -9,6 +9,7 @@ import com.github.mikephil.charting.utils.Utils;
 import com.github.mikephil.charting.utils.ValueFormatter;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 
 /**
@@ -21,6 +22,14 @@ import java.util.List;
  * @author Philipp Jahoda
  */
 public class YAxis extends AxisBase {
+    /**
+     * Enum that allows to specify which entries will show on the axis
+     */
+    public enum VisibleEntry {
+        MIN,
+        INNER,
+        MAX,
+    }
 
     /** custom formatter that is used instead of the auto-formatter if set */
     protected ValueFormatter mValueFormatter;
@@ -37,11 +46,11 @@ public class YAxis extends AxisBase {
     /** the number of y-label entries the y-labels should have, default 6 */
     private int mLabelCount = 6;
 
-    /** indicates if the top y-label entry is drawn or not */
-    private boolean mDrawTopYLabelEntry = true;
+    /** set contains which labels will draw on the axis */
+    private final EnumSet<VisibleEntry> mVisibleLabelsSet = EnumSet.allOf(VisibleEntry.class);
 
-    /** if true, the y-labels show only the minimum and maximum value */
-    protected boolean mShowOnlyMinMax = false;
+    /** set contains which grid lines will draw on the axis */
+    private final EnumSet<VisibleEntry> mVisibleGridLinesSet = EnumSet.allOf(VisibleEntry.class);
 
     /** flag that indicates if the axis is inverted or not */
     protected boolean mInverted = false;
@@ -135,7 +144,7 @@ public class YAxis extends AxisBase {
      * @return
      */
     public boolean isDrawTopYLabelEntryEnabled() {
-        return mDrawTopYLabelEntry;
+        return mVisibleLabelsSet.contains(VisibleEntry.MAX);
     }
 
     /**
@@ -146,7 +155,12 @@ public class YAxis extends AxisBase {
      * @param enabled
      */
     public void setDrawTopYLabelEntry(boolean enabled) {
-        mDrawTopYLabelEntry = enabled;
+        if(enabled) {
+            mVisibleLabelsSet.add(VisibleEntry.MAX);
+        }
+        else {
+            mVisibleLabelsSet.remove(VisibleEntry.MAX);
+        }
     }
 
     /**
@@ -182,7 +196,16 @@ public class YAxis extends AxisBase {
      * @param enabled
      */
     public void setShowOnlyMinMax(boolean enabled) {
-        mShowOnlyMinMax = enabled;
+        if(enabled) {
+            mVisibleLabelsSet.add(VisibleEntry.MIN);
+            mVisibleLabelsSet.remove(VisibleEntry.INNER);
+            mVisibleLabelsSet.add(VisibleEntry.MAX);
+        }
+        else {
+            mVisibleLabelsSet.add(VisibleEntry.MIN);
+            mVisibleLabelsSet.add(VisibleEntry.INNER);
+            mVisibleLabelsSet.add(VisibleEntry.MAX);
+        }
     }
 
     /**
@@ -191,7 +214,23 @@ public class YAxis extends AxisBase {
      * @return
      */
     public boolean isShowOnlyMinMaxEnabled() {
-        return mShowOnlyMinMax;
+        return !mVisibleLabelsSet.contains(VisibleEntry.INNER);
+    }
+
+    /**
+     * Returns set that contains which labels will draw on the axis
+     * @return
+     */
+    public EnumSet<VisibleEntry> getVisibleLabelsSet() {
+        return mVisibleLabelsSet;
+    }
+
+    /**
+     * Returns set that contains which grid lines will draw on the axis
+     * @return
+     */
+    public EnumSet<VisibleEntry> getVisibleGridLinesSet() {
+        return mVisibleGridLinesSet;
     }
 
     /**

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/YAxisRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/YAxisRenderer.java
@@ -99,36 +99,25 @@ public class YAxisRenderer extends AxisRenderer {
             interval = Math.floor(10 * intervalMagnitude);
         }
 
-        // if the labels should only show min and max
-        if (mYAxis.isShowOnlyMinMaxEnabled()) {
+        double first = Math.ceil(yMin / interval) * interval;
+        double last = Utils.nextUp(Math.floor(yMax / interval) * interval);
 
-            mYAxis.mEntryCount = 2;
-            mYAxis.mEntries = new float[2];
-            mYAxis.mEntries[0] = yMin;
-            mYAxis.mEntries[1] = yMax;
+        double f;
+        int i;
+        int n = 0;
+        for (f = first; f <= last; f += interval) {
+            ++n;
+        }
 
-        } else {
+        mYAxis.mEntryCount = n;
 
-            double first = Math.ceil(yMin / interval) * interval;
-            double last = Utils.nextUp(Math.floor(yMax / interval) * interval);
+        if (mYAxis.mEntries.length < n) {
+            // Ensure stops contains at least numStops elements.
+            mYAxis.mEntries = new float[n];
+        }
 
-            double f;
-            int i;
-            int n = 0;
-            for (f = first; f <= last; f += interval) {
-                ++n;
-            }
-
-            mYAxis.mEntryCount = n;
-
-            if (mYAxis.mEntries.length < n) {
-                // Ensure stops contains at least numStops elements.
-                mYAxis.mEntries = new float[n];
-            }
-
-            for (f = first, i = 0; i < n; f += interval, ++i) {
-                mYAxis.mEntries[i] = (float) f;
-            }
+        for (f = first, i = 0; i < n; f += interval, ++i) {
+            mYAxis.mEntries[i] = (float) f;
         }
 
         if (interval < 1) {
@@ -224,12 +213,22 @@ public class YAxisRenderer extends AxisRenderer {
 
         // draw
         for (int i = 0; i < mYAxis.mEntryCount; i++) {
+            if(i == 0
+                    && !mYAxis.getVisibleLabelsSet().contains(YAxis.VisibleEntry.MIN)) {
+                continue;
+            }
+
+            if(i == mYAxis.mEntryCount - 1
+                    && !mYAxis.getVisibleLabelsSet().contains(YAxis.VisibleEntry.MAX)) {
+                continue;
+            }
+
+            if(i > 0 && i < mYAxis.mEntryCount - 1
+                    && !mYAxis.getVisibleLabelsSet().contains(YAxis.VisibleEntry.INNER)) {
+                continue;
+            }
 
             String text = mYAxis.getFormattedLabel(i);
-
-            if (!mYAxis.isDrawTopYLabelEntryEnabled() && i >= mYAxis.mEntryCount - 1)
-                return;
-
             c.drawText(text, fixedPosition, positions[i * 2 + 1] + offset, mAxisLabelPaint);
         }
     }
@@ -251,6 +250,20 @@ public class YAxisRenderer extends AxisRenderer {
 
         // draw the horizontal grid
         for (int i = 0; i < mYAxis.mEntryCount; i++) {
+            if(i == 0
+                    && !mYAxis.getVisibleGridLinesSet().contains(YAxis.VisibleEntry.MIN)) {
+                continue;
+            }
+
+            if(i == mYAxis.mEntryCount - 1
+                    && !mYAxis.getVisibleGridLinesSet().contains(YAxis.VisibleEntry.MAX)) {
+                continue;
+            }
+
+            if(i > 0 && i < mYAxis.mEntryCount - 1
+                    && !mYAxis.getVisibleGridLinesSet().contains(YAxis.VisibleEntry.INNER)) {
+                continue;
+            }
 
             position[1] = mYAxis.mEntries[i];
             mTrans.pointValuesToPixel(position);

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/YAxisRendererHorizontalBarChart.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/YAxisRendererHorizontalBarChart.java
@@ -145,6 +145,20 @@ public class YAxisRendererHorizontalBarChart extends YAxisRenderer {
         mAxisLabelPaint.setColor(mYAxis.getTextColor());
 
         for (int i = 0; i < mYAxis.mEntryCount; i++) {
+            if(i == 0
+                    && !mYAxis.getVisibleLabelsSet().contains(YAxis.VisibleEntry.MIN)) {
+                continue;
+            }
+
+            if(i == mYAxis.mEntryCount - 1
+                    && !mYAxis.getVisibleLabelsSet().contains(YAxis.VisibleEntry.MAX)) {
+                continue;
+            }
+
+            if(i > 0 && i < mYAxis.mEntryCount - 1
+                    && !mYAxis.getVisibleLabelsSet().contains(YAxis.VisibleEntry.INNER)) {
+                continue;
+            }
 
             String text = mYAxis.getFormattedLabel(i);
 
@@ -169,6 +183,20 @@ public class YAxisRendererHorizontalBarChart extends YAxisRenderer {
 
         // draw the horizontal grid
         for (int i = 0; i < mYAxis.mEntryCount; i++) {
+            if(i == 0
+                    && !mYAxis.getVisibleGridLinesSet().contains(YAxis.VisibleEntry.MIN)) {
+                continue;
+            }
+
+            if(i == mYAxis.mEntryCount - 1
+                    && !mYAxis.getVisibleGridLinesSet().contains(YAxis.VisibleEntry.MAX)) {
+                continue;
+            }
+
+            if(i > 0 && i < mYAxis.mEntryCount - 1
+                    && !mYAxis.getVisibleGridLinesSet().contains(YAxis.VisibleEntry.INNER)) {
+                continue;
+            }
 
             position[0] = mYAxis.mEntries[i];
             mTrans.pointValuesToPixel(position);

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/YAxisRendererRadarChart.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/YAxisRendererRadarChart.java
@@ -53,38 +53,28 @@ public class YAxisRendererRadarChart extends YAxisRenderer {
         }
 
         // if the labels should only show min and max
-        if (mYAxis.isShowOnlyMinMaxEnabled()) {
+        double first = Math.ceil(yMin / interval) * interval;
+        double last = Utils.nextUp(Math.floor(yMax / interval) * interval);
 
-            mYAxis.mEntryCount = 2;
-            mYAxis.mEntries = new float[2];
-            mYAxis.mEntries[0] = yMin;
-            mYAxis.mEntries[1] = yMax;
+        double f;
+        int i;
+        int n = 0;
+        for (f = first; f <= last; f += interval) {
+            ++n;
+        }
 
-        } else {
+        if (Float.isNaN(mYAxis.getAxisMaxValue()))
+            n += 1;
 
-            double first = Math.ceil(yMin / interval) * interval;
-            double last = Utils.nextUp(Math.floor(yMax / interval) * interval);
+        mYAxis.mEntryCount = n;
 
-            double f;
-            int i;
-            int n = 0;
-            for (f = first; f <= last; f += interval) {
-                ++n;
-            }
+        if (mYAxis.mEntries.length < n) {
+            // Ensure stops contains at least numStops elements.
+            mYAxis.mEntries = new float[n];
+        }
 
-            if (Float.isNaN(mYAxis.getAxisMaxValue()))
-                n += 1;
-            
-            mYAxis.mEntryCount = n;
-
-            if (mYAxis.mEntries.length < n) {
-                // Ensure stops contains at least numStops elements.
-                mYAxis.mEntries = new float[n];
-            }
-
-            for (f = first, i = 0; i < n; f += interval, ++i) {
-                mYAxis.mEntries[i] = (float) f;
-            }
+        for (f = first, i = 0; i < n; f += interval, ++i) {
+            mYAxis.mEntries[i] = (float) f;
         }
 
         if (interval < 1) {
@@ -114,8 +104,20 @@ public class YAxisRendererRadarChart extends YAxisRenderer {
 
         for (int j = 0; j < labelCount; j++) {
 
-            if (j == labelCount - 1 && mYAxis.isDrawTopYLabelEntryEnabled() == false)
-                break;
+            if(j == 0
+                    && !mYAxis.getVisibleLabelsSet().contains(YAxis.VisibleEntry.MIN)) {
+                continue;
+            }
+
+            if(j == mYAxis.mEntryCount - 1
+                    && !mYAxis.getVisibleLabelsSet().contains(YAxis.VisibleEntry.MAX)) {
+                continue;
+            }
+
+            if(j > 0 && j < mYAxis.mEntryCount - 1
+                    && !mYAxis.getVisibleLabelsSet().contains(YAxis.VisibleEntry.INNER)) {
+                continue;
+            }
 
             float r = (mYAxis.mEntries[j] - mYAxis.mAxisMinimum) * factor;
 


### PR DESCRIPTION
Implement VisibleEntry enum for the YAxis class, to handle various cases for showing labels and grid lines, because there are cases when we want to show only min max, but want to keep grid lines, or want to show only min, or only max.
Tested a lot and think that didn't break anything :)

Example 1
```java
yAxis.getVisibleLabelsSet().remove(YAxis.VisibleEntry.MIN);
yAxis.getVisibleLabelsSet().remove(YAxis.VisibleEntry.MAX);
yAxis.getVisibleGridLinesSet().remove(YAxis.VisibleEntry.INNER);
```
![screenshot_2015-04-02-11-55-08](https://cloud.githubusercontent.com/assets/8722637/6960775/a79d4cb4-d936-11e4-9a1e-5f1ceff589fa.png)

Example 2
```java
yAxis.getVisibleLabelsSet().remove(YAxis.VisibleEntry.INNER);
```
![screenshot_2015-04-02-12-06-42](https://cloud.githubusercontent.com/assets/8722637/6960782/be58eb8e-d936-11e4-8c52-6dfc1589806b.png)
