### PR TITLE
Fixes for the y axis with negative values

### DIFF
--- a/MPChartLib/src/com/github/mikephil/charting/charts/BarLineChartBase.java
+++ b/MPChartLib/src/com/github/mikephil/charting/charts/BarLineChartBase.java
@@ -377,8 +377,8 @@ public abstract class BarLineChartBase<T extends BarLineScatterCandleData<? exte
             if (mAxisLeft.mAxisMinimum < 0f && mAxisLeft.mAxisMaximum < 0f) {
                 // If the values are all negative, let's stay in the negative zone
                 mAxisLeft.mAxisMaximum = 0f;
-            } else {
-                // We have positive values, stay in the positive zone
+            } else if (mAxisLeft.mAxisMinimum >= 0f) {
+                // We have positive values only, stay in the positive zone
                 mAxisLeft.mAxisMinimum = 0f;
             }
         }
@@ -387,8 +387,8 @@ public abstract class BarLineChartBase<T extends BarLineScatterCandleData<? exte
             if (mAxisRight.mAxisMinimum < 0.0 && mAxisRight.mAxisMaximum < 0.0) {
                 // If the values are all negative, let's stay in the negative zone
                 mAxisRight.mAxisMaximum = 0f;
-            } else {
-                // We have positive values, stay in the positive zone
+            } else if (mAxisRight.mAxisMinimum >= 0f) {
+                // We have positive values only, stay in the positive zone
                 mAxisRight.mAxisMinimum = 0f;
             }
         }

--- a/MPChartLib/src/com/github/mikephil/charting/charts/RadarChart.java
+++ b/MPChartLib/src/com/github/mikephil/charting/charts/RadarChart.java
@@ -107,7 +107,7 @@ public class RadarChart extends PieRadarChartBase<RadarData> {
 
         // consider starting at zero (0)
         if (mYAxis.isStartAtZeroEnabled())
-            mYAxis.mAxisMinimum = 0f;
+            mYAxis.mAxisMinimum = Math.min(0f, mYAxis.mAxisMinimum);
 
         mYAxis.mAxisRange = Math.abs(mYAxis.mAxisMaximum - mYAxis.mAxisMinimum);
     }

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/YAxisRendererRadarChart.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/YAxisRendererRadarChart.java
@@ -82,7 +82,13 @@ public class YAxisRendererRadarChart extends YAxisRenderer {
 
 			} else {
 
-				double first = Math.ceil(yMin / interval) * interval;
+				final double rawCount = yMin / interval;
+				double first = rawCount < 0.0 ? Math.floor(rawCount) * interval : Math.ceil(rawCount) * interval;
+
+				if (first < yMin && mYAxis.isStartAtZeroEnabled()) {
+					// Force the first label to be at the 0 (or smallest negative value)
+					first = yMin;
+				}
 
 				if (first == 0.0) // Fix for IEEE negative zero case (Where value == -0.0, and 0.0 == -0.0)
 					first = 0.0;
@@ -116,6 +122,12 @@ public class YAxisRendererRadarChart extends YAxisRenderer {
 			mYAxis.mDecimals = (int) Math.ceil(-Math.log10(interval));
 		} else {
 			mYAxis.mDecimals = 0;
+		}
+
+		if (!mYAxis.isStartAtZeroEnabled() && mYAxis.mEntries[0] < yMin) {
+			// If startAtZero is disabled, and the first label is lower that the axis minimum,
+			// Then adjust the axis minimum
+			mYAxis.mAxisMinimum = mYAxis.mEntries[0];
 		}
 
 		mYAxis.mAxisMaximum = mYAxis.mEntries[mYAxis.mEntryCount - 1];


### PR DESCRIPTION
* `startAtZeroEnabled` should not actually start at zero when there are negative values, as these will be unaccessible
* In radar charts, when values are drawn below zero, they are actually draw in another x-index as it is a circular chart. So no we handle that correctly in (hopefully) all cases of `startAtZeroEnabled` = true/false 