### PR TITLE
Fixed a crash after matrix transformation when only one bar is visible

### DIFF
--- a/MPChartLib/src/com/github/mikephil/charting/data/ChartData.java
+++ b/MPChartLib/src/com/github/mikephil/charting/data/ChartData.java
@@ -203,7 +203,7 @@ public abstract class ChartData<T extends DataSet<? extends Entry>> {
             mLastEnd = end;
 
             mYMin = Float.MAX_VALUE;
-            mYMax = Float.MIN_VALUE;
+            mYMax = -Float.MIN_VALUE;
 
             for (int i = 0; i < mDataSets.size(); i++) {
 
@@ -214,6 +214,11 @@ public abstract class ChartData<T extends DataSet<? extends Entry>> {
 
                 if (mDataSets.get(i).getYMax() > mYMax)
                     mYMax = mDataSets.get(i).getYMax();
+            }
+
+            if (mYMin == Float.MAX_VALUE) {
+                mYMin = 0.f;
+                mYMax = 0.f;
             }
 
             // left axis

--- a/MPChartLib/src/com/github/mikephil/charting/data/DataSet.java
+++ b/MPChartLib/src/com/github/mikephil/charting/data/DataSet.java
@@ -123,7 +123,7 @@ public abstract class DataSet<T extends Entry> {
         mLastEnd = endValue;
 
         mYMin = Float.MAX_VALUE;
-        mYMax = Float.MIN_VALUE;
+        mYMax = -Float.MIN_VALUE;
 
         for (int i = start; i <= endValue; i++) {
 
@@ -137,6 +137,11 @@ public abstract class DataSet<T extends Entry> {
                 if (e.getVal() > mYMax)
                     mYMax = e.getVal();
             }
+        }
+
+        if (mYMin == Float.MAX_VALUE) {
+            mYMin = 0.f;
+            mYMax = 0.f;
         }
     }
 


### PR DESCRIPTION
Float.MIN_VALUE is not the minimum... -Float.MIN_VALUE is!
And of course we need to also account for a case where we are looping over zero elements.