### PR TITLE
Improved LineChart non-cubic fill rendering

### DIFF
--- a/MPChartLib/src/com/github/mikephil/charting/renderer/LineChartRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/LineChartRenderer.java
@@ -347,22 +347,19 @@ public class LineChartRenderer extends LineScatterCandleRadarRenderer {
             int maxx,
             Transformer trans) {
 
-        mRenderPaint.setStyle(Paint.Style.FILL);
-
-        mRenderPaint.setColor(dataSet.getFillColor());
-        // filled is drawn with less alpha
-        mRenderPaint.setAlpha(dataSet.getFillAlpha());
-
         Path filled = generateFilledPath(
                 entries,
                 dataSet.getFillFormatter().getFillLinePosition(dataSet, mChart), minx, maxx);
 
         trans.pathValueToPixel(filled);
 
-        c.drawPath(filled, mRenderPaint);
+        c.save();
+        c.clipPath(filled);
 
-        // restore alpha
-        mRenderPaint.setAlpha(255);
+        int color = (dataSet.getFillAlpha() << 24) | (dataSet.getFillColor() & 0xffffff);
+        c.drawColor(color);
+
+        c.restore();
     }
 
     /**


### PR DESCRIPTION
According to Romain Guy (http://stackoverflow.com/a/15208783/477243), Path drawing is not hardware accelerated, but drawn to a Bitmap and pushed to the GPU as a texture. This, on certain scenarios, causes the "W/OpenGLRenderer: Path too large to be rendered into a texture" error.

The proposed solution is to simply set the fill Path as a clip and then fill the clipped Canvas with the proper color.

According to http://developer.android.com/guide/topics/graphics/hardware-accel.html, clipping with a Path is hardware accelerated and should cause no performance penalties.