### PR TITLE
Add possibility to draw arrow heads to each axis extremities

### DIFF
--- a/MPChartLib/src/com/github/mikephil/charting/components/AxisBase.java
+++ b/MPChartLib/src/com/github/mikephil/charting/components/AxisBase.java
@@ -41,6 +41,21 @@ public abstract class AxisBase extends ComponentBase {
     protected boolean mDrawLabels = true;
 
     /**
+     * flag that indicates of the negative arrow head (left or bottom) of this axis should be drawn or not
+     */
+    protected boolean mDrawNegativeArrowHead = false;
+
+    /**
+     * flag that indicates of the positive arrow head (right or top) of this axis should be drawn or not
+     */
+    protected boolean mDrawPositiveArrowHead = false;
+
+    /**
+     * flag that indicates the arrow head width
+     */
+    protected float mArrowHeadWidth = 10f;
+
+    /**
      * the path effect of the grid lines that makes dashed lines possible
      */
     private DashPathEffect mGridDashPathEffect = null;
@@ -219,6 +234,62 @@ public abstract class AxisBase extends ComponentBase {
      */
     public boolean isDrawLabelsEnabled() {
         return mDrawLabels;
+    }
+
+    /**
+     * Returns true if drawing the negative arrow head is enabled for this axis.
+     *
+     * @return
+     */
+    public boolean isDrawNegativeArrowHeadEnabled() {
+        return mDrawNegativeArrowHead;
+    }
+
+    /**
+     * Set this to true to enable drawing the negative arrow head of this axis (this will not
+     * affect drawing the grid lines or axis lines).
+     *
+     * @param enabled
+     */
+    public void setDrawNegativeArrowHead(boolean enabled) {
+        mDrawNegativeArrowHead = enabled;
+    }
+
+    /**
+     * Returns true if drawing the positive arrow head is enabled for this axis.
+     *
+     * @return
+     */
+    public boolean isDrawPositiveArrowHeadEnabled() {
+        return mDrawPositiveArrowHead;
+    }
+
+    /**
+     * Set this to true to enable drawing the positive arrow head of this axis (this will not
+     * affect drawing the grid lines or axis lines).
+     *
+     * @param enabled
+     */
+    public void setDrawPositiveArrowHead(boolean enabled) {
+        mDrawPositiveArrowHead = enabled;
+    }
+
+    /**
+     * Returns the width of the arrow head that are drawn at the axis' border
+     *
+     * @return
+     */
+    public float getArrowHeadWidth() {
+        return mArrowHeadWidth;
+    }
+
+    /**
+     * Sets the width of the arrow head surrounding the axis in dp.
+     *
+     * @param width
+     */
+    public void setArrowHeadWidth(float width) {
+        mArrowHeadWidth = Utils.convertDpToPixel(width);
     }
 
     /**

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/XAxisRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/XAxisRenderer.java
@@ -119,24 +119,60 @@ public class XAxisRenderer extends AxisRenderer {
         if (!mXAxis.isDrawAxisLineEnabled() || !mXAxis.isEnabled())
             return;
 
+        float axisLineWidth = mXAxis.getAxisLineWidth();
+
         mAxisLinePaint.setColor(mXAxis.getAxisLineColor());
-        mAxisLinePaint.setStrokeWidth(mXAxis.getAxisLineWidth());
+        mAxisLinePaint.setStrokeWidth(axisLineWidth);
 
         if (mXAxis.getPosition() == XAxisPosition.TOP
                 || mXAxis.getPosition() == XAxisPosition.TOP_INSIDE
                 || mXAxis.getPosition() == XAxisPosition.BOTH_SIDED) {
-            c.drawLine(mViewPortHandler.contentLeft(),
-                    mViewPortHandler.contentTop(), mViewPortHandler.contentRight(),
-                    mViewPortHandler.contentTop(), mAxisLinePaint);
+            drawAxisLine(c, mViewPortHandler.contentLeft(), mViewPortHandler.contentRight(), mViewPortHandler.contentTop() - axisLineWidth / 2);
         }
 
         if (mXAxis.getPosition() == XAxisPosition.BOTTOM
                 || mXAxis.getPosition() == XAxisPosition.BOTTOM_INSIDE
                 || mXAxis.getPosition() == XAxisPosition.BOTH_SIDED) {
-            c.drawLine(mViewPortHandler.contentLeft(),
-                    mViewPortHandler.contentBottom(), mViewPortHandler.contentRight(),
-                    mViewPortHandler.contentBottom(), mAxisLinePaint);
+            drawAxisLine(c, mViewPortHandler.contentLeft(), mViewPortHandler.contentRight(), mViewPortHandler.contentBottom() + axisLineWidth / 2);
         }
+    }
+
+    /**
+     * Draw the axis line and its arrow heads if required
+     *
+     * @param c c The canvas where the arrow head will be drawn
+     * @param x1 The start x position
+     * @param x2 The final x position
+     * @param y The y position
+     */
+    protected void drawAxisLine(Canvas c, float x1, float x2, float y) {
+        c.drawLine(x1, y, x2, y, mAxisLinePaint);
+
+        float arrowHeadWidth = mXAxis.getArrowHeadWidth();
+
+        if (mXAxis.isDrawNegativeArrowHeadEnabled())
+            drawArrowHead(c, x1, x1 + arrowHeadWidth, y, arrowHeadWidth);
+
+        if (mXAxis.isDrawPositiveArrowHeadEnabled())
+            drawArrowHead(c, x2, x2 - arrowHeadWidth, y, arrowHeadWidth);
+    }
+
+    /**
+     * Draw the arrow head to the appropriate position
+     *
+     * @param c The canvas where the arrow head will be drawn
+     * @param x1 The start x position
+     * @param x2 The final x position
+     * @param y The y position
+     * @param arrowHeadWidth The width of the arrow head
+     */
+    protected void drawArrowHead(Canvas c, float x1, float x2, float y, float arrowHeadWidth) {
+        Path path = new Path();
+        path.moveTo(x2, y - arrowHeadWidth);
+        path.lineTo(x1, y);
+        path.lineTo(x2, y + arrowHeadWidth);
+
+        c.drawPath(path, mAxisLinePaint);
     }
 
     /**

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/YAxisRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/YAxisRenderer.java
@@ -233,16 +233,54 @@ public class YAxisRenderer extends AxisRenderer {
         if (!mYAxis.isEnabled() || !mYAxis.isDrawAxisLineEnabled())
             return;
 
+        float axisLineWidth = mYAxis.getAxisLineWidth();
+
         mAxisLinePaint.setColor(mYAxis.getAxisLineColor());
-        mAxisLinePaint.setStrokeWidth(mYAxis.getAxisLineWidth());
+        mAxisLinePaint.setStrokeWidth(axisLineWidth);
 
         if (mYAxis.getAxisDependency() == AxisDependency.LEFT) {
-            c.drawLine(mViewPortHandler.contentLeft(), mViewPortHandler.contentTop(), mViewPortHandler.contentLeft(),
-                    mViewPortHandler.contentBottom(), mAxisLinePaint);
+            drawAxisLine(c, mViewPortHandler.contentLeft() + axisLineWidth / 2, mViewPortHandler.contentTop(), mViewPortHandler.contentBottom());
         } else {
-            c.drawLine(mViewPortHandler.contentRight(), mViewPortHandler.contentTop(), mViewPortHandler.contentRight(),
-                    mViewPortHandler.contentBottom(), mAxisLinePaint);
+            drawAxisLine(c, mViewPortHandler.contentRight() - axisLineWidth / 2, mViewPortHandler.contentTop(), mViewPortHandler.contentBottom());
         }
+    }
+
+    /**
+     * Draw the axis line and its arrow heads if required
+     *
+     * @param c c The canvas where the arrow head will be drawn
+     * @param x The y position
+     * @param y1 The start y position
+     * @param y2 The final y position
+     */
+    protected void drawAxisLine(Canvas c, float x, float y1, float y2) {
+        c.drawLine(x, y1, x, y2, mAxisLinePaint);
+
+        float arrowHeadWidth = mYAxis.getArrowHeadWidth();
+
+        if (mYAxis.isDrawNegativeArrowHeadEnabled())
+            drawArrowHead(c, x, y1, y1 + arrowHeadWidth, arrowHeadWidth);
+
+        if (mYAxis.isDrawPositiveArrowHeadEnabled())
+            drawArrowHead(c, x, y2, y2 - arrowHeadWidth, arrowHeadWidth);
+    }
+
+    /**
+     * Draw the arrow head to the appropriate position
+     *
+     * @param c The canvas where the arrow head will be drawn
+     * @param x The y position
+     * @param y1 The start y position
+     * @param y2 The final y position
+     * @param arrowHeadWidth The width of the arrow head
+     */
+    protected void drawArrowHead(Canvas c, float x, float y1, float y2, float arrowHeadWidth) {
+        Path path = new Path();
+        path.moveTo(x - arrowHeadWidth, y2);
+        path.lineTo(x, y1);
+        path.lineTo(x + arrowHeadWidth, y2);
+
+        c.drawPath(path, mAxisLinePaint);
     }
 
     /**

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/YAxisRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/YAxisRenderer.java
@@ -259,10 +259,10 @@ public class YAxisRenderer extends AxisRenderer {
         float arrowHeadWidth = mYAxis.getArrowHeadWidth();
 
         if (mYAxis.isDrawNegativeArrowHeadEnabled())
-            drawArrowHead(c, x, y1, y1 + arrowHeadWidth, arrowHeadWidth);
+            drawArrowHead(c, x, y2, y2 - arrowHeadWidth, arrowHeadWidth);
 
         if (mYAxis.isDrawPositiveArrowHeadEnabled())
-            drawArrowHead(c, x, y2, y2 - arrowHeadWidth, arrowHeadWidth);
+            drawArrowHead(c, x, y1, y1 + arrowHeadWidth, arrowHeadWidth);
     }
 
     /**


### PR DESCRIPTION
Hi again @PhilJay,

Feeling in a contributing mood today :)

I just finished developing a possibility to draw arrow heads at each axis extremities. I have a requirement to draw an axis with an arrow head at its extremity so I thought other people might be in the same situation ;)

This is disabled by default and is bound to the axis attributes (color and size) and can be enabled for each extremity independently with a specified width.

Please note that it takes care of the axis width meaning it will conflict with my previous [Pull Request](https://github.com/PhilJay/MPAndroidChart/pull/1757) as I redeveloped how the axis is drawn with this fixed (so that this feature is not broken due to axis width). I haven't redeveloped the overlapping issue fix from the mentionned PR to keep things separate for you to review it.

So there will be conflicts if you decide to merge my previous PR before this one so let me know first if this is a wanted feature and when you're okay to merge my first PR so that I can resolve the conflicts to have a clean branch.

As before, a screenshot showing the results (note that I enabled all arrow heads which leads to ugly axes but it's just for show ^^).

Cheers,
Stephen

![arrowheads](https://cloud.githubusercontent.com/assets/14751184/15151677/7826abee-16d2-11e6-867a-968c0754b250.png)
