### PR TITLE
Deceleration after dragging in Line and Pie/Radar charts

### DIFF
--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/notimportant/MainActivity.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/notimportant/MainActivity.java
@@ -59,7 +59,7 @@ public class MainActivity extends Activity implements OnItemClickListener {
         setContentView(R.layout.activity_main);
 
         // initialize the utilities
-        Utils.init(getResources());
+        Utils.init(this);
 
         ArrayList<ContentItem> objects = new ArrayList<ContentItem>();
 

--- a/MPChartLib/src/com/github/mikephil/charting/charts/BarLineChartBase.java
+++ b/MPChartLib/src/com/github/mikephil/charting/charts/BarLineChartBase.java
@@ -95,6 +95,16 @@ public abstract class BarLineChartBase<T extends BarLineScatterCandleData<? exte
 
     protected boolean mDrawBorders = false;
 
+    /** If set to true, chart continues to scroll after touch up */
+    private boolean mDragDecelarationEnabled = true;
+
+    /**
+     * Decelaration friction coefficient in [0 ; 1] interval, higher values indicate that
+     * speed will decrease slowly, for example if it set to 0, it will stop immediately.
+     * 1 is an invalid value, and will be converted to 0 automatically.
+     */
+    private float mDragDecelarationFrictionCoef = 0.9f;
+
     /** the listener for user drawing on the chart */
     protected OnDrawListener mDrawListener;
 
@@ -539,6 +549,13 @@ public abstract class BarLineChartBase<T extends BarLineScatterCandleData<? exte
             return mListener.onTouch(this, event);
     }
 
+    @Override
+    public void computeScroll() {
+
+        if (mListener instanceof BarLineChartTouchListener)
+            ((BarLineChartTouchListener)mListener).computeScroll();
+    }
+
     /**
      * ################ ################ ################ ################
      */
@@ -966,6 +983,46 @@ public abstract class BarLineChartBase<T extends BarLineScatterCandleData<? exte
      */
     public void setBorderColor(int color) {
         mBorderPaint.setColor(color);
+    }
+
+    /**
+     * If set to true, chart continues to scroll after touch up
+     *
+     * default: true
+     */
+    public boolean isDragDecelarationEnabled() {
+        return mDragDecelarationEnabled;
+    }
+
+    /**
+     * If set to true, chart continues to scroll after touch up
+     *
+     * @param enabled
+     */
+    public void setDragDecelarationEnabled(boolean enabled) {
+        mDragDecelarationEnabled = enabled;
+    }
+
+    /**
+     * Returns drag deceleration friction coefficient
+     * @return
+     */
+    public float getDragDecelarationFrictionCoef() {
+        return mDragDecelarationFrictionCoef;
+    }
+
+    /**+
+     * Decelaration friction coefficient in [0 ; 1] interval, higher values indicate that
+     * speed will decrease slowly, for example if it set to 0, it will stop immediately.
+     * 1 is an invalid value, and will be converted to 0 automatically.
+     *
+     * @param newValue
+     */
+    public void setDragDecelarationFrictionCoef(float newValue) {
+        if (newValue < 0.f || newValue >= 1.f)
+            newValue = 0.f;
+
+        mDragDecelarationFrictionCoef = newValue;
     }
 
     /**

--- a/MPChartLib/src/com/github/mikephil/charting/charts/PieRadarChartBase.java
+++ b/MPChartLib/src/com/github/mikephil/charting/charts/PieRadarChartBase.java
@@ -41,6 +41,16 @@ public abstract class PieRadarChartBase<T extends ChartData<? extends DataSet<? 
     /** flag that indicates if rotation is enabled or not */
     protected boolean mRotateEnabled = true;
 
+    /** If set to true, chart continues to scroll after touch up */
+    private boolean mDragDecelarationEnabled = true;
+
+    /**
+     * Decelaration friction coefficient in [0 ; 1] interval, higher values indicate that
+     * speed will decrease slowly, for example if it set to 0, it will stop immediately,
+     * if set to 1, it will scroll with constant speed, until the last point
+     */
+    private float mDragDecelarationFrictionCoef = 0.9f;
+
     /** the pie- and radarchart touchlistener */
     protected OnTouchListener mListener;
 
@@ -75,6 +85,13 @@ public abstract class PieRadarChartBase<T extends ChartData<? extends DataSet<? 
             return mListener.onTouch(this, event);
         else
             return super.onTouchEvent(event);
+    }
+
+    @Override
+    public void computeScroll() {
+
+        if (mListener instanceof PieRadarChartTouchListener)
+            ((PieRadarChartTouchListener)mListener).computeScroll();
     }
 
     @Override
@@ -203,7 +220,7 @@ public abstract class PieRadarChartBase<T extends ChartData<? extends DataSet<? 
      * @param x
      * @param y
      */
-    public void setStartAngle(float x, float y) {
+    public void setGestureStartAngle(float x, float y) {
 
         mStartAngle = getAngleForPoint(x, y);
 
@@ -330,8 +347,10 @@ public abstract class PieRadarChartBase<T extends ChartData<? extends DataSet<? 
      */
     public void setRotationAngle(float angle) {
 
-        angle = (int) Math.abs(angle % 360);
-        mRotationAngle = angle;
+        while (angle < 0.f)
+            angle += 360.f;
+
+        mRotationAngle = angle % 360;
     }
 
     /**
@@ -360,6 +379,46 @@ public abstract class PieRadarChartBase<T extends ChartData<? extends DataSet<? 
      */
     public boolean isRotationEnabled() {
         return mRotateEnabled;
+    }
+
+    /**
+     * If set to true, chart continues to scroll after touch up
+     *
+     * default: true
+     */
+    public boolean isDragDecelarationEnabled() {
+        return mDragDecelarationEnabled;
+    }
+
+    /**
+     * If set to true, chart continues to scroll after touch up
+     *
+     * @param enabled
+     */
+    public void setDragDecelarationEnabled(boolean enabled) {
+        mDragDecelarationEnabled = enabled;
+    }
+
+    /**
+     * Returns drag deceleration friction coefficient
+     * @return
+     */
+    public float getDragDecelarationFrictionCoef() {
+        return mDragDecelarationFrictionCoef;
+    }
+
+    /**+
+     * Decelaration friction coefficient in [0 ; 1] interval, higher values indicate that
+     * speed will decrease slowly, for example if it set to 0, it will stop immediately,
+     * if set to 1, it will scroll with constant speed, until the last point
+     *
+     * @param newValue
+     */
+    public void setDragDecelarationFrictionCoef(float newValue) {
+        if (newValue < 0.f || newValue >= 1.f)
+            newValue = 0.f;
+
+        mDragDecelarationFrictionCoef = newValue;
     }
 
     /**

--- a/MPChartLib/src/com/github/mikephil/charting/utils/ViewPortHandler.java
+++ b/MPChartLib/src/com/github/mikephil/charting/utils/ViewPortHandler.java
@@ -260,7 +260,8 @@ public class ViewPortHandler {
         // make sure scale and translation are within their bounds
         limitTransAndScale(mMatrixTouch, mContentRect);
 
-        chart.invalidate();
+        if (invalidate)
+            chart.invalidate();
 
         newMatrix.set(mMatrixTouch);
         return newMatrix;


### PR DESCRIPTION
You should test this for performance!

Anyway I've looked at the `OverScroll` (API>=16) implementation, and Google says that to work with it you need to `postInvalidateOnAnimation()` and listen to `computeScroll()`.

The `OverScroll` is API 16 and is a bit of an overkill and meant for views, so I haven't used it, but used the same mechanism (`postInvalidateOnAnimation`/`computeScroll`).
If we will want to support bounce on edges, we will need to support it in the viewport and maybe in the renderers. `OverScroll` is meant to do that on `View`s only...

Also I've used `VelocityTracker` (which is used by the Fling recognizer) because we are not tracking fling but tracking sequential movement for panning. So android supplies the velocity arguments in the wrong listener but at least the `VelocityTracker` is public...

I can't test to see how smooth it works because the simulator only generates 10 fps when using `postInvalidateOnAnimation` which is incorrect, and I don't have a device here.