### PR TITLE
Add bitmap in  data of an Entry to show Marker in BarChart and LineChart

### DIFF
--- a/MPChartLib/src/com/github/mikephil/charting/data/Entry.java
+++ b/MPChartLib/src/com/github/mikephil/charting/data/Entry.java
@@ -25,9 +25,6 @@ public class Entry implements Parcelable {
     private Object mData = null;
 
 
-    /** the marker view associated to the highlight */
-    private MarkerView markerView;
-
     /**
      * A Entry represents one single entry in the chart.
      * 
@@ -41,19 +38,7 @@ public class Entry implements Parcelable {
         mXIndex = xIndex;
     }
 
-    /**
-     * A Entry represents one single entry in the chart.
-     *
-     * @param val the y value (the actual value of the entry)
-     * @param xIndex the corresponding index in the x value array (index on the
-     *            x-axis of the chart, must NOT be higher than the length of the
-     *            x-values String array)
-     */
-    public Entry(float val, int xIndex, MarkerView markerView) {
-        mVal = val;
-        mXIndex = xIndex;
-        this.markerView = markerView;
-    }
+
     /**
      * A Entry represents one single entry in the chart.
      * 
@@ -205,8 +190,4 @@ public class Entry implements Parcelable {
         }
     };
 
-
-    public MarkerView getMarkerView() {
-        return markerView;
-    }
 }

--- a/MPChartLib/src/com/github/mikephil/charting/data/Entry.java
+++ b/MPChartLib/src/com/github/mikephil/charting/data/Entry.java
@@ -5,6 +5,8 @@ import android.os.Parcel;
 import android.os.ParcelFormatException;
 import android.os.Parcelable;
 
+import com.github.mikephil.charting.components.MarkerView;
+
 /**
  * Class representing one entry in the chart. Might contain multiple values.
  * Might only contain a single value depending on the used constructor.
@@ -22,6 +24,10 @@ public class Entry implements Parcelable {
     /** optional spot for additional data this Entry represents */
     private Object mData = null;
 
+
+    /** the marker view associated to the highlight */
+    private MarkerView markerView;
+
     /**
      * A Entry represents one single entry in the chart.
      * 
@@ -35,6 +41,19 @@ public class Entry implements Parcelable {
         mXIndex = xIndex;
     }
 
+    /**
+     * A Entry represents one single entry in the chart.
+     *
+     * @param val the y value (the actual value of the entry)
+     * @param xIndex the corresponding index in the x value array (index on the
+     *            x-axis of the chart, must NOT be higher than the length of the
+     *            x-values String array)
+     */
+    public Entry(float val, int xIndex, MarkerView markerView) {
+        mVal = val;
+        mXIndex = xIndex;
+        this.markerView = markerView;
+    }
     /**
      * A Entry represents one single entry in the chart.
      * 
@@ -185,4 +204,9 @@ public class Entry implements Parcelable {
             return new Entry[size];
         }
     };
+
+
+    public MarkerView getMarkerView() {
+        return markerView;
+    }
 }

--- a/MPChartLib/src/com/github/mikephil/charting/data/Entry.java
+++ b/MPChartLib/src/com/github/mikephil/charting/data/Entry.java
@@ -5,8 +5,6 @@ import android.os.Parcel;
 import android.os.ParcelFormatException;
 import android.os.Parcelable;
 
-import com.github.mikephil.charting.components.MarkerView;
-
 /**
  * Class representing one entry in the chart. Might contain multiple values.
  * Might only contain a single value depending on the used constructor.

--- a/MPChartLib/src/com/github/mikephil/charting/highlight/Highlight.java
+++ b/MPChartLib/src/com/github/mikephil/charting/highlight/Highlight.java
@@ -1,6 +1,8 @@
 
 package com.github.mikephil.charting.highlight;
 
+import com.github.mikephil.charting.components.MarkerView;
+
 /**
  * Contains information needed to determine the highlighted value.
  * 
@@ -19,7 +21,6 @@ public class Highlight {
 
     /** the range of the bar that is selected (only for stacked-barchart) */
     private Range mRange;
-
     /**
      * constructor
      * 
@@ -119,4 +120,5 @@ public class Highlight {
         return "Highlight, xIndex: " + mXIndex + ", dataSetIndex: " + mDataSetIndex
                 + ", stackIndex (only stacked barentry): " + mStackIndex;
     }
+
 }

--- a/MPChartLib/src/com/github/mikephil/charting/highlight/Highlight.java
+++ b/MPChartLib/src/com/github/mikephil/charting/highlight/Highlight.java
@@ -1,8 +1,6 @@
 
 package com.github.mikephil.charting.highlight;
 
-import com.github.mikephil.charting.components.MarkerView;
-
 /**
  * Contains information needed to determine the highlighted value.
  * 

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/LineChartRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/LineChartRenderer.java
@@ -476,65 +476,50 @@ public class LineChartRenderer extends LineScatterCandleRadarRenderer {
     }
 
     private void drawMarkersView(Canvas c) {
-        if (mChart.getLineData().getYValCount() < mChart.getMaxVisibleCount()
-                * mViewPortHandler.getScaleX()) {
 
-            List<LineDataSet> dataSets = mChart.getLineData().getDataSets();
 
-            for (int i = 0; i < dataSets.size(); i++) {
+        List<LineDataSet> dataSets = mChart.getLineData().getDataSets();
 
-                LineDataSet dataSet = dataSets.get(i);
+        for (int i = 0; i < dataSets.size(); i++) {
 
-                if (!dataSet.isDrawValuesEnabled() || dataSet.getEntryCount() == 0)
+            LineDataSet dataSet = dataSets.get(i);
+
+            if (dataSet.getEntryCount() == 0)
+                continue;
+
+            Transformer trans = mChart.getTransformer(dataSet.getAxisDependency());
+
+            List<Entry> entries = dataSet.getYVals();
+
+            Entry entryFrom = dataSet.getEntryForXIndex(mMinX);
+            Entry entryTo = dataSet.getEntryForXIndex(mMaxX);
+
+            int diff = (entryFrom == entryTo) ? 1 : 0;
+            int minx = Math.max(dataSet.getEntryPosition(entryFrom) - diff, 0);
+            int maxx = Math.min(Math.max(
+                    minx + 2, dataSet.getEntryPosition(entryTo) + 1), entries.size());
+
+            float[] positions = trans.generateTransformedValuesLine(
+                    entries, mAnimator.getPhaseX(), mAnimator.getPhaseY(), minx, maxx);
+
+            for (int j = 0; j < positions.length; j += 2) {
+
+                float x = positions[j];
+                float y = positions[j + 1];
+
+                if (!mViewPortHandler.isInBoundsRight(x))
+                    break;
+
+                if (!mViewPortHandler.isInBoundsLeft(x) || !mViewPortHandler.isInBoundsY(y))
                     continue;
 
-                // apply the text-styling defined by the DataSet
-                applyValueTextStyle(dataSet);
-
-                Transformer trans = mChart.getTransformer(dataSet.getAxisDependency());
-
-                // make sure the values do not interfear with the circles
-                int valOffset = (int) (dataSet.getCircleSize() * 1.75f);
-
-                if (!dataSet.isDrawCirclesEnabled())
-                    valOffset = valOffset / 2;
-
-                List<Entry> entries = dataSet.getYVals();
-
-                Entry entryFrom = dataSet.getEntryForXIndex(mMinX);
-                Entry entryTo = dataSet.getEntryForXIndex(mMaxX);
-
-                int diff = (entryFrom == entryTo) ? 1 : 0;
-                int minx = Math.max(dataSet.getEntryPosition(entryFrom) - diff, 0);
-                int maxx = Math.min(Math.max(
-                        minx + 2, dataSet.getEntryPosition(entryTo) + 1), entries.size());
-
-                float[] positions = trans.generateTransformedValuesLine(
-                        entries, mAnimator.getPhaseX(), mAnimator.getPhaseY(), minx, maxx);
-
-                for (int j = 0; j < positions.length; j += 2) {
-
-                    float x = positions[j];
-                    float y = positions[j + 1];
-
-                    if (!mViewPortHandler.isInBoundsRight(x))
-                        break;
-
-                    if (!mViewPortHandler.isInBoundsLeft(x) || !mViewPortHandler.isInBoundsY(y))
-                        continue;
-
-                    Entry entry = entries.get(j / 2 + minx);
-                    MarkerView markerView = entry.getMarkerView();
-                    if (markerView!= null) {
-
-
-                        markerView.measure(View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED),
-                                View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED));
-                        markerView.layout(0, 0, markerView.getMeasuredWidth(),
-                                markerView.getMeasuredHeight());
-
-                            markerView.draw(c,x, y);
-
+                Entry entry = entries.get(j / 2 + minx);
+                if (entry.getData() != null) {
+                    if (entry.getData() instanceof Bitmap) {
+                        Bitmap b = (Bitmap) entry.getData();
+                        if (b != null) {
+                            c.drawBitmap(b, x, y, null);
+                        }
                     }
                 }
             }

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/LineChartRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/LineChartRenderer.java
@@ -6,6 +6,7 @@ import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.Path;
+import android.graphics.Rect;
 import android.view.View;
 
 import com.github.mikephil.charting.animation.ChartAnimator;
@@ -518,7 +519,11 @@ public class LineChartRenderer extends LineScatterCandleRadarRenderer {
                     if (entry.getData() instanceof Bitmap) {
                         Bitmap b = (Bitmap) entry.getData();
                         if (b != null) {
-                            c.drawBitmap(b, x, y, null);
+                            int halfWidth = (int) (b.getWidth() * 0.5f);
+                            int halfHeight = (int) (b.getHeight() * 0.5f);
+                            Rect dstRectForRender = new Rect((int) (x - halfWidth), (int) (y - halfHeight), (int) (x + halfWidth), (int) (y + halfHeight));
+                            dstRectForRender.offset(0, - halfHeight);
+                            c.drawBitmap(b, null, dstRectForRender, null);
                         }
                     }
                 }


### PR DESCRIPTION

Hi,

For my project, I needed the possibility to add multiple Marker on different charts.
I began with MarkerViews/HighLights, but I found it easier to add it in the Data of the Entry an object of type Bitmap.
I have not been able to use MarkerView, (with its method draw), so i cheated using Bitmap. 
In this case, there is a test in the renderer (bar char/line) to draw the bitmap.

For example  : 

    Intensity intensity = intensities.get(i);
                if (intensity.showAlert()) {
                    entries.add(new Entry(intensity.getValue(), i, BitmapFactory.decodeResource(getResources(), R.drawable.star)));
                } else {
                    entries.add(new Entry(intensity.getValue(), i));
                }

If you want a specific view, I create a CustomView then I transform it to a bitmap
 

    if (i % 3 == 0) {
                    CustomValueView customValueView = CustomValueView_.build(getContext());
                    customValueView.bind(value);
                    entry = new BarEntry(value, i, customValueView.toBitmap());
                } else {
                    entry = new BarEntry(value, i);
      }

The toBitmap() method :

        
    public static Bitmap getBitmapFromView(View v) {
            v.setDrawingCacheEnabled(true);
    
    // this is the important code :)
    // Without it the view will have a dimension of 0,0 and the bitmap will be null
            v.measure(View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED),
                    View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED));
            v.layout(0, 0, v.getMeasuredWidth(), v.getMeasuredHeight());
    
            v.buildDrawingCache(true);
            Bitmap b = Bitmap.createBitmap(v.getDrawingCache());
            v.setDrawingCacheEnabled(false); // clear drawing cache
            return b;
        }