### PR TITLE
Stable reference for the yVals array

### DIFF
--- a/MPChartLib/src/com/github/mikephil/charting/data/DataSet.java
+++ b/MPChartLib/src/com/github/mikephil/charting/data/DataSet.java
@@ -430,13 +430,14 @@ public abstract class DataSet<T extends Entry> {
 
         float val = e.getVal();
 
-        if (mYVals == null || mYVals.size() <= 0) {
-
+        if(mYVals == null) {
             mYVals = new ArrayList<T>();
+        }
+
+        if (mYVals.size() == 0) {
             mYMax = val;
             mYMin = val;
         } else {
-
             if (mYMax < val)
                 mYMax = val;
             if (mYMin > val)


### PR DESCRIPTION
There are cases that we want to provide xVals and yVals arrays from the cache, and we want to have the same references for the xVals and yVals arrays, there were no problem with xVals, but there were cases when yVals created again and we loose reference with it, this pull request separates two conditions, thus preventing create yVals when it is not null.