### PR TITLE
Fixed bounding rect for pie center text

### DIFF
--- a/MPChartLib/src/com/github/mikephil/charting/renderer/PieChartRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/PieChartRenderer.java
@@ -311,8 +311,10 @@ public class PieChartRenderer extends DataRenderer {
 
             float radiusPercent = mChart.getCenterTextRadiusPercent();
             if (radiusPercent > 0.0) {
-                boundingRect.inset((boundingRect.width() - boundingRect.width() * radiusPercent) / 2.f,
-                        (boundingRect.height() - boundingRect.height() * radiusPercent) / 2.f);
+                boundingRect.inset(
+                        (boundingRect.width() - boundingRect.width() * (radiusPercent / 100.f)) / 2.f,
+                        (boundingRect.height() - boundingRect.height() * (radiusPercent / 100.f)) / 2.f
+                );
             }
 
             if (!centerText.equals(mCenterTextLastValue) || !boundingRect.equals(mCenterTextLastBounds)) {


### PR DESCRIPTION
It was "insetting" by a factor of 100,
because of wrong perception of the percentage property.