### PR TITLE
Renamed "circle size" to "circle radius", deprecated set/getCircleSize

### DIFF
--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/CombinedChartActivity.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/CombinedChartActivity.java
@@ -90,7 +90,7 @@ public class CombinedChartActivity extends DemoBase {
         set.setColor(Color.rgb(240, 238, 70));
         set.setLineWidth(2.5f);
         set.setCircleColor(Color.rgb(240, 238, 70));
-        set.setCircleSize(5f);
+        set.setCircleRadius(5f);
         set.setFillColor(Color.rgb(240, 238, 70));
         set.setDrawCubic(true);
         set.setDrawValues(true);

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/CubicLineChartActivity.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/CubicLineChartActivity.java
@@ -281,7 +281,7 @@ public class CubicLineChartActivity extends DemoBase implements OnSeekBarChangeL
         //set1.setDrawFilled(true);
         set1.setDrawCircles(false); 
         set1.setLineWidth(1.8f);
-        set1.setCircleSize(4f);
+        set1.setCircleRadius(4f);
         set1.setCircleColor(Color.WHITE);
         set1.setHighLightColor(Color.rgb(244, 117, 117));
         set1.setColor(Color.WHITE);

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/DrawChartActivity.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/DrawChartActivity.java
@@ -84,7 +84,7 @@ public class DrawChartActivity extends DemoBase implements OnChartValueSelectedL
         // create a dataset and give it a type (0)
         LineDataSet set1 = new LineDataSet(yVals, "DataSet");
         set1.setLineWidth(3f);
-        set1.setCircleSize(5f);
+        set1.setCircleRadius(5f);
 
         ArrayList<ILineDataSet> dataSets = new ArrayList<ILineDataSet>();
         dataSets.add(set1); // add the datasets

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/DynamicalAddingActivity.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/DynamicalAddingActivity.java
@@ -126,7 +126,7 @@ public class DynamicalAddingActivity extends DemoBase implements OnChartValueSel
 
             LineDataSet set = new LineDataSet(yVals, "DataSet " + count);
             set.setLineWidth(2.5f);
-            set.setCircleSize(4.5f);
+            set.setCircleRadius(4.5f);
 
             int color = mColors[count % mColors.length];
 
@@ -209,7 +209,7 @@ public class DynamicalAddingActivity extends DemoBase implements OnChartValueSel
 
         LineDataSet set = new LineDataSet(null, "DataSet 1");
         set.setLineWidth(2.5f);
-        set.setCircleSize(4.5f);
+        set.setCircleRadius(4.5f);
         set.setColor(Color.rgb(240, 99, 99));
         set.setCircleColor(Color.rgb(240, 99, 99));
         set.setHighLightColor(Color.rgb(190, 190, 190));

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/InvertedLineChartActivity.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/InvertedLineChartActivity.java
@@ -292,7 +292,7 @@ public class InvertedLineChartActivity extends DemoBase implements OnSeekBarChan
         LineDataSet set1 = new LineDataSet(yVals, "DataSet 1");
 
         set1.setLineWidth(1.5f);
-        set1.setCircleSize(4f);
+        set1.setCircleRadius(4f);
 
         // create a data object with the datasets
         LineData data = new LineData(xVals, set1);

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/LineChartActivity1.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/LineChartActivity1.java
@@ -355,7 +355,7 @@ public class LineChartActivity1 extends DemoBase implements OnSeekBarChangeListe
         set1.setColor(Color.BLACK);
         set1.setCircleColor(Color.BLACK);
         set1.setLineWidth(1f);
-        set1.setCircleSize(3f);
+        set1.setCircleRadius(3f);
         set1.setDrawCircleHole(false);
         set1.setValueTextSize(9f);
         set1.setFillAlpha(65);

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/LineChartActivity2.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/LineChartActivity2.java
@@ -296,7 +296,7 @@ public class LineChartActivity2 extends DemoBase implements OnSeekBarChangeListe
         set1.setColor(ColorTemplate.getHoloBlue());
         set1.setCircleColor(Color.WHITE);
         set1.setLineWidth(2f);
-        set1.setCircleSize(3f);
+        set1.setCircleRadius(3f);
         set1.setFillAlpha(65);
         set1.setFillColor(ColorTemplate.getHoloBlue());
         set1.setHighLightColor(Color.rgb(244, 117, 117));
@@ -322,7 +322,7 @@ public class LineChartActivity2 extends DemoBase implements OnSeekBarChangeListe
         set2.setColor(Color.RED);
         set2.setCircleColor(Color.WHITE);
         set2.setLineWidth(2f);
-        set2.setCircleSize(3f);
+        set2.setCircleRadius(3f);
         set2.setFillAlpha(65);
         set2.setFillColor(Color.RED);
         set2.setDrawCircleHole(false);

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/LineChartActivityColored.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/LineChartActivityColored.java
@@ -113,7 +113,7 @@ public class LineChartActivityColored extends DemoBase {
         // set1.setFillColor(Color.RED);
 
         set1.setLineWidth(1.75f);
-        set1.setCircleSize(3f);
+        set1.setCircleRadius(3f);
         set1.setColor(Color.WHITE);
         set1.setCircleColor(Color.WHITE);
         set1.setHighLightColor(Color.WHITE);

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/ListViewMultiChartActivity.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/ListViewMultiChartActivity.java
@@ -103,7 +103,7 @@ public class ListViewMultiChartActivity extends DemoBase {
 
         LineDataSet d1 = new LineDataSet(e1, "New DataSet " + cnt + ", (1)");
         d1.setLineWidth(2.5f);
-        d1.setCircleSize(4.5f);
+        d1.setCircleRadius(4.5f);
         d1.setHighLightColor(Color.rgb(244, 117, 117));
         d1.setDrawValues(false);
         
@@ -115,7 +115,7 @@ public class ListViewMultiChartActivity extends DemoBase {
 
         LineDataSet d2 = new LineDataSet(e2, "New DataSet " + cnt + ", (2)");
         d2.setLineWidth(2.5f);
-        d2.setCircleSize(4.5f);
+        d2.setCircleRadius(4.5f);
         d2.setHighLightColor(Color.rgb(244, 117, 117));
         d2.setColor(ColorTemplate.VORDIPLOM_COLORS[0]);
         d2.setCircleColor(ColorTemplate.VORDIPLOM_COLORS[0]);

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/MultiLineChartActivity.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/MultiLineChartActivity.java
@@ -228,7 +228,7 @@ public class MultiLineChartActivity extends DemoBase implements OnSeekBarChangeL
 
             LineDataSet d = new LineDataSet(values, "DataSet " + (z + 1));
             d.setLineWidth(2.5f);
-            d.setCircleSize(4f);
+            d.setCircleRadius(4f);
 
             int color = mColors[z % mColors.length];
             d.setColor(color);

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/RealtimeLineChartActivity.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/RealtimeLineChartActivity.java
@@ -168,7 +168,7 @@ public class RealtimeLineChartActivity extends DemoBase implements
         set.setColor(ColorTemplate.getHoloBlue());
         set.setCircleColor(Color.WHITE);
         set.setLineWidth(2f);
-        set.setCircleSize(4f);
+        set.setCircleRadius(4f);
         set.setFillAlpha(65);
         set.setFillColor(ColorTemplate.getHoloBlue());
         set.setHighLightColor(Color.rgb(244, 117, 117));

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/fragments/SimpleFragment.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/fragments/SimpleFragment.java
@@ -185,13 +185,13 @@ public abstract class SimpleFragment extends Fragment {
         ds4.setCircleColor(ColorTemplate.VORDIPLOM_COLORS[3]);
         
         ds1.setLineWidth(2.5f);
-        ds1.setCircleSize(3f);
+        ds1.setCircleRadius(3f);
         ds2.setLineWidth(2.5f);
-        ds2.setCircleSize(3f);
+        ds2.setCircleRadius(3f);
         ds3.setLineWidth(2.5f);
-        ds3.setCircleSize(3f);
+        ds3.setCircleRadius(3f);
         ds4.setLineWidth(2.5f);
-        ds4.setCircleSize(3f);
+        ds4.setCircleRadius(3f);
         
         
         // load DataSets from textfiles in assets folders

--- a/MPChartLib/src/com/github/mikephil/charting/data/LineDataSet.java
+++ b/MPChartLib/src/com/github/mikephil/charting/data/LineDataSet.java
@@ -23,7 +23,7 @@ public class LineDataSet extends LineRadarDataSet<Entry> implements ILineDataSet
     private int mCircleColorHole = Color.WHITE;
 
     /** the radius of the circle-shaped value indicators */
-    private float mCircleSize = 8f;
+    private float mCircleRadius = 8f;
 
     /** sets the intensity of the cubic lines */
     private float mCubicIntensity = 0.2f;
@@ -45,7 +45,7 @@ public class LineDataSet extends LineRadarDataSet<Entry> implements ILineDataSet
     public LineDataSet(List<Entry> yVals, String label) {
         super(yVals, label);
 
-        // mCircleSize = Utils.convertDpToPixel(4f);
+        // mCircleRadius = Utils.convertDpToPixel(4f);
         // mLineWidth = Utils.convertDpToPixel(1f);
 
         mCircleColors = new ArrayList<Integer>();
@@ -67,7 +67,7 @@ public class LineDataSet extends LineRadarDataSet<Entry> implements ILineDataSet
 
         LineDataSet copied = new LineDataSet(yVals, getLabel());
         copied.mColors = mColors;
-        copied.mCircleSize = mCircleSize;
+        copied.mCircleRadius = mCircleRadius;
         copied.mCircleColors = mCircleColors;
         copied.mDashPathEffect = mDashPathEffect;
         copied.mDrawCircles = mDrawCircles;
@@ -98,19 +98,43 @@ public class LineDataSet extends LineRadarDataSet<Entry> implements ILineDataSet
         return mCubicIntensity;
     }
 
+
     /**
-     * sets the size (radius) of the circle shpaed value indicators, default
-     * size = 4f
-     * 
-     * @param size
+     * sets the radius of the drawn circles.
+     * Default radius = 4f
+     *
+     * @param radius
      */
-    public void setCircleSize(float size) {
-        mCircleSize = Utils.convertDpToPixel(size);
+    public void setCircleRadius(float radius) {
+        mCircleRadius = Utils.convertDpToPixel(radius);
     }
 
     @Override
+    public float getCircleRadius() {
+        return mCircleRadius;
+    }
+
+    /**
+     * sets the size (radius) of the circle shpaed value indicators,
+     * default size = 4f
+     *
+     * This method is deprecated because of unclarity. Use setCircleRadius instead.
+     *
+     * @param size
+     */
+    @Deprecated
+    public void setCircleSize(float size) {
+        setCircleRadius(size);
+    }
+
+    /**
+     *
+     * This function is deprecated because of unclarity. Use getCircleRadius instead.
+     *
+     */
+    @Deprecated
     public float getCircleSize() {
-        return mCircleSize;
+        return getCircleRadius();
     }
 
     /**

--- a/MPChartLib/src/com/github/mikephil/charting/data/realm/implementation/RealmLineDataSet.java
+++ b/MPChartLib/src/com/github/mikephil/charting/data/realm/implementation/RealmLineDataSet.java
@@ -139,7 +139,7 @@ public class RealmLineDataSet<T extends RealmObject> extends RealmLineRadarDataS
     }
 
     @Override
-    public float getCircleSize() {
+    public float getCircleRadius() {
         return mCircleSize;
     }
 

--- a/MPChartLib/src/com/github/mikephil/charting/interfaces/datasets/ILineDataSet.java
+++ b/MPChartLib/src/com/github/mikephil/charting/interfaces/datasets/ILineDataSet.java
@@ -28,7 +28,7 @@ public interface ILineDataSet extends ILineRadarDataSet<Entry> {
     /**
      * Returns the size of the drawn circles.
      */
-    float getCircleSize();
+    float getCircleRadius();
 
     /**
      * Returns the color at the given index of the DataSet's circle-color array.

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/LineChartRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/LineChartRenderer.java
@@ -428,7 +428,7 @@ public class LineChartRenderer extends LineScatterCandleRadarRenderer {
                 Transformer trans = mChart.getTransformer(dataSet.getAxisDependency());
 
                 // make sure the values do not interfear with the circles
-                int valOffset = (int) (dataSet.getCircleSize() * 1.75f);
+                int valOffset = (int) (dataSet.getCircleRadius() * 1.75f);
 
                 if (!dataSet.isDrawCirclesEnabled())
                     valOffset = valOffset / 2;
@@ -506,7 +506,7 @@ public class LineChartRenderer extends LineScatterCandleRadarRenderer {
 
             trans.pointValuesToPixel(buffer.buffer);
 
-            float halfsize = dataSet.getCircleSize() / 2f;
+            float halfsize = dataSet.getCircleRadius() / 2f;
 
             for (int j = 0, count = (int) Math.ceil((maxx - minx) * phaseX + minx) * 2; j < count; j += 2) {
 
@@ -525,7 +525,7 @@ public class LineChartRenderer extends LineScatterCandleRadarRenderer {
 
                 mRenderPaint.setColor(circleColor);
 
-                c.drawCircle(x, y, dataSet.getCircleSize(),
+                c.drawCircle(x, y, dataSet.getCircleRadius(),
                         mRenderPaint);
 
                 if (dataSet.isDrawCircleHoleEnabled()


### PR DESCRIPTION
Kept the old functions for compatibility - but marked as Deprecated.