### PR TITLE
Fix x-axis labels' display of bar chart when set ```isAvoidFirstLastClippingEnabled```

### DIFF
--- a/MPChartLib/src/com/github/mikephil/charting/renderer/XAxisRendererBarChart.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/XAxisRendererBarChart.java
@@ -68,7 +68,7 @@ public class XAxisRendererBarChart extends XAxisRenderer {
                     } else if (i == 0) {
 
                         float width = Utils.calcTextWidth(mAxisLabelPaint, label);
-                        position[0] += width / 2;
+                        position[0] = mViewPortHandler.offsetLeft() + (width / 2);
                     }
                 }
 


### PR DESCRIPTION
same issue with https://github.com/danielgindi/ios-charts/issues/479

Related with https://github.com/danielgindi/ios-charts/pull/489