### PR TITLE
Fixed rounding issue with LineChartRenderer

### DIFF
--- a/MPChartLib/src/com/github/mikephil/charting/renderer/LineChartRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/LineChartRenderer.java
@@ -1,4 +1,3 @@
-
 package com.github.mikephil.charting.renderer;
 
 import android.graphics.Bitmap;
@@ -11,6 +10,7 @@ import com.github.mikephil.charting.animation.ChartAnimator;
 import com.github.mikephil.charting.buffer.CircleBuffer;
 import com.github.mikephil.charting.buffer.LineBuffer;
 import com.github.mikephil.charting.charts.LineChart;
+import com.github.mikephil.charting.data.DataSet;
 import com.github.mikephil.charting.data.Entry;
 import com.github.mikephil.charting.data.LineData;
 import com.github.mikephil.charting.data.LineDataSet;
@@ -138,13 +138,11 @@ public class LineChartRenderer extends LineScatterCandleRadarRenderer {
 
         Transformer trans = mChart.getTransformer(dataSet.getAxisDependency());
 
-        Entry entryFrom = dataSet.getEntryForXIndex(mMinX);
-        Entry entryTo = dataSet.getEntryForXIndex(mMaxX);
+        Entry entryFrom = dataSet.getEntryForXIndex((mMinX < 0) ? 0 : mMinX, DataSet.Rounding.DOWN);
+        Entry entryTo = dataSet.getEntryForXIndex(mMaxX, DataSet.Rounding.UP);
 
-        int diff = (entryFrom == entryTo) ? 1 : 0;
-        int minx = Math.max(dataSet.getEntryPosition(entryFrom) - diff, 0);
-        int maxx = Math.min(Math.max(
-                minx + 2, dataSet.getEntryPosition(entryTo) + 1), entries.size());
+        int minx = Math.max(dataSet.getEntryPosition(entryFrom), 0);
+        int maxx = Math.min(dataSet.getEntryPosition(entryTo) + 1, entries.size());
 
         float phaseX = mAnimator.getPhaseX();
         float phaseY = mAnimator.getPhaseY();
@@ -284,13 +282,11 @@ public class LineChartRenderer extends LineScatterCandleRadarRenderer {
             canvas = c;
         }
 
-        Entry entryFrom = dataSet.getEntryForXIndex(mMinX);
-        Entry entryTo = dataSet.getEntryForXIndex(mMaxX);
+        Entry entryFrom = dataSet.getEntryForXIndex((mMinX < 0) ? 0 : mMinX, DataSet.Rounding.DOWN);
+        Entry entryTo = dataSet.getEntryForXIndex(mMaxX, DataSet.Rounding.UP);
 
-        int diff = (entryFrom == entryTo) ? 1 : 0;
-        int minx = Math.max(dataSet.getEntryPosition(entryFrom) - diff, 0);
-        int maxx = Math.min(Math.max(
-                minx + 2, dataSet.getEntryPosition(entryTo) + 1), entries.size());
+        int minx = Math.max(dataSet.getEntryPosition(entryFrom), 0);
+        int maxx = Math.min(dataSet.getEntryPosition(entryTo) + 1, entries.size());
 
         int range = (maxx - minx) * 4 - 4;
 
@@ -436,13 +432,11 @@ public class LineChartRenderer extends LineScatterCandleRadarRenderer {
 
                 List<Entry> entries = dataSet.getYVals();
 
-                Entry entryFrom = dataSet.getEntryForXIndex(mMinX);
-                Entry entryTo = dataSet.getEntryForXIndex(mMaxX);
+                Entry entryFrom = dataSet.getEntryForXIndex((mMinX < 0) ? 0 : mMinX, DataSet.Rounding.DOWN);
+                Entry entryTo = dataSet.getEntryForXIndex(mMaxX, DataSet.Rounding.UP);
 
-                int diff = (entryFrom == entryTo) ? 1 : 0;
-                int minx = Math.max(dataSet.getEntryPosition(entryFrom) - diff, 0);
-                int maxx = Math.min(Math.max(
-                        minx + 2, dataSet.getEntryPosition(entryTo) + 1), entries.size());
+                int minx = Math.max(dataSet.getEntryPosition(entryFrom), 0);
+                int maxx = Math.min(dataSet.getEntryPosition(entryTo) + 1, entries.size());
 
                 float[] positions = trans.generateTransformedValuesLine(
                         entries, mAnimator.getPhaseX(), mAnimator.getPhaseY(), minx, maxx);
@@ -494,13 +488,11 @@ public class LineChartRenderer extends LineScatterCandleRadarRenderer {
             Transformer trans = mChart.getTransformer(dataSet.getAxisDependency());
             List<Entry> entries = dataSet.getYVals();
 
-            Entry entryFrom = dataSet.getEntryForXIndex((mMinX < 0) ? 0 : mMinX);
-            Entry entryTo = dataSet.getEntryForXIndex(mMaxX);
+            Entry entryFrom = dataSet.getEntryForXIndex((mMinX < 0) ? 0 : mMinX, DataSet.Rounding.DOWN);
+            Entry entryTo = dataSet.getEntryForXIndex(mMaxX, DataSet.Rounding.UP);
 
-            int diff = (entryFrom == entryTo) ? 1 : 0;
-            int minx = Math.max(dataSet.getEntryPosition(entryFrom) - diff, 0);
-            int maxx = Math.min(Math.max(
-                    minx + 2, dataSet.getEntryPosition(entryTo) + 1), entries.size());
+            int minx = Math.max(dataSet.getEntryPosition(entryFrom), 0);
+            int maxx = Math.min(dataSet.getEntryPosition(entryTo) + 1, entries.size());
 
             CircleBuffer buffer = mCircleBuffers[i];
             buffer.setPhases(phaseX, phaseY);


### PR DESCRIPTION
I tried to fix this issue in 92ea5b3, but it looks like it didn't cover all issues. The initial issue was that `getEntryForXIndex()` was returning the same `Entry`, but the deeper reason is that it is doing so because it rounds the x-index to the *nearest* one if there is no entry at that specific index. Both calls were getting rounded to the same x-index.

To avoid this scenario, `getEntryIndex(int)` has been overloaded to take in a parameter that defines which way to round the index if it is not found. The default is to keep the original behavior, but the LineChartRenderer needs to make sure that the two entries are rounded away from each other, so that the lines extend *at least* as far as the viewport bounds.