### PR TITLE
Fix invalid default y position of the markerview

### DIFF
--- a/MPChartLib/src/com/github/mikephil/charting/charts/Chart.java
+++ b/MPChartLib/src/com/github/mikephil/charting/charts/Chart.java
@@ -716,12 +716,7 @@ public abstract class Chart<T extends ChartData<? extends IDataSet<? extends Ent
                 mMarkerView.layout(0, 0, mMarkerView.getMeasuredWidth(),
                         mMarkerView.getMeasuredHeight());
 
-                if (pos[1] - mMarkerView.getHeight() <= 0) {
-                    float y = mMarkerView.getHeight() - pos[1];
-                    mMarkerView.draw(canvas, pos[0], pos[1] + y);
-                } else {
-                    mMarkerView.draw(canvas, pos[0], pos[1]);
-                }
+                mMarkerView.draw(canvas, pos[0], pos[1]);
             }
         }
     }


### PR DESCRIPTION
If the Entry(yvalue) is near the top of the chart, `posy` will be the height of the MarkerView and is NOT "drawn with it's top left edge at the position of the entry."

