### PR TITLE
Fixes an issue with X min/max in combined charts without bubble data

### DIFF
--- a/MPChartLib/src/com/github/mikephil/charting/charts/CombinedChart.java
+++ b/MPChartLib/src/com/github/mikephil/charting/charts/CombinedChart.java
@@ -101,9 +101,6 @@ public class CombinedChart extends BarLineChartBase<CombinedData> implements Lin
                         mXChartMax = xmax;
                 }
             }
-        } else {
-            mXChartMin = 0f;
-            mXChartMax = mData.getXValCount()-1;
         }
 
         mDeltaX = Math.abs(mXChartMax - mXChartMin);


### PR DESCRIPTION
This fixes https://github.com/danielgindi/ios-charts/issues/323