### PR TITLE
Fix/axis width

### DIFF
--- a/MPChartLib/src/com/github/mikephil/charting/charts/BarLineChartBase.java
+++ b/MPChartLib/src/com/github/mikephil/charting/charts/BarLineChartBase.java
@@ -15,8 +15,6 @@ import android.util.AttributeSet;
 import android.util.Log;
 import android.view.MotionEvent;
 
-import com.github.mikephil.charting.components.Legend;
-import com.github.mikephil.charting.components.Legend.LegendPosition;
 import com.github.mikephil.charting.components.XAxis.XAxisPosition;
 import com.github.mikephil.charting.components.YAxis;
 import com.github.mikephil.charting.components.YAxis.AxisDependency;
@@ -201,15 +199,6 @@ public abstract class BarLineChartBase<T extends BarLineScatterCandleBubbleData<
         // execute all drawing commands
         drawGridBackground(canvas);
 
-        if (mAxisLeft.isEnabled())
-            mAxisRendererLeft.computeAxis(mAxisLeft.mAxisMinimum, mAxisLeft.mAxisMaximum);
-        if (mAxisRight.isEnabled())
-            mAxisRendererRight.computeAxis(mAxisRight.mAxisMinimum, mAxisRight.mAxisMaximum);
-
-        mXAxisRenderer.renderAxisLine(canvas);
-        mAxisRendererLeft.renderAxisLine(canvas);
-        mAxisRendererRight.renderAxisLine(canvas);
-
         if (mAutoScaleMinMaxEnabled) {
             final int lowestVisibleXIndex = getLowestVisibleXIndex();
             final int highestVisibleXIndex = getHighestVisibleXIndex();
@@ -255,6 +244,16 @@ public abstract class BarLineChartBase<T extends BarLineScatterCandleBubbleData<
         canvas.restoreToCount(clipRestoreCount);
 
         mRenderer.drawExtras(canvas);
+
+        if (mAxisLeft.isEnabled())
+            mAxisRendererLeft.computeAxis(mAxisLeft.mAxisMinimum, mAxisLeft.mAxisMaximum);
+
+        if (mAxisRight.isEnabled())
+            mAxisRendererRight.computeAxis(mAxisRight.mAxisMinimum, mAxisRight.mAxisMaximum);
+
+        mXAxisRenderer.renderAxisLine(canvas);
+        mAxisRendererLeft.renderAxisLine(canvas);
+        mAxisRendererRight.renderAxisLine(canvas);
 
         if (!mXAxis.isDrawLimitLinesBehindDataEnabled())
             mXAxisRenderer.renderLimitLines(canvas);

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/XAxisRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/XAxisRenderer.java
@@ -119,23 +119,23 @@ public class XAxisRenderer extends AxisRenderer {
         if (!mXAxis.isDrawAxisLineEnabled() || !mXAxis.isEnabled())
             return;
 
+        float axisLineWidth = mXAxis.getAxisLineWidth();
+
         mAxisLinePaint.setColor(mXAxis.getAxisLineColor());
-        mAxisLinePaint.setStrokeWidth(mXAxis.getAxisLineWidth());
+        mAxisLinePaint.setStrokeWidth(axisLineWidth);
 
         if (mXAxis.getPosition() == XAxisPosition.TOP
                 || mXAxis.getPosition() == XAxisPosition.TOP_INSIDE
                 || mXAxis.getPosition() == XAxisPosition.BOTH_SIDED) {
-            c.drawLine(mViewPortHandler.contentLeft(),
-                    mViewPortHandler.contentTop(), mViewPortHandler.contentRight(),
-                    mViewPortHandler.contentTop(), mAxisLinePaint);
+            c.drawLine(mViewPortHandler.contentLeft(), mViewPortHandler.contentTop() + axisLineWidth / 2,
+                    mViewPortHandler.contentRight(), mViewPortHandler.contentTop() + axisLineWidth / 2, mAxisLinePaint);
         }
 
         if (mXAxis.getPosition() == XAxisPosition.BOTTOM
                 || mXAxis.getPosition() == XAxisPosition.BOTTOM_INSIDE
                 || mXAxis.getPosition() == XAxisPosition.BOTH_SIDED) {
-            c.drawLine(mViewPortHandler.contentLeft(),
-                    mViewPortHandler.contentBottom(), mViewPortHandler.contentRight(),
-                    mViewPortHandler.contentBottom(), mAxisLinePaint);
+            c.drawLine(mViewPortHandler.contentLeft(), mViewPortHandler.contentBottom() - axisLineWidth / 2,
+                    mViewPortHandler.contentRight(), mViewPortHandler.contentBottom() - axisLineWidth / 2, mAxisLinePaint);
         }
     }
 

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/XAxisRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/XAxisRenderer.java
@@ -127,15 +127,15 @@ public class XAxisRenderer extends AxisRenderer {
         if (mXAxis.getPosition() == XAxisPosition.TOP
                 || mXAxis.getPosition() == XAxisPosition.TOP_INSIDE
                 || mXAxis.getPosition() == XAxisPosition.BOTH_SIDED) {
-            c.drawLine(mViewPortHandler.contentLeft(), mViewPortHandler.contentTop() + axisLineWidth / 2,
-                    mViewPortHandler.contentRight(), mViewPortHandler.contentTop() + axisLineWidth / 2, mAxisLinePaint);
+            c.drawLine(mViewPortHandler.contentLeft(), mViewPortHandler.contentTop() - axisLineWidth / 2,
+                    mViewPortHandler.contentRight(), mViewPortHandler.contentTop() - axisLineWidth / 2, mAxisLinePaint);
         }
 
         if (mXAxis.getPosition() == XAxisPosition.BOTTOM
                 || mXAxis.getPosition() == XAxisPosition.BOTTOM_INSIDE
                 || mXAxis.getPosition() == XAxisPosition.BOTH_SIDED) {
-            c.drawLine(mViewPortHandler.contentLeft(), mViewPortHandler.contentBottom() - axisLineWidth / 2,
-                    mViewPortHandler.contentRight(), mViewPortHandler.contentBottom() - axisLineWidth / 2, mAxisLinePaint);
+            c.drawLine(mViewPortHandler.contentLeft(), mViewPortHandler.contentBottom() + axisLineWidth / 2,
+                    mViewPortHandler.contentRight(), mViewPortHandler.contentBottom() + axisLineWidth / 2, mAxisLinePaint);
         }
     }
 

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/YAxisRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/YAxisRenderer.java
@@ -233,15 +233,17 @@ public class YAxisRenderer extends AxisRenderer {
         if (!mYAxis.isEnabled() || !mYAxis.isDrawAxisLineEnabled())
             return;
 
+        float axisLineWidth = mYAxis.getAxisLineWidth();
+
         mAxisLinePaint.setColor(mYAxis.getAxisLineColor());
-        mAxisLinePaint.setStrokeWidth(mYAxis.getAxisLineWidth());
+        mAxisLinePaint.setStrokeWidth(axisLineWidth);
 
         if (mYAxis.getAxisDependency() == AxisDependency.LEFT) {
-            c.drawLine(mViewPortHandler.contentLeft(), mViewPortHandler.contentTop(), mViewPortHandler.contentLeft(),
-                    mViewPortHandler.contentBottom(), mAxisLinePaint);
+            c.drawLine(mViewPortHandler.contentLeft() + axisLineWidth / 2, mViewPortHandler.contentTop(),
+                    mViewPortHandler.contentLeft() + axisLineWidth / 2, mViewPortHandler.contentBottom(), mAxisLinePaint);
         } else {
-            c.drawLine(mViewPortHandler.contentRight(), mViewPortHandler.contentTop(), mViewPortHandler.contentRight(),
-                    mViewPortHandler.contentBottom(), mAxisLinePaint);
+            c.drawLine(mViewPortHandler.contentRight() - axisLineWidth / 2, mViewPortHandler.contentTop(),
+                    mViewPortHandler.contentRight() - axisLineWidth / 2, mViewPortHandler.contentBottom(), mAxisLinePaint);
         }
     }
 


### PR DESCRIPTION
Hi @PhilJay,

I came across another issue while increasing the axis width in a bar chart. It appears that the width was not taken into consideration while drawing the axis, hence leading to the bar entries drawn on top of them.

Plus I found that the entries were drawn after the axis, leading also to an overlap while dragging/scaling the chart. I inverted the order without giving a parameter that lets the user to choose whether it should overlap or not. I thought it would not be a wanted feature but I don't want to break the spirit of this library either so let me know what you would found better.

Finally, I am attaching a screenshot illustrating both the badly drawn axis (with a bigger width) and the bar on top of the Y axis (for a non-horizontal bar chart). There is another screenshot showing the result from the fix.

Cheers,
Stephen

![after_fix](https://cloud.githubusercontent.com/assets/14751184/15145824/3d9729be-16b8-11e6-8f24-9491c1101ca1.png)
![before_fix](https://cloud.githubusercontent.com/assets/14751184/15145825/3d984c0e-16b8-11e6-8a71-95f36c4fe3a2.png)

