### PR TITLE
Implement fling friction for the BarLineChartBase derived classes (Update 2)

### DIFF
--- a/MPChartLib/src/com/github/mikephil/charting/charts/BarLineChartBase.java
+++ b/MPChartLib/src/com/github/mikephil/charting/charts/BarLineChartBase.java
@@ -110,6 +110,19 @@ public abstract class BarLineChartBase<T extends BarLineScatterCandleData<? exte
 
     protected XAxisRenderer mXAxisRenderer;
 
+    /**
+     * If set to true, chart continues to scroll after touch up, but with friction, and its speed
+     * decrease over time, depend on mFlingFriction value
+     */
+    private boolean mFlingFrictionEnabled;
+
+    /**
+     * Fling friction coefficient in [0 ; 1] interval, higher values indicate that speed will
+     * decrease slowly, for example if it set to 0, it will stop immediately, if set to 1, it will
+     * scroll with constant speed, until the last point
+     */
+    private float mFlingFrictionCoef = 0.9f;
+
     // /** the approximator object used for data filtering */
     // private Approximator mApproximator;
 
@@ -1373,6 +1386,47 @@ public abstract class BarLineChartBase<T extends BarLineScatterCandleData<? exte
         }
 
         return null;
+    }
+
+    /**
+     * Returns fling friction coefficient
+     * @return
+     */
+    public float getFlingFrictionCoef() {
+        return mFlingFrictionCoef;
+    }
+
+    /**
+     * Fling friction coefficient in [0 ; 1] interval, higher values indicate that speed will
+     * decrease slowly, for example if it set to 0, it will stop immediately, if set to 1, it will
+     * scroll with constant speed, until last point
+     * @param flingFrictionCoef
+     */
+    public void setFlingFrictionCoef(float flingFrictionCoef) {
+        if(flingFrictionCoef < 0) {
+            flingFrictionCoef = 0;
+        }
+        else if(flingFrictionCoef > 1) {
+            flingFrictionCoef = 1;
+        }
+        mFlingFrictionCoef = flingFrictionCoef;
+    }
+
+    /**
+     * If fling friction enabled or not
+     * @return
+     */
+    public boolean isFlingFrictionEnabled() {
+        return mFlingFrictionEnabled;
+    }
+
+    /**
+     * If set to true, chart continues to scroll after touch up, but with friction, and its speed
+     * decrease over time, depend on getFlingFrictionCoef value
+     * @param flingFrictionEnabled
+     */
+    public void setFlingFrictionEnabled(boolean flingFrictionEnabled) {
+        mFlingFrictionEnabled = flingFrictionEnabled;
     }
 
     /**

--- a/MPChartLib/src/com/github/mikephil/charting/listener/BarLineChartTouchListener.java
+++ b/MPChartLib/src/com/github/mikephil/charting/listener/BarLineChartTouchListener.java
@@ -180,9 +180,7 @@ public class BarLineChartTouchListener<T extends BarLineChartBase<? extends BarL
                 break;
 
             case MotionEvent.ACTION_UP:
-                mTouchMode = NONE;
-                mChart.enableScroll();
-                if(mChart.isFlingFrictionEnabled()) {
+                if(mChart.isFlingFrictionEnabled() && mTouchMode == DRAG) {
                     long currentTime = System.currentTimeMillis();
                     mFlingCurrentPoint.set(event.getX(), event.getY());
                     long dt = currentTime - mTouchStartTime;
@@ -193,6 +191,8 @@ public class BarLineChartTouchListener<T extends BarLineChartBase<? extends BarL
                     mFlingHandler.removeCallbacks(flingRunnable);
                     mFlingHandler.post(flingRunnable);
                 }
+                mTouchMode = NONE;
+                mChart.enableScroll();
                 break;
             case MotionEvent.ACTION_POINTER_UP:
                 mTouchMode = POST_ZOOM;

--- a/MPChartLib/src/com/github/mikephil/charting/listener/BarLineChartTouchListener.java
+++ b/MPChartLib/src/com/github/mikephil/charting/listener/BarLineChartTouchListener.java
@@ -4,6 +4,8 @@ package com.github.mikephil.charting.listener;
 import android.annotation.SuppressLint;
 import android.graphics.Matrix;
 import android.graphics.PointF;
+import android.os.Handler;
+import android.os.SystemClock;
 import android.util.Log;
 import android.view.GestureDetector;
 import android.view.GestureDetector.SimpleOnGestureListener;
@@ -70,6 +72,21 @@ public class BarLineChartTouchListener<T extends BarLineChartBase<? extends BarL
     /** the gesturedetector used for detecting taps and longpresses, ... */
     private GestureDetector mGestureDetector;
 
+    /* Handler for fling animation */
+    private Handler mFlingHandler = new Handler();
+
+    /* Current fling point after start time */
+    private final PointF mFlingCurrentPoint = new PointF();
+
+    /* Current fling velocity in pixel per millisecond */
+    private final PointF flingVelocity = new PointF();
+
+    /* When touch down happened */
+    private long mTouchStartTime;
+
+    /* When flingRunnable's run method called last time */
+    private long mRunnableLastTime;
+
     public BarLineChartTouchListener(T chart, Matrix touchMatrix) {
         this.mChart = chart;
         this.mMatrix = touchMatrix;
@@ -92,7 +109,10 @@ public class BarLineChartTouchListener<T extends BarLineChartBase<? extends BarL
         switch (event.getAction() & MotionEvent.ACTION_MASK) {
 
             case MotionEvent.ACTION_DOWN:
-
+                if(mChart.isFlingFrictionEnabled()) {
+                    mTouchStartTime = System.currentTimeMillis();
+                    mFlingHandler.removeCallbacks(flingRunnable);
+                }
                 saveTouchStart(event);
                 break;
             case MotionEvent.ACTION_POINTER_DOWN:
@@ -162,6 +182,17 @@ public class BarLineChartTouchListener<T extends BarLineChartBase<? extends BarL
             case MotionEvent.ACTION_UP:
                 mTouchMode = NONE;
                 mChart.enableScroll();
+                if(mChart.isFlingFrictionEnabled()) {
+                    long currentTime = System.currentTimeMillis();
+                    mFlingCurrentPoint.set(event.getX(), event.getY());
+                    long dt = currentTime - mTouchStartTime;
+                    flingVelocity.x = (event.getX() - mTouchStartPoint.x) / dt;
+                    flingVelocity.y = (event.getY() - mTouchStartPoint.y) / dt;
+                    mRunnableLastTime = currentTime;
+                    saveTouchStart(event);
+                    mFlingHandler.removeCallbacks(flingRunnable);
+                    mFlingHandler.post(flingRunnable);
+                }
                 break;
             case MotionEvent.ACTION_POINTER_UP:
                 mTouchMode = POST_ZOOM;
@@ -229,6 +260,28 @@ public class BarLineChartTouchListener<T extends BarLineChartBase<? extends BarL
 		if (l != null)
 			l.onChartTranslate(event, dX, dY);
     }
+
+    private final Runnable flingRunnable = new Runnable() {
+        @Override
+        public void run() {
+            long currentTime = System.currentTimeMillis();
+            long dt = currentTime - mRunnableLastTime;
+            mFlingCurrentPoint.x += flingVelocity.x * dt;
+            mFlingCurrentPoint.y += flingVelocity.y * dt;
+            flingVelocity.x *= mChart.getFlingFrictionCoef();
+            flingVelocity.y *= mChart.getFlingFrictionCoef();
+            MotionEvent motionEvent =
+                    MotionEvent.obtain(SystemClock.uptimeMillis(),
+                    SystemClock.uptimeMillis(),
+                    MotionEvent.ACTION_MOVE, mFlingCurrentPoint.x, mFlingCurrentPoint.y, 0);
+            mChart.dispatchTouchEvent(motionEvent);
+            mRunnableLastTime = currentTime;
+            float eps = 0.01f;
+            if(Math.abs(flingVelocity.x) > eps || Math.abs(flingVelocity.y) > eps) {
+                mFlingHandler.postDelayed(this, 25);
+            }
+        }
+    };
 
     /**
      * Performs the all operations necessary for pinch and axis zoom.
@@ -400,8 +453,8 @@ public class BarLineChartTouchListener<T extends BarLineChartBase<? extends BarL
     /**
      * returns the correct translation depending on the provided x and y touch
      * points
-     * 
-     * @param e
+     * @param x
+     * @param y
      * @return
      */
     public PointF getTrans(float x, float y) {


### PR DESCRIPTION
Add an option to continue scrolling with friction after touch up (https://www.youtube.com/watch?v=9Z8UH8mB5Qg). 
In this update I create a MotionEvent and dispatch it via `dispatchTouchEvent` method, instead of calling perfomrDrag and getViewPortHandler().refresh() methods directly, so this is more adaptive to future updates.

Usage
```java
chart.setFlingFrictionEnabled(true);
chart.setFlingFrictionCoef(0.8f);
```