### PR TITLE
Do not serialize ValueFormatter interface member variable

### DIFF
--- a/MPChartLib/src/com/github/mikephil/charting/data/DataSet.java
+++ b/MPChartLib/src/com/github/mikephil/charting/data/DataSet.java
@@ -64,7 +64,7 @@ public abstract class DataSet<T extends Entry> {
     private Typeface mValueTypeface;
 
     /** custom formatter that is used instead of the auto-formatter if set */
-    protected ValueFormatter mValueFormatter;
+    protected transient ValueFormatter mValueFormatter;
 
     /** this specifies which axis this DataSet should be plotted against */
     protected AxisDependency mAxisDependency = AxisDependency.LEFT;


### PR DESCRIPTION
When deserializing an object from this lib that contains a ValueFormatter member variable, Gson throws an exception. And since there is a ValueFormatter variable in DataSet, and ChartData uses DataSet, this affects many objects. I came across it deserializing my object which contained a PieChart using mGson.fromJson(myJsonString, MyPieChartObject.class);. Making an instance creator as Gson suggested did not solve the problem.

To fix this all I did was make the mValueFormatter transient so it does not get serialized by Gson, and therefore does not throw the exception. It works like a charm, and hopefully shouldn't affect anything negatively.

Before:
(Stack trace)
```
1265-1265/com.example.test E/AndroidRuntime﹕ FATAL EXCEPTION: main
    Process: com.example.test, PID: 1265
    java.lang.RuntimeException: Unable to start activity ComponentInfo{com.example.test/com.example.test.DetailActivity}: java.lang.RuntimeException: Unable to invoke no-args constructor for interface com.github.mikephil.charting.utils.ValueFormatter. Register an InstanceCreator with Gson for this type may fix this problem.
            at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2184)
            at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2233)
            at android.app.ActivityThread.access$800(ActivityThread.java:135)
            at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1196)
            at android.os.Handler.dispatchMessage(Handler.java:102)
            at android.os.Looper.loop(Looper.java:136)
            at android.app.ActivityThread.main(ActivityThread.java:5001)
            at java.lang.reflect.Method.invokeNative(Native Method)
            at java.lang.reflect.Method.invoke(Method.java:515)
            at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:785)
            at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:601)
            at dalvik.system.NativeStart.main(Native Method)
     Caused by: java.lang.RuntimeException: Unable to invoke no-args constructor for interface com.github.mikephil.charting.utils.ValueFormatter. Register an InstanceCreator with Gson for this type may fix this problem.
            at com.google.gson.internal.ConstructorConstructor$12.construct(ConstructorConstructor.java:210)
            at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:186)
            at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.read(ReflectiveTypeAdapterFactory.java:103)
            at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:196)
            at com.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.read(TypeAdapterRuntimeTypeWrapper.java:40)
            at com.google.gson.internal.bind.CollectionTypeAdapterFactory$Adapter.read(CollectionTypeAdapterFactory.java:81)
            at com.google.gson.internal.bind.CollectionTypeAdapterFactory$Adapter.read(CollectionTypeAdapterFactory.java:60)
            at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.read(ReflectiveTypeAdapterFactory.java:103)
            at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:196)
            at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.read(ReflectiveTypeAdapterFactory.java:103)
            at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:196)
            at com.google.gson.Gson.fromJson(Gson.java:810)
            at com.google.gson.Gson.fromJson(Gson.java:775)
            at com.google.gson.Gson.fromJson(Gson.java:724)
            at com.google.gson.Gson.fromJson(Gson.java:696)
            ...
```

After:
No exceptions for deserializing any of my objects that contain a chart from this lib anymore!