### PR TITLE
Fix disappearing line when zooming into LineChart

### DIFF
--- a/MPChartLib/src/com/github/mikephil/charting/renderer/LineChartRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/LineChartRenderer.java
@@ -138,8 +138,10 @@ public class LineChartRenderer extends LineScatterCandleRadarRenderer {
         Entry entryFrom = dataSet.getEntryForXIndex(mMinX);
         Entry entryTo = dataSet.getEntryForXIndex(mMaxX);
 
-        int minx = Math.max(dataSet.getEntryPosition(entryFrom), 0);
-        int maxx = Math.min(dataSet.getEntryPosition(entryTo) + 1, entries.size());
+        int diff = (entryFrom == entryTo) ? 1 : 0;
+        int minx = Math.max(dataSet.getEntryPosition(entryFrom) - diff, 0);
+        int maxx = Math.min(Math.max(
+                minx + 2, dataSet.getEntryPosition(entryTo) + 1), entries.size());
 
         float phaseX = mAnimator.getPhaseX();
         float phaseY = mAnimator.getPhaseY();
@@ -289,8 +291,10 @@ public class LineChartRenderer extends LineScatterCandleRadarRenderer {
         Entry entryFrom = dataSet.getEntryForXIndex(mMinX);
         Entry entryTo = dataSet.getEntryForXIndex(mMaxX);
 
-        int minx = Math.max(dataSet.getEntryPosition(entryFrom), 0);
-        int maxx = Math.min(dataSet.getEntryPosition(entryTo) + 1, entries.size());
+        int diff = (entryFrom == entryTo) ? 1 : 0;
+        int minx = Math.max(dataSet.getEntryPosition(entryFrom) - diff, 0);
+        int maxx = Math.min(Math.max(
+                minx + 2, dataSet.getEntryPosition(entryTo) + 1), entries.size());
 
         int range = (maxx - minx) * 4 - 4;
 
@@ -430,8 +434,10 @@ public class LineChartRenderer extends LineScatterCandleRadarRenderer {
                 Entry entryFrom = dataSet.getEntryForXIndex(mMinX);
                 Entry entryTo = dataSet.getEntryForXIndex(mMaxX);
 
-                int minx = Math.max(dataSet.getEntryPosition(entryFrom), 0);
-                int maxx = Math.min(dataSet.getEntryPosition(entryTo) + 1, entries.size());
+                int diff = (entryFrom == entryTo) ? 1 : 0;
+                int minx = Math.max(dataSet.getEntryPosition(entryFrom) - diff, 0);
+                int maxx = Math.min(Math.max(
+                        minx + 2, dataSet.getEntryPosition(entryTo) + 1), entries.size());
 
                 float[] positions = trans.generateTransformedValuesLine(
                         entries, mAnimator.getPhaseX(), mAnimator.getPhaseY(), minx, maxx);
@@ -485,8 +491,10 @@ public class LineChartRenderer extends LineScatterCandleRadarRenderer {
             Entry entryFrom = dataSet.getEntryForXIndex((mMinX < 0) ? 0 : mMinX);
             Entry entryTo = dataSet.getEntryForXIndex(mMaxX);
 
-            int minx = Math.max(dataSet.getEntryPosition(entryFrom), 0);
-            int maxx = Math.min(dataSet.getEntryPosition(entryTo) + 1, entries.size());
+            int diff = (entryFrom == entryTo) ? 1 : 0;
+            int minx = Math.max(dataSet.getEntryPosition(entryFrom) - diff, 0);
+            int maxx = Math.min(Math.max(
+                    minx + 2, dataSet.getEntryPosition(entryTo) + 1), entries.size());
 
             CircleBuffer buffer = mCircleBuffers[i];
             buffer.setPhases(phaseX, phaseY);


### PR DESCRIPTION
If you have two values that are at separated by a large number of empty x-vals in between and you pinch to zoom inwards, eventually the line between them is not drawn. This is because the two `DataSet.getEntryForXIndex` calls may return the same `Entry`. The fix is to try and modify the min and max values to accommodate drawing a single line, rather than no line.