### PR TITLE
Adding configurable circle hole ratio

### DIFF
--- a/MPChartLib/src/com/github/mikephil/charting/data/LineDataSet.java
+++ b/MPChartLib/src/com/github/mikephil/charting/data/LineDataSet.java
@@ -43,6 +43,7 @@ public class LineDataSet extends LineRadarDataSet<Entry> implements ILineDataSet
 
     private boolean mDrawCircleHole = true;
 
+    private float mCircleHoleRatio = 0.5f;
 
     public LineDataSet(List<Entry> yVals, String label) {
         super(yVals, label);
@@ -308,6 +309,20 @@ public class LineDataSet extends LineRadarDataSet<Entry> implements ILineDataSet
     @Override
     public boolean isDrawCircleHoleEnabled() {
         return mDrawCircleHole;
+    }
+
+    /**
+     * Sets the ratio between the inner and outer circle.
+     *
+     * @param ratio
+     */
+    public void setCircleHoleRatio(float ratio) {
+        mCircleHoleRatio = ratio;
+    }
+    
+    @Override
+    public float getCircleHoleRatio() {
+        return mCircleHoleRatio;
     }
 
     /**

--- a/MPChartLib/src/com/github/mikephil/charting/data/realm/implementation/RealmLineDataSet.java
+++ b/MPChartLib/src/com/github/mikephil/charting/data/realm/implementation/RealmLineDataSet.java
@@ -65,6 +65,8 @@ public class RealmLineDataSet<T extends RealmObject> extends RealmLineRadarDataS
 
     private boolean mDrawCircleHole = true;
 
+    private float mCircleHoleRatio = 0.5f;
+
     /**
      * Constructor for creating a LineDataSet with realm data.
      *
@@ -310,6 +312,20 @@ public class RealmLineDataSet<T extends RealmObject> extends RealmLineRadarDataS
     @Override
     public boolean isDrawCircleHoleEnabled() {
         return mDrawCircleHole;
+    }
+
+    /**
+     * Sets the ratio between the inner and outer circle.
+     *
+     * @param ratio
+     */
+    public void setCircleHoleRatio(float ratio) {
+        mCircleHoleRatio = ratio;
+    }
+
+    @Override
+    public float getCircleHoleRatio() {
+        return mCircleHoleRatio;
     }
 
     /**

--- a/MPChartLib/src/com/github/mikephil/charting/interfaces/datasets/ILineDataSet.java
+++ b/MPChartLib/src/com/github/mikephil/charting/interfaces/datasets/ILineDataSet.java
@@ -62,6 +62,13 @@ public interface ILineDataSet extends ILineRadarDataSet<Entry> {
     boolean isDrawCircleHoleEnabled();
 
     /**
+     * Returns the ratio of the inner circle (the circle-hole) to the outer circle.
+     *
+     * @return
+     */
+    float getCircleHoleRatio();
+
+    /**
      * Returns the DashPathEffect that is used for drawing the lines.
      *
      * @return

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/LineChartRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/LineChartRenderer.java
@@ -518,7 +518,7 @@ public class LineChartRenderer extends LineRadarRenderer {
 
             trans.pointValuesToPixel(buffer.buffer);
 
-            float halfsize = dataSet.getCircleRadius() / 2f;
+            float circleHoleSize = dataSet.getCircleRadius() * dataSet.getCircleHoleRatio();
 
             for (int j = 0, count = (int) Math.ceil((maxx - minx) * phaseX + minx) * 2; j < count; j += 2) {
 
@@ -543,7 +543,7 @@ public class LineChartRenderer extends LineRadarRenderer {
                 if (dataSet.isDrawCircleHoleEnabled()
                         && circleColor != mCirclePaintInner.getColor())
                     c.drawCircle(x, y,
-                            halfsize,
+                            circleHoleSize,
                             mCirclePaintInner);
             }
         }


### PR DESCRIPTION
This patch changes the line chart circle holes so the ratio between the inner and outer hole is configurable instead of set to a constant half size as before.