### PR TITLE
How to hide labels of pie part if its value is 0 #1692

### DIFF
--- a/MPChartLib/src/com/github/mikephil/charting/charts/PieChart.java
+++ b/MPChartLib/src/com/github/mikephil/charting/charts/PieChart.java
@@ -1,4 +1,5 @@
 
+
 package com.github.mikephil.charting.charts;
 
 import android.content.Context;
@@ -93,6 +94,8 @@ public class PieChart extends PieRadarChartBase<PieData> {
 
     protected float mMaxAngle = 360f;
 
+    private boolean mDrawEmptyXLabel = true;
+
     public PieChart(Context context) {
         super(context);
     }
@@ -126,7 +129,7 @@ public class PieChart extends PieRadarChartBase<PieData> {
             mRenderer.drawHighlighted(canvas, mIndicesToHighlight);
 
         mRenderer.drawExtras(canvas);
-
+        //draw the values on the center of PieChart
         mRenderer.drawValues(canvas);
 
         mLegendRenderer.renderLegend(canvas);
@@ -161,7 +164,7 @@ public class PieChart extends PieRadarChartBase<PieData> {
 
     @Override
     protected void calcMinMax() {
-        
+
         calcAngles();
     }
 
@@ -654,4 +657,21 @@ public class PieChart extends PieRadarChartBase<PieData> {
         super.onDetachedFromWindow();
     }
 
+    /**
+     * Returns true if to draw the x-value text with value equals 0 .
+     *
+     * @return
+     */
+    public boolean isDrawEmptyXLabel() {
+        return mDrawEmptyXLabel;
+    }
+
+    /**
+     * set this to fase to dont draw the x-value text into the pie slices when value equals 0
+     *
+     * @param enabled
+     */
+    public void setDrawEmptyXLabel(boolean enabled) {
+        this.mDrawEmptyXLabel = enabled;
+    }
 }

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/PieChartRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/PieChartRenderer.java
@@ -14,6 +14,7 @@ import android.os.Build;
 import android.text.Layout;
 import android.text.StaticLayout;
 import android.text.TextPaint;
+import android.util.Log;
 
 import com.github.mikephil.charting.animation.ChartAnimator;
 import com.github.mikephil.charting.charts.LineChart;
@@ -353,8 +354,9 @@ public class PieChartRenderer extends DataRenderer {
 
     @Override
     public void drawValues(Canvas c) {
-
         PointF center = mChart.getCenterCircleBox();
+
+        boolean isDrawEmptyXLabel = mChart.isDrawEmptyXLabel();
 
         // get whole the radius
         float radius = mChart.getRadius();
@@ -465,9 +467,9 @@ public class PieChartRenderer extends DataRenderer {
                         line1Radius = radius * valueLinePart1OffsetPercentage;
 
                     final float polyline2Width = dataSet.isValueLineVariableLength()
-                        ? labelRadius * valueLineLength2 * (float)Math.abs(Math.sin(
+                            ? labelRadius * valueLineLength2 * (float)Math.abs(Math.sin(
                             transformedAngle * Utils.FDEG2RAD))
-                        : labelRadius * valueLineLength2;
+                            : labelRadius * valueLineLength2;
 
                     final float pt0x = line1Radius * sliceXBase + center.x;
                     final float pt0y = line1Radius * sliceYBase + center.y;
@@ -490,35 +492,74 @@ public class PieChartRenderer extends DataRenderer {
                     }
 
                     if (dataSet.getValueLineColor() != ColorTemplate.COLOR_NONE) {
-                        c.drawLine(pt0x, pt0y, pt1x, pt1y, mValueLinePaint);
-                        c.drawLine(pt1x, pt1y, pt2x, pt2y, mValueLinePaint);
+                        if(isDrawEmptyXLabel) {
+                            c.drawLine(pt0x, pt0y, pt1x, pt1y, mValueLinePaint);
+                            c.drawLine(pt1x, pt1y, pt2x, pt2y, mValueLinePaint);
+                        }else{
+                            if(entry.getVal() != 0.0){
+                                c.drawLine(pt0x, pt0y, pt1x, pt1y, mValueLinePaint);
+                                c.drawLine(pt1x, pt1y, pt2x, pt2y, mValueLinePaint);
+                            }
+                        }
                     }
 
                     // draw everything, depending on settings
                     if (drawXOutside && drawYOutside) {
+                        if(isDrawEmptyXLabel){
+                            drawValue(c,
+                                    formatter,
+                                    value,
+                                    entry,
+                                    0,
+                                    labelPtx,
+                                    labelPty,
+                                    dataSet.getValueTextColor(j));
 
-                        drawValue(c,
-                                formatter,
-                                value,
-                                entry,
-                                0,
-                                labelPtx,
-                                labelPty,
-                                dataSet.getValueTextColor(j));
+                            if (j < data.getXValCount()) {
+                                c.drawText(data.getXVals().get(j), labelPtx, labelPty + lineHeight,
+                                        mValuePaint);
+                            }
+                        }else{
+                            if(entry.getVal() != 0.0 ) {
+                                drawValue(c,
+                                        formatter,
+                                        value,
+                                        entry,
+                                        0,
+                                        labelPtx,
+                                        labelPty,
+                                        dataSet.getValueTextColor(j));
 
-                        if (j < data.getXValCount()) {
-                            c.drawText(data.getXVals().get(j), labelPtx, labelPty + lineHeight,
-                                    mValuePaint);
+                                if (j < data.getXValCount()) {
+                                    c.drawText(data.getXVals().get(j), labelPtx, labelPty + lineHeight,
+                                            mValuePaint);
+                                }
+                            }
                         }
+
 
                     } else if (drawXOutside) {
-                        if (j < data.getXValCount()) {
-                            mValuePaint.setColor(dataSet.getValueTextColor(j));
-                            c.drawText(data.getXVals().get(j), labelPtx, labelPty + lineHeight / 2.f, mValuePaint);
+                        if(isDrawEmptyXLabel) {
+                            if (j < data.getXValCount()) {
+                                mValuePaint.setColor(dataSet.getValueTextColor(j));
+                                c.drawText(data.getXVals().get(j), labelPtx, labelPty + lineHeight / 2.f, mValuePaint);
+                            }
+                        }else{
+                            if(entry.getVal() != 0.0){
+                                if (j < data.getXValCount()) {
+                                    mValuePaint.setColor(dataSet.getValueTextColor(j));
+                                    c.drawText(data.getXVals().get(j), labelPtx, labelPty + lineHeight / 2.f, mValuePaint);
+                                }
+                            }
                         }
                     } else if (drawYOutside) {
-
-                        drawValue(c, formatter, value, entry, 0, labelPtx, labelPty + lineHeight / 2.f, dataSet.getValueTextColor(j));
+                        if(isDrawEmptyXLabel) {
+                            drawValue(c, formatter, value, entry, 0, labelPtx, labelPty + lineHeight / 2.f, dataSet.getValueTextColor(j));
+                        }else{
+                            if(entry.getVal() != 0.0){
+                                drawValue(c, formatter, value, entry, 0, labelPtx, labelPty + lineHeight / 2.f, dataSet.getValueTextColor(j));
+                            }
+                        }
                     }
                 }
 
@@ -531,22 +572,46 @@ public class PieChartRenderer extends DataRenderer {
 
                     // draw everything, depending on settings
                     if (drawXInside && drawYInside) {
+                        if(isDrawEmptyXLabel) {
+                            drawValue(c, formatter, value, entry, 0, x, y, dataSet.getValueTextColor(j));
 
-                        drawValue(c, formatter, value, entry, 0, x, y, dataSet.getValueTextColor(j));
+                            if (j < data.getXValCount()) {
+                                c.drawText(data.getXVals().get(j), x, y + lineHeight,
+                                        mValuePaint);
+                            }
+                        }else{
+                            if(entry.getVal() != 0.0){
+                                drawValue(c, formatter, value, entry, 0, x, y, dataSet.getValueTextColor(j));
 
-                        if (j < data.getXValCount()) {
-                            c.drawText(data.getXVals().get(j), x, y + lineHeight,
-                                    mValuePaint);
+                                if (j < data.getXValCount()) {
+                                    c.drawText(data.getXVals().get(j), x, y + lineHeight,
+                                            mValuePaint);
+                                }
+                            }
                         }
 
                     } else if (drawXInside) {
-                        if (j < data.getXValCount()) {
-                            mValuePaint.setColor(dataSet.getValueTextColor(j));
-                            c.drawText(data.getXVals().get(j), x, y + lineHeight / 2f, mValuePaint);
+                        if(isDrawEmptyXLabel) {
+                            if (j < data.getXValCount()) {
+                                mValuePaint.setColor(dataSet.getValueTextColor(j));
+                                c.drawText(data.getXVals().get(j), x, y + lineHeight / 2f, mValuePaint);
+                            }
+                        }else{
+                            if(entry.getVal() != 0.0){
+                                if (j < data.getXValCount()) {
+                                    mValuePaint.setColor(dataSet.getValueTextColor(j));
+                                    c.drawText(data.getXVals().get(j), x, y + lineHeight / 2f, mValuePaint);
+                                }
+                            }
                         }
                     } else if (drawYInside) {
-
-                        drawValue(c, formatter, value, entry, 0, x, y + lineHeight / 2f, dataSet.getValueTextColor(j));
+                        if(isDrawEmptyXLabel) {
+                            drawValue(c, formatter, value, entry, 0, x, y + lineHeight / 2f, dataSet.getValueTextColor(j));
+                        }else{
+                            if(entry.getVal() != 0.0){
+                                drawValue(c, formatter, value, entry, 0, x, y + lineHeight / 2f, dataSet.getValueTextColor(j));
+                            }
+                        }
                     }
                 }
 
@@ -756,7 +821,7 @@ public class PieChartRenderer extends DataRenderer {
             }
 
             mPathBuffer.reset();
-            
+
             if (sweepAngleOuter % 360f == 0.f) {
                 // Android is doing "mod 360"
                 mPathBuffer.addCircle(center.x, center.y, highlightedRadius, Path.Direction.CW);

--- a/MPChartLib/src/com/github/mikephil/charting/utils/Utils.java
+++ b/MPChartLib/src/com/github/mikephil/charting/utils/Utils.java
@@ -547,6 +547,7 @@ public abstract class Utils {
         // Android sometimes has pre-padding
         drawOffsetX -= mDrawTextRectBuffer.left;
 
+
         // Android does not snap the bounds to line boundaries,
         //  and draws from bottom to top.
         // And we want to normalize it.

--- a/MPChartLib/src/com/github/mikephil/charting/utils/Utils.java
+++ b/MPChartLib/src/com/github/mikephil/charting/utils/Utils.java
@@ -532,7 +532,7 @@ public abstract class Utils {
 
     private static Rect mDrawTextRectBuffer = new Rect();
     private static Paint.FontMetrics mFontMetricsBuffer = new Paint.FontMetrics();
-    private static float mLineHeight = 9999.0f;
+    private static float mLineHeight = 0.0f;
 
     public static void drawText(Canvas c, String text, float x, float y,
                                 Paint paint,
@@ -543,11 +543,15 @@ public abstract class Utils {
 
         paint.getTextBounds(text, 0, text.length(), mDrawTextRectBuffer);
 
-        if(mDrawTextRectBuffer.height() < mLineHeight){
+        //the method paint.getTextBounds return different values height for letter.
+        //so we need get only one lineHeight for textAlign
+        if(mDrawTextRectBuffer.height() > mLineHeight){
             mLineHeight = mDrawTextRectBuffer.height();
         }
-        final float lineHeight = mLineHeight;
 
+        mLineHeight = mDrawTextRectBuffer.bottom + mLineHeight / 2;
+
+        final float lineHeight = mLineHeight;
         // Android sometimes has pre-padding
         drawOffsetX -= mDrawTextRectBuffer.left;
 

--- a/MPChartLib/src/com/github/mikephil/charting/utils/Utils.java
+++ b/MPChartLib/src/com/github/mikephil/charting/utils/Utils.java
@@ -547,7 +547,6 @@ public abstract class Utils {
         // Android sometimes has pre-padding
         drawOffsetX -= mDrawTextRectBuffer.left;
 
-
         // Android does not snap the bounds to line boundaries,
         //  and draws from bottom to top.
         // And we want to normalize it.


### PR DESCRIPTION
Hi Phil and Daniel. Based on a request from a user (#1692), I made a change in the pie chart to show no label with value 0. 
In this picture, you can be see that problem:

<img width="393" alt="img" src="https://cloud.githubusercontent.com/assets/10009422/14718614/1901b0d6-07ce-11e6-9ad4-eb9bf9f419da.png">

My modification allows the user to choose withdraw from the graph the values 0 but keep them in the legend. This change also includes the Pie Chart with value lines

Thus, the user can choose whether he wants to or not show on the chart a value 0. I would like to hear from you about this change?