### PR TITLE
Fixing overlapping label closes #1085

### DIFF
--- a/MPChartLib/src/com/github/mikephil/charting/charts/BarChart.java
+++ b/MPChartLib/src/com/github/mikephil/charting/charts/BarChart.java
@@ -133,6 +133,29 @@ public class BarChart extends BarLineChartBase<BarData> implements BarDataProvid
 	}
 
 	/**
+	 * Returns the bounding box of the specified label on the X-axis
+	 * @param xIndex index of the label
+	 * @param yPos y coordinate of the label on the x-axis
+	 * @return bounding box reference
+	 */
+	public RectF getBarBounds(int xIndex, float yPos) {
+		float barspace = 0.6f;
+		float barWidth = 0.5f;
+
+		float spaceThird = barWidth / 2.8f;
+
+		float left = xIndex;
+		float right = xIndex + barspace - spaceThird;
+		float top = yPos >= 0 ? yPos : 0;
+		float bottom = yPos <= 0 ? yPos : 0;
+
+		RectF bounds = new RectF(left, top, right, bottom);
+
+		getTransformer(AxisDependency.LEFT).rectValueToPixel(bounds);
+		return bounds;
+	}
+
+	/**
 	 * set this to true to draw the highlightning arrow
 	 * 
 	 * @param enabled

--- a/MPChartLib/src/com/github/mikephil/charting/formatter/DefaultXAxisValueFormatter.java
+++ b/MPChartLib/src/com/github/mikephil/charting/formatter/DefaultXAxisValueFormatter.java
@@ -1,5 +1,9 @@
 package com.github.mikephil.charting.formatter;
 
+import android.graphics.Paint;
+import android.text.TextPaint;
+import android.text.TextUtils;
+
 import com.github.mikephil.charting.utils.ViewPortHandler;
 
 /**
@@ -8,9 +12,16 @@ import com.github.mikephil.charting.utils.ViewPortHandler;
  * This simply returns the original value unmodified.
  */
 public class DefaultXAxisValueFormatter implements XAxisValueFormatter {
+    private TextPaint mTextPaint;
+    public DefaultXAxisValueFormatter() {
+        mTextPaint = new TextPaint(Paint.ANTI_ALIAS_FLAG);
+    }
 
     @Override
     public String getXValue(String original, int index, ViewPortHandler viewPortHandler) {
-        return original; // just return original, no adjustments
+        /** This will truncate long text based on the available space mentioned on xLabelRect */
+        return TextUtils.ellipsize(original, mTextPaint,
+                viewPortHandler.getXLabelRect().right - viewPortHandler.getXLabelRect().left,
+                TextUtils.TruncateAt.MIDDLE).toString();
     }
 }

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/XAxisRendererBarChart.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/XAxisRendererBarChart.java
@@ -72,6 +72,8 @@ public class XAxisRendererBarChart extends XAxisRenderer {
                     }
                 }
 
+                // find available bounds for the label at index i
+                mViewPortHandler.setXLabelRect(mChart.getBarBounds(i, pos));
                 drawLabel(c, label, i, position[0], pos);
             }
         }

--- a/MPChartLib/src/com/github/mikephil/charting/utils/ViewPortHandler.java
+++ b/MPChartLib/src/com/github/mikephil/charting/utils/ViewPortHandler.java
@@ -23,6 +23,9 @@ public class ViewPortHandler {
      */
     protected RectF mContentRect = new RectF();
 
+    /** this rectangle defines the area in which X-axis labels can be drawn */
+    protected RectF mXLabelRect = new RectF();
+
     protected float mChartWidth = 0f;
     protected float mChartHeight = 0f;
 
@@ -163,6 +166,14 @@ public class ViewPortHandler {
 
     public PointF getContentCenter() {
         return new PointF(mContentRect.centerX(), mContentRect.centerY());
+    }
+
+    public RectF getXLabelRect() {
+        return mXLabelRect;
+    }
+
+    public void setXLabelRect(RectF xLabelRect) {
+        mXLabelRect = xLabelRect;
     }
 
     public float getChartHeight() {


### PR DESCRIPTION
Fixing bug that caused x-axis labels to overlap by introducing initial label truncation and gradually revealing more text as the user zooms in. closes #1085