### PR TITLE
Fixes #1258

### DIFF
--- a/MPChartLib/src/com/github/mikephil/charting/renderer/PieChartRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/PieChartRenderer.java
@@ -246,7 +246,7 @@ public class PieChartRenderer extends DataRenderer {
     public void drawExtras(Canvas c) {
         // drawCircles(c);
         drawHole(c);
-        c.drawBitmap(mDrawBitmap, 0, 0, mRenderPaint);
+        c.drawBitmap(mDrawBitmap, 0, 0, null);
         drawCenterText(c);
     }
 


### PR DESCRIPTION
Passing a Paint object as the 4th argument to `drawBitmap` will draw the entire canvas with transparency if the last color used was transparent.
We can pass null instead.

http://developer.android.com/reference/android/graphics/Canvas.html#drawBitmap(android.graphics.Bitmap, float, float, android.graphics.Paint)