### PR TITLE
potential solution to rare out of memory problems

### DIFF
--- a/MPChartLib/src/com/github/mikephil/charting/renderer/LineChartRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/LineChartRenderer.java
@@ -736,6 +736,5 @@ public class LineChartRenderer extends LineRadarRenderer {
             mDrawBitmap.clear();
             mDrawBitmap = null;
         }
-        System.gc();
     }
 }

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/LineChartRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/LineChartRenderer.java
@@ -727,10 +727,15 @@ public class LineChartRenderer extends LineRadarRenderer {
      * Releases the drawing bitmap. This should be called when {@link LineChart#onDetachedFromWindow()}.
      */
     public void releaseBitmap() {
+        if (mBitmapCanvas != null) {
+            mBitmapCanvas.setBitmap(null);
+            mBitmapCanvas = null;
+        }
         if (mDrawBitmap != null) {
             mDrawBitmap.get().recycle();
             mDrawBitmap.clear();
             mDrawBitmap = null;
         }
+        System.gc();
     }
 }

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/PieChartRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/PieChartRenderer.java
@@ -919,10 +919,15 @@ public class PieChartRenderer extends DataRenderer {
      * Releases the drawing bitmap. This should be called when {@link LineChart#onDetachedFromWindow()}.
      */
     public void releaseBitmap() {
+        if (mBitmapCanvas != null) {
+            mBitmapCanvas.setBitmap(null);
+            mBitmapCanvas = null;
+        }
         if (mDrawBitmap != null) {
             mDrawBitmap.get().recycle();
             mDrawBitmap.clear();
             mDrawBitmap = null;
         }
+        System.gc();
     }
 }

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/PieChartRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/PieChartRenderer.java
@@ -928,6 +928,5 @@ public class PieChartRenderer extends DataRenderer {
             mDrawBitmap.clear();
             mDrawBitmap = null;
         }
-        System.gc();
     }
 }


### PR DESCRIPTION
The test were performed by manually opening and closing line chart (or pie chart) as fast as possible in a loop

Results before changes:

![before_changes](https://cloud.githubusercontent.com/assets/5712784/14510746/58dd7736-01d3-11e6-8e3d-90c2f8de0fd4.png)

Results after changes:

![after_changes](https://cloud.githubusercontent.com/assets/5712784/14510788/9007ffc4-01d3-11e6-8953-59f5b2f69fb0.png)


I don't know which code change contributed more, setting canvas to null or calling gc