### PR TITLE
Attempt to fix issue #1622

### DIFF
--- a/MPChartLib/src/com/github/mikephil/charting/charts/PieChart.java
+++ b/MPChartLib/src/com/github/mikephil/charting/charts/PieChart.java
@@ -161,8 +161,7 @@ public class PieChart extends PieRadarChartBase<PieData> {
 
     @Override
     protected void calcMinMax() {
-        super.calcMinMax();
-
+        
         calcAngles();
     }
 


### PR DESCRIPTION
Remove call to super.calcMinMax() in PieChart.

In the PieChart, the method:

 protected void calcMinMax() {
       super.calcMinMax();

        calcAngles();
    }
Calls the parent's method, which is in PieRadarChartBase:

    protected void calcMinMax() {
        mXAxis.mAxisRange = mData.getXVals().size() - 1;
    }

This gives an error, because in the init section of the PieChart, mAxis is set to null.
My proposed fix would be to remove the call to the parent's calcMinMax method, but I am not deep enough into the framework to decide if that's a good idea.