### PR TITLE
Allow to draw xaxis center-line as a center-value

### DIFF
--- a/MPChartLib/src/com/github/mikephil/charting/components/XAxis.java
+++ b/MPChartLib/src/com/github/mikephil/charting/components/XAxis.java
@@ -60,6 +60,9 @@ public class XAxis extends AxisBase {
      */
     private boolean mAvoidFirstLastClipping = false;
 
+    /** flag indicating if the xAxis center line should be drawn or not */
+    private boolean mDrawAxisCenterLine = false;
+
     /** the position of the x-labels relative to the chart */
     private XAxisPosition mPosition = XAxisPosition.TOP;
 
@@ -196,5 +199,23 @@ public class XAxis extends AxisBase {
         }
 
         return longest;
+    }
+
+    /**
+     * returns true if draw-center-line is enabled, false if not
+     *
+     * @return
+     */
+    public boolean getDrawAxisCenterLine() {
+        return mDrawAxisCenterLine;
+    }
+
+    /**
+     * set this to true to draw center xAxis line, false if not
+     *
+     * @param enabled
+     */
+    public void setDrawAxisCenterLine(boolean enabled) {
+        this.mDrawAxisCenterLine = enabled;
     }
 }

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/XAxisRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/XAxisRenderer.java
@@ -108,6 +108,12 @@ public class XAxisRenderer extends AxisRenderer {
                     mViewPortHandler.contentBottom(), mViewPortHandler.contentRight(),
                     mViewPortHandler.contentBottom(), mAxisLinePaint);
         }
+
+        if(mXAxis.getDrawAxisCenterLine()) {
+            c.drawLine(mViewPortHandler.contentLeft(),
+                    mViewPortHandler.getContentCenter().y, mViewPortHandler.contentRight(),
+                    mViewPortHandler.getContentCenter().y, getPaintAxisLine());
+        }
     }
 
     /**


### PR DESCRIPTION
- If set to show only min and max yAxis, shows 2 y-labels: (Eg MAX=1200 & MIN=0)
- But there is no attribute to show average (center) yAxis, when it set to show only min and max: (Eg MAX=1200 AVG=600 MIN=0)

To temporary achieve this in other way now:
- Allow to draw xaxis center-line as a average (center) value of y-label

Note: We can also implement to show the average (center) value on yAxis, when set to show on min and max (or) separate attribute to showAverage value.