### PR TITLE
Allow getting/settings minOffset of the charts

### DIFF
--- a/MPChartLib/src/com/github/mikephil/charting/charts/BarLineChartBase.java
+++ b/MPChartLib/src/com/github/mikephil/charting/charts/BarLineChartBase.java
@@ -1131,6 +1131,16 @@ public abstract class BarLineChartBase<T extends BarLineScatterCandleBubbleData<
         mBorderPaint.setColor(color);
     }
 
+    /** Gets the minimum offset (padding) around the chart, defaults to 10.f */
+    public float getMinOffset() {
+        return mMinOffset;
+    }
+
+    /** Sets the minimum offset (padding) around the chart, defaults to 10.f */
+    public void setMinOffset(float minOffset) {
+        mMinOffset = minOffset;
+    }
+
     /**
      * Returns the Highlight object (contains x-index and DataSet index) of the
      * selected value at the given touch point inside the Line-, Scatter-, or

--- a/MPChartLib/src/com/github/mikephil/charting/charts/PieRadarChartBase.java
+++ b/MPChartLib/src/com/github/mikephil/charting/charts/PieRadarChartBase.java
@@ -42,6 +42,9 @@ public abstract class PieRadarChartBase<T extends ChartData<? extends DataSet<? 
     /** flag that indicates if rotation is enabled or not */
     protected boolean mRotateEnabled = true;
 
+    /** Sets the minimum offset (padding) around the chart, defaults to 0.f */
+    protected float mMinOffset = 0.f;
+
     public PieRadarChartBase(Context context) {
         super(context);
     }
@@ -209,13 +212,13 @@ public abstract class PieRadarChartBase<T extends ChartData<? extends DataSet<? 
             legendTop += getRequiredBaseOffset();
         }
 
-        float minOffset = 0f;
+        float minOffset = Utils.convertDpToPixel(mMinOffset);
 
         if (this instanceof RadarChart) {
             XAxis x = ((RadarChart) this).getXAxis();
 
             if (x.isEnabled() && x.isDrawLabelsEnabled()) {
-                minOffset = x.mLabelWidth;
+                minOffset = Math.max(minOffset, x.mLabelWidth);
             }
         }
 
@@ -378,6 +381,16 @@ public abstract class PieRadarChartBase<T extends ChartData<? extends DataSet<? 
      */
     public boolean isRotationEnabled() {
         return mRotateEnabled;
+    }
+
+    /** Gets the minimum offset (padding) around the chart, defaults to 0.f */
+    public float getMinOffset() {
+        return mMinOffset;
+    }
+
+    /** Sets the minimum offset (padding) around the chart, defaults to 0.f */
+    public void setMinOffset(float minOffset) {
+        mMinOffset = minOffset;
     }
 
     /**


### PR DESCRIPTION
Instead of zeroing the minOffset and losing the ability to add it - now we can control it manually if needed, and still defaults to 0...