### PR TITLE
New feature - suppress overlapping values

### DIFF
--- a/MPChartLib/src/com/github/mikephil/charting/charts/BarChart.java
+++ b/MPChartLib/src/com/github/mikephil/charting/charts/BarChart.java
@@ -38,6 +38,12 @@ public class BarChart extends BarLineChartBase<BarData> implements BarDataProvid
      * just their sum
      */
     private boolean mDrawValuesForWholeStack = true;
+    
+    /**
+     * if set to true, sums, which are zero are not drawn on stacked bars.
+     * It is used to prevent overlapping values on the chart.
+     */
+    private boolean mDrawSuppressZeroSums = false;
 
     /**
      * if set to true, a grey area is drawn behind each bar that indicates the
@@ -302,6 +308,26 @@ public class BarChart extends BarLineChartBase<BarData> implements BarDataProvid
         return mDrawValuesForWholeStack;
     }
 
+    /**
+     * if set to true, sums, which are zero are not drawn on stacked bars.
+     * It is used to prevent overlapping values on the chart.
+     * 
+     * @param enabled
+     */
+    public void setDrawSuppressZeroSums(boolean enabled) {
+    	mDrawSuppressZeroSums = enabled;
+    }
+    
+    /**
+     * returns true if sums, which are zero are not drawn on stacked bars
+     * It is used to prevent overlapping values on the chart.
+     * 
+     * @return
+     */
+	public boolean isDrawSuppressZeroSumsEnabled() {
+		return mDrawSuppressZeroSums;
+	}
+	
     /**
      * If set to true, a grey area is drawn behind each bar that indicates the
      * maximum value. Enabling his will reduce performance by about 50%.

--- a/MPChartLib/src/com/github/mikephil/charting/charts/CombinedChart.java
+++ b/MPChartLib/src/com/github/mikephil/charting/charts/CombinedChart.java
@@ -47,6 +47,12 @@ public class CombinedChart extends BarLineChartBase<CombinedData> implements Lin
     private boolean mDrawValuesForWholeStack = true;
 
     /**
+     * if set to true, sums, which are zero are not drawn on stacked bars.
+     * It is used to prevent overlapping values on the chart.
+     */
+    private boolean mDrawSuppressZeroSums = false;
+    
+    /**
      * if set to true, a grey area is drawn behind each bar that indicates the
      * maximum value
      */
@@ -187,6 +193,11 @@ public class CombinedChart extends BarLineChartBase<CombinedData> implements Lin
         return mDrawValuesForWholeStack;
     }
 
+    @Override
+	public boolean isDrawSuppressZeroSumsEnabled() {
+		return mDrawSuppressZeroSums;
+	}
+	
     /**
      * set this to true to draw the highlightning arrow
      * 
@@ -214,6 +225,16 @@ public class CombinedChart extends BarLineChartBase<CombinedData> implements Lin
      */
     public void setDrawValuesForWholeStack(boolean enabled) {
         mDrawValuesForWholeStack = enabled;
+    }
+    
+    /**
+     * if set to true, sums, which are zero are not drawn on stacked bars.
+     * It is used to prevent overlapping values on the chart.
+     * 
+     * @param enabled
+     */
+    public void setDrawSuppressZeroSums(boolean enabled) {
+    	mDrawSuppressZeroSums = enabled;
     }
 
     /**

--- a/MPChartLib/src/com/github/mikephil/charting/interfaces/BarDataProvider.java
+++ b/MPChartLib/src/com/github/mikephil/charting/interfaces/BarDataProvider.java
@@ -9,4 +9,5 @@ public interface BarDataProvider extends BarLineScatterCandleDataProvider {
     public boolean isDrawValueAboveBarEnabled();
     public boolean isDrawHighlightArrowEnabled();
     public boolean isDrawValuesForWholeStackEnabled();
+    public boolean isDrawSuppressZeroSumsEnabled();
 }

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/BarChartRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/BarChartRenderer.java
@@ -284,7 +284,12 @@ public class BarChartRenderer extends DataRenderer {
                                         || !mViewPortHandler.isInBoundsLeft(x))
                                     continue;
 
-                                drawValue(c, formatter.getFormattedValue(vals[k / 2]), x, y);
+                                float val = vals[k / 2];
+                                
+                                if(!(mChart.isDrawSuppressZeroSumsEnabled() && val == 0))
+                                {
+                                    drawValue(c, formatter.getFormattedValue(val), x, y);
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
I have encountered a problem when some of the stacks sums in stacked bar chart were zero, they were overlapping with other stacks values. So I have made some changes to allow the user suppress drawing zero values (since the stack won't be visible and that should be enough for the user there was no data). To do this all the user has to do is to use `setDrawSuppressZeroSums(boolean enabled)` on either `BarChart` or `CombinedChart`.

PS. Sorry if I have left any mess around, I have never been using GitHub : (