### PR TITLE
Fixed an issue where highlights disappear on multi-datasets

### DIFF
--- a/MPChartLib/src/com/github/mikephil/charting/charts/BarLineChartBase.java
+++ b/MPChartLib/src/com/github/mikephil/charting/charts/BarLineChartBase.java
@@ -1112,7 +1112,10 @@ public abstract class BarLineChartBase<T extends BarLineScatterCandleData<? exte
                 continue;
 
             // extract all y-values from all DataSets at the given x-index
-            float yVal = dataSet.getYValForXIndex(xIndex);
+            final float yVal = dataSet.getYValForXIndex(xIndex);
+            if (yVal == Float.NaN)
+                continue;
+
             pts[1] = yVal;
 
             getTransformer(dataSet.getAxisDependency()).pointValuesToPixel(pts);

--- a/MPChartLib/src/com/github/mikephil/charting/charts/PieRadarChartBase.java
+++ b/MPChartLib/src/com/github/mikephil/charting/charts/PieRadarChartBase.java
@@ -426,11 +426,11 @@ public abstract class PieRadarChartBase<T extends ChartData<? extends DataSet<? 
             DataSet<?> dataSet = mData.getDataSetByIndex(i);
 
             // extract all y-values from all DataSets at the given x-index
-            float yVal = dataSet.getYValForXIndex(xIndex);
+            final float yVal = dataSet.getYValForXIndex(xIndex);
+            if (yVal == Float.NaN)
+                continue;
 
-            if (!Float.isNaN(yVal)) {
-                vals.add(new SelectionDetail(yVal, i, dataSet));
-            }
+            vals.add(new SelectionDetail(yVal, i, dataSet));
         }
 
         return vals;

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/LineChartRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/LineChartRenderer.java
@@ -546,11 +546,11 @@ public class LineChartRenderer extends DataRenderer {
             if (xIndex > mChart.getXChartMax() * mAnimator.getPhaseX())
                 continue;
 
-            float yValue = set.getYValForXIndex(xIndex);
-            if (yValue == Float.NaN)
+            final float yVal = set.getYValForXIndex(xIndex);
+            if (yVal == Float.NaN)
                 continue;
 
-            float y = yValue * mAnimator.getPhaseY(); // get
+            float y = yVal * mAnimator.getPhaseY(); // get
                                                                             // the
             // y-position
 

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/ScatterChartRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/ScatterChartRenderer.java
@@ -266,11 +266,11 @@ public class ScatterChartRenderer extends DataRenderer {
             if (xIndex > mChart.getXChartMax() * mAnimator.getPhaseX())
                 continue;
 
-            float yValue = set.getYValForXIndex(xIndex);
-            if (yValue == Float.NaN)
+            final float yVal = set.getYValForXIndex(xIndex);
+            if (yVal == Float.NaN)
                 continue;
 
-            float y = yValue * mAnimator.getPhaseY(); // get
+            float y = yVal * mAnimator.getPhaseY(); // get
                                                                             // the
             // y-position
 


### PR DESCRIPTION
They disappeared because of NaN values introduces in the previous iteration, when the previous dataset does not contain a yValue for that specific index.

(And a little refactoring to make this thing consistent across all appearances)