### PR TITLE
Added ability to show images in Pie Chart.

### DIFF
--- a/MPChartLib/src/com/github/mikephil/charting/charts/PieChart.java
+++ b/MPChartLib/src/com/github/mikephil/charting/charts/PieChart.java
@@ -70,6 +70,8 @@ public class PieChart extends PieRadarChartBase<PieData> {
     /** if enabled, centertext is drawn */
     private boolean mDrawCenterText = true;
 
+    private boolean mDrawImages = false;
+
     public PieChart(Context context) {
         super(context);
     }
@@ -518,5 +520,13 @@ public class PieChart extends PieRadarChartBase<PieData> {
      */
     public boolean isUsePercentValuesEnabled() {
         return mUsePercentValues;
+    }
+
+    public boolean isDrawImagesEnabled() {
+        return mDrawImages;
+    }
+
+    public void setDrawImages(boolean mDrawImages) {
+        this.mDrawImages = mDrawImages;
     }
 }

--- a/MPChartLib/src/com/github/mikephil/charting/data/ChartData.java
+++ b/MPChartLib/src/com/github/mikephil/charting/data/ChartData.java
@@ -47,7 +47,7 @@ public abstract class ChartData<T extends DataSet<? extends Entry>> {
     private float mXValAverageLength = 0;
 
     /** holds all x-values the chart represents */
-    protected List<String> mXVals;
+    protected List<XValue> mXVals;
 
     /** array that holds all DataSets the ChartData object represents */
     protected List<T> mDataSets;
@@ -97,7 +97,7 @@ public abstract class ChartData<T extends DataSet<? extends Entry>> {
      * @param sets the dataset array
      */
     public ChartData(List<String> xVals, List<T> sets) {
-        this.mXVals = xVals;
+        this.mXVals = XValue.fromStringList(xVals);
         this.mDataSets = sets;
 
         init(mDataSets);
@@ -131,7 +131,7 @@ public abstract class ChartData<T extends DataSet<? extends Entry>> {
         float sum = 1f;
 
         for (int i = 0; i < mXVals.size(); i++) {
-            sum += mXVals.get(i).length();
+            sum += mXVals.get(i).getValue().length();
         }
 
         mXValAverageLength = sum / (float) mXVals.size();
@@ -272,6 +272,23 @@ public abstract class ChartData<T extends DataSet<? extends Entry>> {
     /** ONLY GETTERS AND SETTERS BELOW THIS */
 
     /**
+     * Sets the x values of the chart.
+     * @param xVals A string list of x values.
+     */
+    public void setXVals(List<String> xVals) {
+        this.mXVals = XValue.fromStringList(xVals);
+    }
+
+    /**
+     * Sets the x values of the chart as an XValue object which contains both the string
+     * title and an optional icon.
+     * @param xValues A list of XValue objects
+     */
+    public void setXValues(List<XValue> xValues) {
+        this.mXVals = xValues;
+    }
+
+    /**
      * returns the number of LineDataSets this object contains
      * 
      * @return
@@ -358,10 +375,19 @@ public abstract class ChartData<T extends DataSet<? extends Entry>> {
 
     /**
      * returns the x-values the chart represents
-     * 
+     *
      * @return
      */
     public List<String> getXVals() {
+        return XValue.toStringList(mXVals);
+    }
+
+    /**
+     * returns the x-values the chart represents
+     *
+     * @return
+     */
+    public List<XValue> getXValues() {
         return mXVals;
     }
 
@@ -373,7 +399,7 @@ public abstract class ChartData<T extends DataSet<? extends Entry>> {
     public void addXValue(String xVal) {
 
         mXValAverageLength = (mXValAverageLength + xVal.length()) / 2f;
-        mXVals.add(xVal);
+        mXVals.add(new XValue(xVal));
     }
 
     /**

--- a/MPChartLib/src/com/github/mikephil/charting/data/ChartData.java
+++ b/MPChartLib/src/com/github/mikephil/charting/data/ChartData.java
@@ -53,8 +53,7 @@ public abstract class ChartData<T extends DataSet<? extends Entry>> {
     protected List<T> mDataSets;
 
     public ChartData() {
-        mXVals = new ArrayList<String>();
-        mDataSets = new ArrayList<T>();
+        this(new ArrayList<String>(), new ArrayList<T>());
     }
 
     /**
@@ -64,9 +63,7 @@ public abstract class ChartData<T extends DataSet<? extends Entry>> {
      * @param xVals
      */
     public ChartData(List<String> xVals) {
-        this.mXVals = xVals;
-        this.mDataSets = new ArrayList<T>();
-        init(mDataSets);
+        this(xVals, new ArrayList<T>());
     }
 
     /**
@@ -76,9 +73,19 @@ public abstract class ChartData<T extends DataSet<? extends Entry>> {
      * @param xVals
      */
     public ChartData(String[] xVals) {
-        this.mXVals = arrayToList(xVals);
-        this.mDataSets = new ArrayList<T>();
-        init(mDataSets);
+        this(Arrays.asList(xVals), new ArrayList<T>());
+    }
+
+    /**
+     * constructor that takes string array instead of List string
+     *
+     * @param xVals The values describing the x-axis. Must be at least as long
+     *            as the highest xIndex in the Entry objects across all
+     *            DataSets.
+     * @param sets the dataset array
+     */
+    public ChartData(String[] xVals, List<T> sets) {
+        this(Arrays.asList(xVals), sets);
     }
 
     /**
@@ -94,31 +101,6 @@ public abstract class ChartData<T extends DataSet<? extends Entry>> {
         this.mDataSets = sets;
 
         init(mDataSets);
-    }
-
-    /**
-     * constructor that takes string array instead of List string
-     * 
-     * @param xVals The values describing the x-axis. Must be at least as long
-     *            as the highest xIndex in the Entry objects across all
-     *            DataSets.
-     * @param sets the dataset array
-     */
-    public ChartData(String[] xVals, List<T> sets) {
-        this.mXVals = arrayToList(xVals);
-        this.mDataSets = sets;
-
-        init(mDataSets);
-    }
-
-    /**
-     * Turns an array of strings into an List of strings.
-     * 
-     * @param array
-     * @return
-     */
-    private List<String> arrayToList(String[] array) {
-        return Arrays.asList(array);
     }
 
     /**
@@ -419,7 +401,7 @@ public abstract class ChartData<T extends DataSet<? extends Entry>> {
      * situations.
      * 
      * @param dataSets the DataSet array to search
-     * @param type
+     * @param label
      * @param ignorecase if true, the search is not case-sensitive
      * @return
      */
@@ -625,7 +607,7 @@ public abstract class ChartData<T extends DataSet<? extends Entry>> {
      * Adds an Entry to the DataSet at the specified index. Entries are added to
      * the end of the list.
      * 
-     * @param entry
+     * @param e
      * @param dataSetIndex
      */
     public void addEntry(Entry e, int dataSetIndex) {
@@ -858,7 +840,7 @@ public abstract class ChartData<T extends DataSet<? extends Entry>> {
      * Sets the Typeface for all value-labels for all DataSets this data object
      * contains.
      * 
-     * @param color
+     * @param tf
      */
     public void setValueTypeface(Typeface tf) {
         for (DataSet<?> set : mDataSets) {
@@ -870,7 +852,7 @@ public abstract class ChartData<T extends DataSet<? extends Entry>> {
      * Sets the size (in dp) of the value-text for all DataSets this data object
      * contains.
      * 
-     * @param color
+     * @param size
      */
     public void setValueTextSize(float size) {
         for (DataSet<?> set : mDataSets) {

--- a/MPChartLib/src/com/github/mikephil/charting/data/XValue.java
+++ b/MPChartLib/src/com/github/mikephil/charting/data/XValue.java
@@ -1,0 +1,42 @@
+package com.github.mikephil.charting.data;
+
+import android.graphics.Bitmap;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Represents a x value label, which must contain a title and optionally an image.
+ *
+ * @author Alex Macrae
+ */
+public class XValue {
+    private final String value;
+    private final Bitmap image;
+
+    public XValue(String value) {
+        this(value, null);
+    }
+
+    public XValue(String value, Bitmap image) {
+        this.value = value;
+        this.image = image;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public Bitmap getImage() {
+        return image;
+    }
+
+    public static List<XValue> convertStringList(List<String> xValueStrings) {
+        ArrayList<XValue> xValues = new ArrayList<>();
+        for (String xValueString : xValueStrings) {
+            xValues.add(new XValue(xValueString));
+        }
+
+        return xValues;
+    }
+}

--- a/MPChartLib/src/com/github/mikephil/charting/data/XValue.java
+++ b/MPChartLib/src/com/github/mikephil/charting/data/XValue.java
@@ -31,7 +31,16 @@ public class XValue {
         return image;
     }
 
-    public static List<XValue> convertStringList(List<String> xValueStrings) {
+    public static List<String> toStringList(List<XValue> xValues) {
+        ArrayList<String> xValueStrings = new ArrayList<>();
+        for (XValue xValue : xValues) {
+            xValueStrings.add(xValue.getValue());
+        }
+
+        return xValueStrings;
+    }
+
+    public static List<XValue> fromStringList(List<String> xValueStrings) {
         ArrayList<XValue> xValues = new ArrayList<>();
         for (String xValueString : xValueStrings) {
             xValues.add(new XValue(xValueString));

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/PieChartRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/PieChartRenderer.java
@@ -15,6 +15,7 @@ import com.github.mikephil.charting.charts.PieChart;
 import com.github.mikephil.charting.data.Entry;
 import com.github.mikephil.charting.data.PieData;
 import com.github.mikephil.charting.data.PieDataSet;
+import com.github.mikephil.charting.data.XValue;
 import com.github.mikephil.charting.utils.Highlight;
 import com.github.mikephil.charting.utils.Utils;
 import com.github.mikephil.charting.utils.ViewPortHandler;
@@ -167,14 +168,15 @@ public class PieChartRenderer extends DataRenderer {
         PieData data = mChart.getData();
         List<PieDataSet> dataSets = data.getDataSets();
         boolean drawXVals = mChart.isDrawSliceTextEnabled();
+        boolean showImages = mChart.isDrawImagesEnabled();
 
         int cnt = 0;
 
-        for (int i = 0; i < dataSets.size(); i++) {
+        for (int dataSetIndex = 0; dataSetIndex < dataSets.size(); dataSetIndex++) {
 
-            PieDataSet dataSet = dataSets.get(i);
+            PieDataSet dataSet = dataSets.get(dataSetIndex);
 
-            if (!dataSet.isDrawValuesEnabled() && !drawXVals)
+            if (!dataSet.isDrawValuesEnabled() && !drawXVals && !showImages)
                 continue;
 
             // apply the text-styling defined by the DataSet
@@ -182,8 +184,8 @@ public class PieChartRenderer extends DataRenderer {
 
             List<Entry> entries = dataSet.getYVals();
 
-            for (int j = 0, maxEntry = Math.min(
-                    (int) Math.ceil(entries.size() * mAnimator.getPhaseX()), entries.size()); j < maxEntry; j++) {
+            for (int entryIndex = 0, maxEntry = Math.min(
+                    (int) Math.ceil(entries.size() * mAnimator.getPhaseX()), entries.size()); entryIndex < maxEntry; entryIndex++) {
 
                 // offset needed to center the drawn text in the slice
                 float offset = drawAngles[cnt] / 2;
@@ -196,8 +198,8 @@ public class PieChartRenderer extends DataRenderer {
                         * Math.sin(Math.toRadians((rotationAngle + absoluteAngles[cnt] - offset)
                                 * mAnimator.getPhaseY())) + center.y);
 
-                float value = mChart.isUsePercentValuesEnabled() ? entries.get(j).getVal()
-                        / mChart.getYValueSum() * 100f : entries.get(j).getVal();
+                float value = mChart.isUsePercentValuesEnabled() ? entries.get(entryIndex).getVal()
+                        / mChart.getYValueSum() * 100f : entries.get(entryIndex).getVal();
 
                 String val = dataSet.getValueFormatter().getFormattedValue(value);
 
@@ -207,19 +209,21 @@ public class PieChartRenderer extends DataRenderer {
                 boolean drawYVals = dataSet.isDrawValuesEnabled();
 
                 // draw everything, depending on settings
-                if (drawXVals && drawYVals) {
-
-                    c.drawText(val, x, y, mValuePaint);
-                    if (j < data.getXValCount())
-                        c.drawText(data.getXVals().get(j), x, y + lineHeight,
-                                mValuePaint);
-
-                } else if (drawXVals && !drawYVals) {
-                    if (j < data.getXValCount())
-                        c.drawText(data.getXVals().get(j), x, y + lineHeight / 2f, mValuePaint);
-                } else if (!drawXVals && drawYVals) {
-
-                    c.drawText(val, x, y + lineHeight / 2f, mValuePaint);
+                if(entryIndex < data.getXValCount()) {
+                    XValue xValue = data.getXValues().get(entryIndex);
+                    if(xValue.getImage() != null && showImages) {
+                        float imageX = x - xValue.getImage().getWidth() / 2;
+                        float imageY = y - xValue.getImage().getHeight() / 2;
+                        c.drawBitmap(xValue.getImage(), imageX, imageY, mValuePaint);
+                    }
+                    if(drawXVals) {
+                        float heightOffset = drawYVals ? lineHeight : lineHeight / 2;
+                        c.drawText(xValue.getValue(), x, y + heightOffset, mValuePaint);
+                    }
+                }
+                if(drawYVals) {
+                    float yPos = drawXVals ? y : y + lineHeight / 2;
+                    c.drawText(val, x, yPos, mValuePaint);
                 }
 
                 cnt++;


### PR DESCRIPTION
I wanted the ability to show an image instead of text in the pie chart like so:
![Pie Chart With images](http://mungorae.me.uk/img/Chart.png)

So I modified the Chart data class to use an XValue object for the X axis points that contains a text title and an optional image. I have then changed the Pie Chart Renderer to show this image if the pie chart has draw images enabled and the image is not null.

To maintain backwards capability, I have added static methods to convert the string lists into XValue lists while keeping the existing APIs the same. Added a few more methods for images and setting XValues.