### PR TITLE
Feature/legend border

### DIFF
--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/BarChartActivity.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/BarChartActivity.java
@@ -107,11 +107,12 @@ public class BarChartActivity extends DemoBase implements OnSeekBarChangeListene
 
         Legend l = mChart.getLegend();
         l.setPosition(LegendPosition.ABOVE_CHART_CENTER);
-        l.setForm(LegendForm.CIRCLE);
+        l.setForm(LegendForm.SQUARE);
         l.setFormSize(15f);
         l.setTextSize(15f);
         l.setXEntrySpace(20f);
         l.setFormBorderSize(1);
+        l.setFormRadius(2);
         // l.setExtra(ColorTemplate.VORDIPLOM_COLORS, new String[] { "abc",
         // "def", "ghj", "ikl", "mno" });
         // l.setCustom(ColorTemplate.VORDIPLOM_COLORS, new String[] { "abc",

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/BarChartActivity.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/BarChartActivity.java
@@ -106,13 +106,11 @@ public class BarChartActivity extends DemoBase implements OnSeekBarChangeListene
         rightAxis.setAxisMinValue(0f); // this replaces setStartAtZero(true)
 
         Legend l = mChart.getLegend();
-        l.setPosition(LegendPosition.ABOVE_CHART_CENTER);
+        l.setPosition(LegendPosition.BELOW_CHART_LEFT);
         l.setForm(LegendForm.SQUARE);
-        l.setFormSize(15f);
-        l.setTextSize(15f);
-        l.setXEntrySpace(20f);
-        l.setFormBorderSize(1);
-        l.setFormRadius(2);
+        l.setFormSize(9f);
+        l.setTextSize(11f);
+        l.setXEntrySpace(4f);
         // l.setExtra(ColorTemplate.VORDIPLOM_COLORS, new String[] { "abc",
         // "def", "ghj", "ikl", "mno" });
         // l.setCustom(ColorTemplate.VORDIPLOM_COLORS, new String[] { "abc",
@@ -259,7 +257,6 @@ public class BarChartActivity extends DemoBase implements OnSeekBarChangeListene
             set1 = new BarDataSet(yVals1, "DataSet");
             set1.setBarSpacePercent(35f);
             set1.setColors(ColorTemplate.MATERIAL_COLORS);
-            set1.setBorderColors(ColorTemplate.MATERIAL_COLORS_DARK);
 
             ArrayList<IBarDataSet> dataSets = new ArrayList<IBarDataSet>();
             dataSets.add(set1);

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/BarChartActivity.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/BarChartActivity.java
@@ -28,8 +28,6 @@ import com.github.mikephil.charting.data.BarData;
 import com.github.mikephil.charting.data.BarDataSet;
 import com.github.mikephil.charting.data.BarEntry;
 import com.github.mikephil.charting.data.Entry;
-import com.github.mikephil.charting.data.filter.Approximator;
-import com.github.mikephil.charting.data.filter.Approximator.ApproximatorType;
 import com.github.mikephil.charting.formatter.YAxisValueFormatter;
 import com.github.mikephil.charting.highlight.Highlight;
 import com.github.mikephil.charting.interfaces.datasets.IBarDataSet;
@@ -108,11 +106,12 @@ public class BarChartActivity extends DemoBase implements OnSeekBarChangeListene
         rightAxis.setAxisMinValue(0f); // this replaces setStartAtZero(true)
 
         Legend l = mChart.getLegend();
-        l.setPosition(LegendPosition.BELOW_CHART_LEFT);
-        l.setForm(LegendForm.SQUARE);
-        l.setFormSize(9f);
-        l.setTextSize(11f);
-        l.setXEntrySpace(4f);
+        l.setPosition(LegendPosition.ABOVE_CHART_CENTER);
+        l.setForm(LegendForm.CIRCLE);
+        l.setFormSize(15f);
+        l.setTextSize(15f);
+        l.setXEntrySpace(20f);
+        l.setFormBorderSize(1);
         // l.setExtra(ColorTemplate.VORDIPLOM_COLORS, new String[] { "abc",
         // "def", "ghj", "ikl", "mno" });
         // l.setCustom(ColorTemplate.VORDIPLOM_COLORS, new String[] { "abc",
@@ -259,6 +258,7 @@ public class BarChartActivity extends DemoBase implements OnSeekBarChangeListene
             set1 = new BarDataSet(yVals1, "DataSet");
             set1.setBarSpacePercent(35f);
             set1.setColors(ColorTemplate.MATERIAL_COLORS);
+            set1.setBorderColors(ColorTemplate.MATERIAL_COLORS_DARK);
 
             ArrayList<IBarDataSet> dataSets = new ArrayList<IBarDataSet>();
             dataSets.add(set1);

--- a/MPChartLib/src/com/github/mikephil/charting/components/Legend.java
+++ b/MPChartLib/src/com/github/mikephil/charting/components/Legend.java
@@ -60,6 +60,12 @@ public class Legend extends ComponentBase {
      */
     private int[] mColors;
 
+    /**
+     * the legend border colors array, each color is for the form's border drawn at the same
+     * index
+     */
+    private int[] mBorderColors;
+
     /** the legend text array. a null label will start a group. */
     private String[] mLabels;
 
@@ -68,6 +74,12 @@ public class Legend extends ComponentBase {
      * calculating the legend.
      */
     private int[] mExtraColors;
+
+    /**
+     * border colors that will be appended to the end of the colors array after
+     * calculating the legend.
+     */
+    private int[] mExtraBorderColors;
 
     /**
      * labels that will be appended to the end of the labels array after
@@ -94,6 +106,12 @@ public class Legend extends ComponentBase {
 
     /** the size of the legend forms/shapes */
     private float mFormSize = 8f;
+
+    /** the size of the legend forms/shapes' border */
+    private int mFormBorderColor;
+
+    /** the size of the legend forms/shapes' border */
+    private float mFormBorderSize = 0f;
 
     /**
      * the space between the legend entries on a horizontal axis, default 6f
@@ -138,6 +156,17 @@ public class Legend extends ComponentBase {
      * @param labels
      */
     public Legend(int[] colors, String[] labels) {
+        this(colors, null, labels);
+    }
+
+    /**
+     * Constructor. Provide colors, border colors and labels for the legend.
+     *
+     * @param colors
+     * @param borderColors
+     * @param labels
+     */
+    public Legend(int[] colors, int[] borderColors, String[] labels) {
         this();
 
         if (colors == null || labels == null) {
@@ -150,6 +179,7 @@ public class Legend extends ComponentBase {
         }
 
         this.mColors = colors;
+        this.mBorderColors = borderColors;
         this.mLabels = labels;
     }
 
@@ -160,6 +190,17 @@ public class Legend extends ComponentBase {
      * @param labels
      */
     public Legend(List<Integer> colors, List<String> labels) {
+        this(colors, null, labels);
+    }
+
+    /**
+     * Constructor. Provide colors, border colors and labels for the legend.
+     *
+     * @param colors
+     * @param borderColors
+     * @param labels
+     */
+    public Legend(List<Integer> colors, List<Integer> borderColors, List<String> labels) {
         this();
 
         if (colors == null || labels == null) {
@@ -172,6 +213,7 @@ public class Legend extends ComponentBase {
         }
 
         this.mColors = Utils.convertIntegers(colors);
+        this.mBorderColors = borderColors != null ? Utils.convertIntegers(borderColors) : null;
         this.mLabels = Utils.convertStrings(labels);
     }
 
@@ -181,6 +223,14 @@ public class Legend extends ComponentBase {
      */
     public void setComputedColors(List<Integer> colors) {
         mColors = Utils.convertIntegers(colors);
+    }
+
+    /**
+     * This method sets the automatically computed border colors for the legend.
+     * @param colors
+     */
+    public void setComputedBorderColors(List<Integer> colors) {
+        mBorderColors = Utils.convertIntegers(colors);
     }
 
     /**
@@ -250,6 +300,15 @@ public class Legend extends ComponentBase {
     }
 
     /**
+     * returns all the border colors the legend uses
+     *
+     * @return
+     */
+    public int[] getBorderColors() {
+        return mBorderColors;
+    }
+
+    /**
      * returns all the labels the legend uses
      * 
      * @return
@@ -277,6 +336,15 @@ public class Legend extends ComponentBase {
     }
 
     /**
+     * border colors that will be appended to the end of the colors array after
+     * calculating the legend.
+     */
+    public int[] getExtraBorderColors() {
+        return mExtraBorderColors;
+    }
+
+
+    /**
      * labels that will be appended to the end of the labels array after
      * calculating the legend. a null label will start a group.
      */
@@ -291,7 +359,18 @@ public class Legend extends ComponentBase {
      * let the changes take effect)
      */
     public void setExtra(List<Integer> colors, List<String> labels) {
+        setExtra(colors, null, labels);
+    }
+
+    /**
+     * Colors, border colors and labels that will be appended to the end of the auto calculated
+     * colors, border colors and labels arrays after calculating the legend. (if the legend has
+     * already been calculated, you will need to call notifyDataSetChanged() to
+     * let the changes take effect)
+     */
+    public void setExtra(List<Integer> colors, List<Integer> borderColors, List<String> labels) {
         this.mExtraColors = Utils.convertIntegers(colors);
+        this.mExtraBorderColors = borderColors != null ? Utils.convertIntegers(borderColors) : null;
         this.mExtraLabels = Utils.convertStrings(labels);
     }
 
@@ -302,7 +381,18 @@ public class Legend extends ComponentBase {
      * let the changes take effect)
      */
     public void setExtra(int[] colors, String[] labels) {
+        setExtra(colors, null, labels);
+    }
+
+    /**
+     * Colors, border colors and labels that will be appended to the end of the auto calculated
+     * colors, border colors and labels arrays after calculating the legend. (if the legend has
+     * already been calculated, you will need to call notifyDataSetChanged() to
+     * let the changes take effect)
+     */
+    public void setExtra(int[] colors, int[] borderColors, String[] labels) {
         this.mExtraColors = colors;
+        this.mExtraBorderColors = borderColors;
         this.mExtraLabels = labels;
     }
 
@@ -316,6 +406,19 @@ public class Legend extends ComponentBase {
      * notifyDataSetChanged() is needed to auto-calculate the legend again)
      */
     public void setCustom(int[] colors, String[] labels) {
+        setCustom(colors, null, labels);
+    }
+
+    /**
+     * Sets a custom legend's labels, color and border colors arrays. The colors count should
+     * match the labels count. * Each color is for the form drawn at the same
+     * index. * A null label will start a group. * A ColorTemplate.COLOR_SKIP
+     * color will avoid drawing a form This will disable the feature that
+     * automatically calculates the legend labels and colors from the datasets.
+     * Call resetCustom() to re-enable automatic calculation (and then
+     * notifyDataSetChanged() is needed to auto-calculate the legend again)
+     */
+    public void setCustom(int[] colors, int[] borderColors, String[] labels) {
 
         if (colors.length != labels.length) {
             throw new IllegalArgumentException(
@@ -324,6 +427,7 @@ public class Legend extends ComponentBase {
 
         mLabels = labels;
         mColors = colors;
+        mBorderColors = borderColors;
         mIsLegendCustom = true;
     }
 
@@ -337,6 +441,19 @@ public class Legend extends ComponentBase {
      * notifyDataSetChanged() is needed to auto-calculate the legend again)
      */
     public void setCustom(List<Integer> colors, List<String> labels) {
+        setCustom(colors, null, labels);
+    }
+
+    /**
+     * Sets a custom legend's labels, color and border colors arrays. The colors count should
+     * match the labels count. * Each color is for the form drawn at the same
+     * index. * A null label will start a group. * A ColorTemplate.COLOR_SKIP
+     * color will avoid drawing a form This will disable the feature that
+     * automatically calculates the legend labels and colors from the datasets.
+     * Call resetCustom() to re-enable automatic calculation (and then
+     * notifyDataSetChanged() is needed to auto-calculate the legend again)
+     */
+    public void setCustom(List<Integer> colors, List<Integer> borderColors, List<String> labels) {
 
         if (colors.size() != labels.size()) {
             throw new IllegalArgumentException(
@@ -344,6 +461,7 @@ public class Legend extends ComponentBase {
         }
 
         mColors = Utils.convertIntegers(colors);
+        mBorderColors = borderColors != null ? Utils.convertIntegers(borderColors) : null;
         mLabels = Utils.convertStrings(labels);
         mIsLegendCustom = true;
     }
@@ -598,6 +716,25 @@ public class Legend extends ComponentBase {
     }
 
     /**
+     * returns the size in dp of the legend forms' border
+     *
+     * @return
+     */
+    public float getFormBorderSize() {
+        return mFormBorderSize;
+    }
+
+    /**
+     * sets the size in pixels of the legend forms' border, this is internally converted
+     * in dp, default 0f
+     *
+     * @param size
+     */
+    public void setFormBorderSize(float size) {
+        mFormBorderSize = Utils.convertDpToPixel(size);
+    }
+
+    /**
      * returns the space between the legend entries on a horizontal axis in
      * pixels
      * 
@@ -649,7 +786,7 @@ public class Legend extends ComponentBase {
      * sets the space between the form and the actual label/text, converts to dp
      * internally
      * 
-     * @param mFormToTextSpace
+     * @param space
      */
     public void setFormToTextSpace(float space) {
         this.mFormToTextSpace = Utils.convertDpToPixel(space);
@@ -691,6 +828,9 @@ public class Legend extends ComponentBase {
                 if (mColors[i] != ColorTemplate.COLOR_SKIP)
                     width += mFormSize + mFormToTextSpace;
 
+                if (mBorderColors != null && mBorderColors[i] != ColorTemplate.COLOR_SKIP)
+                    width += mFormBorderSize * 2;
+
                 width += Utils.calcTextWidth(labelpaint, mLabels[i]);
 
                 if (i < mLabels.length - 1)
@@ -708,7 +848,7 @@ public class Legend extends ComponentBase {
     /**
      * Calculates the full height of the drawn legend.
      * 
-     * @param mLegendLabelPaint
+     * @param labelpaint
      * @return
      */
     public float getFullHeight(Paint labelpaint) {
@@ -831,6 +971,7 @@ public class Legend extends ComponentBase {
                 for (int i = 0; i < count; i++) {
 
                     boolean drawingForm = mColors[i] != ColorTemplate.COLOR_SKIP;
+                    boolean drawingFormBorder = mColors != null && mColors[i] != ColorTemplate.COLOR_SKIP;
 
                     if (!wasStacked)
                         width = 0.f;
@@ -839,6 +980,9 @@ public class Legend extends ComponentBase {
                         if (wasStacked)
                             width += mStackSpace;
                         width += mFormSize;
+
+                        if (drawingFormBorder)
+                            width += mFormBorderSize * 2;
                     }
 
                     // grouped forms have null labels
@@ -895,6 +1039,7 @@ public class Legend extends ComponentBase {
                 for (int i = 0; i < labelCount; i++) {
 
                     boolean drawingForm = mColors[i] != ColorTemplate.COLOR_SKIP;
+                    boolean drawingFormBorder = mColors != null && mColors[i] != ColorTemplate.COLOR_SKIP;
 
                     calculatedLabelBreakPoints.add(false);
 
@@ -913,12 +1058,14 @@ public class Legend extends ComponentBase {
 
                         calculatedLabelSizes.add(Utils.calcTextSize(labelpaint, mLabels[i]));
                         requiredWidth += drawingForm ? mFormToTextSpace + mFormSize : 0.f;
+                        requiredWidth += drawingFormBorder ? mFormBorderSize * 2 : 0.f;
                         requiredWidth += calculatedLabelSizes.get(i).width;
                     }
                     else {
 
                         calculatedLabelSizes.add(new FSize(0.f, 0.f));
                         requiredWidth += drawingForm ? mFormSize : 0.f;
+                        requiredWidth += drawingFormBorder ? mFormBorderSize * 2 : 0.f;
 
                         if (stackedStartIndex == -1) {
                             // mark this index as we might want to break here later

--- a/MPChartLib/src/com/github/mikephil/charting/components/Legend.java
+++ b/MPChartLib/src/com/github/mikephil/charting/components/Legend.java
@@ -113,6 +113,9 @@ public class Legend extends ComponentBase {
     /** the size of the legend forms/shapes' border */
     private float mFormBorderSize = 0f;
 
+    /** the size of the legend forms/shapes' radius */
+    private float mFormRadius = 0f;
+
     /**
      * the space between the legend entries on a horizontal axis, default 6f
      */
@@ -732,6 +735,26 @@ public class Legend extends ComponentBase {
      */
     public void setFormBorderSize(float size) {
         mFormBorderSize = Utils.convertDpToPixel(size);
+    }
+
+    /**
+     * returns the radius in dp of the legend forms
+     *
+     * @return
+     */
+    public float getFormRadius() {
+        return mFormRadius;
+    }
+
+    /**
+     * sets the radius in pixels of the legend forms, this is internally converted
+     * in dp, default 0f
+     * This will only be interpreted for the SQUARE form as it has no meaning for the other available forms.
+     *
+     * @param radius
+     */
+    public void setFormRadius(float radius) {
+        this.mFormRadius = Utils.convertDpToPixel(radius);
     }
 
     /**

--- a/MPChartLib/src/com/github/mikephil/charting/data/BaseDataSet.java
+++ b/MPChartLib/src/com/github/mikephil/charting/data/BaseDataSet.java
@@ -27,6 +27,11 @@ public abstract class BaseDataSet<T extends Entry> implements IDataSet<T> {
     protected List<Integer> mColors = null;
 
     /**
+     * List representing all colors that are used for this DataSet
+     */
+    protected List<Integer> mBorderColors = null;
+
+    /**
      * List representing all colors that are used for drawing the actual values for this DataSet
      */
     protected List<Integer> mValueColors = null;
@@ -76,6 +81,7 @@ public abstract class BaseDataSet<T extends Entry> implements IDataSet<T> {
      */
     public BaseDataSet() {
         mColors = new ArrayList<Integer>();
+        mBorderColors = new ArrayList<Integer>();
         mValueColors = new ArrayList<Integer>();
 
         // default color
@@ -120,6 +126,21 @@ public abstract class BaseDataSet<T extends Entry> implements IDataSet<T> {
     @Override
     public int getColor(int index) {
         return mColors.get(index % mColors.size());
+    }
+
+    @Override
+    public List<Integer> getBorderColors() {
+        return mBorderColors;
+    }
+
+    @Override
+    public int getBorderColor() {
+        return !mBorderColors.isEmpty() ? mBorderColors.get(0) : ColorTemplate.COLOR_SKIP;
+    }
+
+    @Override
+    public int getBorderColor(int index) {
+        return !mBorderColors.isEmpty() ? mBorderColors.get(index % mBorderColors.size()) : ColorTemplate.COLOR_SKIP;
     }
 
     /**
@@ -223,6 +244,105 @@ public abstract class BaseDataSet<T extends Entry> implements IDataSet<T> {
      */
     public void resetColors() {
         mColors = new ArrayList<Integer>();
+    }
+
+    /**
+     * Sets the border colors that should be used fore this DataSet. Colors are reused
+     * as soon as the number of Entries the DataSet represents is higher than
+     * the size of the colors array. If you are using colors from the resources,
+     * make sure that the colors are already prepared (by calling
+     * getResources().getColor(...)) before adding them to the DataSet.
+     *
+     * @param borderColors
+     */
+    public void setBorderColors(List<Integer> borderColors) {
+        this.mBorderColors = borderColors;
+    }
+
+    /**
+     * Sets the border colors that should be used fore this DataSet. Colors are reused
+     * as soon as the number of Entries the DataSet represents is higher than
+     * the size of the colors array. If you are using colors from the resources,
+     * make sure that the colors are already prepared (by calling
+     * getResources().getColor(...)) before adding them to the DataSet.
+     *
+     * @param borderColors
+     */
+    public void setBorderColors(int[] borderColors) {
+        this.mBorderColors = ColorTemplate.createColors(borderColors);
+    }
+
+    /**
+     * Sets the border colors that should be used fore this DataSet. Colors are reused
+     * as soon as the number of Entries the DataSet represents is higher than
+     * the size of the colors array. You can use
+     * "new int[] { R.color.red, R.color.green, ... }" to provide colors for
+     * this method. Internally, the colors are resolved using
+     * getResources().getColor(...)
+     *
+     * @param borderColors
+     */
+    public void setBorderColors(int[] borderColors, Context c) {
+
+        List<Integer> clrs = new ArrayList<Integer>();
+
+        for (int color : borderColors) {
+            clrs.add(c.getResources().getColor(color));
+        }
+
+        mBorderColors = clrs;
+    }
+
+    /**
+     * Adds a new border color to the colors array of the DataSet.
+     *
+     * @param color
+     */
+    public void addBorderColor(int color) {
+        if (mBorderColors == null)
+            mBorderColors = new ArrayList<Integer>();
+        mBorderColors.add(color);
+    }
+
+    /**
+     * Sets the one and ONLY border color that should be used for this DataSet.
+     * Internally, this recreates the colors array and adds the specified color.
+     *
+     * @param color
+     */
+    public void setBorderColor(int color) {
+        resetColors();
+        mBorderColors.add(color);
+    }
+
+    /**
+     * Sets a color with a specific alpha value.
+     *
+     * @param color
+     * @param alpha from 0-255
+     */
+    public void setBorderColor(int color, int alpha) {
+        setColor(Color.argb(alpha, Color.red(color), Color.green(color), Color.blue(color)));
+    }
+
+    /**
+     * Sets border colors with a specific alpha value.
+     *
+     * @param colors
+     * @param alpha
+     */
+    public void setBorderColors(int[] colors, int alpha) {
+        resetColors();
+        for (int color : colors) {
+            addColor(Color.argb(alpha, Color.red(color), Color.green(color), Color.blue(color)));
+        }
+    }
+
+    /**
+     * Resets all border colors of this DataSet and recreates the colors array.
+     */
+    public void resetBorderColors() {
+        mBorderColors = new ArrayList<Integer>();
     }
 
     /** ###### ###### OTHER STYLING RELATED METHODS ##### ###### */

--- a/MPChartLib/src/com/github/mikephil/charting/data/BaseDataSet.java
+++ b/MPChartLib/src/com/github/mikephil/charting/data/BaseDataSet.java
@@ -311,7 +311,7 @@ public abstract class BaseDataSet<T extends Entry> implements IDataSet<T> {
      * @param color
      */
     public void setBorderColor(int color) {
-        resetColors();
+        resetBorderColors();
         mBorderColors.add(color);
     }
 
@@ -322,7 +322,7 @@ public abstract class BaseDataSet<T extends Entry> implements IDataSet<T> {
      * @param alpha from 0-255
      */
     public void setBorderColor(int color, int alpha) {
-        setColor(Color.argb(alpha, Color.red(color), Color.green(color), Color.blue(color)));
+        setBorderColor(Color.argb(alpha, Color.red(color), Color.green(color), Color.blue(color)));
     }
 
     /**
@@ -332,9 +332,9 @@ public abstract class BaseDataSet<T extends Entry> implements IDataSet<T> {
      * @param alpha
      */
     public void setBorderColors(int[] colors, int alpha) {
-        resetColors();
+        resetBorderColors();
         for (int color : colors) {
-            addColor(Color.argb(alpha, Color.red(color), Color.green(color), Color.blue(color)));
+            addBorderColor(Color.argb(alpha, Color.red(color), Color.green(color), Color.blue(color)));
         }
     }
 

--- a/MPChartLib/src/com/github/mikephil/charting/interfaces/datasets/IDataSet.java
+++ b/MPChartLib/src/com/github/mikephil/charting/interfaces/datasets/IDataSet.java
@@ -271,6 +271,30 @@ public interface IDataSet<T extends Entry> {
     int getColor(int index);
 
     /**
+     * returns all the border colors that are set for this DataSet
+     *
+     * @return
+     */
+    List<Integer> getBorderColors();
+
+    /**
+     * Returns the first border color (index 0) of the colors-array this DataSet
+     * contains. This is only used for performance reasons when only one color is in the colors array (size == 1)
+     *
+     * @return
+     */
+    int getBorderColor();
+
+    /**
+     * Returns the border color at the given index of the DataSet's color array.
+     * Performs a IndexOutOfBounds check by modulus.
+     *
+     * @param index
+     * @return
+     */
+    int getBorderColor(int index);
+
+    /**
      * returns true if highlighting of values is enabled, false if not
      *
      * @return

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/LegendRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/LegendRenderer.java
@@ -216,6 +216,7 @@ public class LegendRenderer extends Renderer {
 
         String[] labels = mLegend.getLabels();
         int[] colors = mLegend.getColors();
+        int[] borderColors = mLegend.getBorderColors();
 
         float formToTextSpace = mLegend.getFormToTextSpace();
         float xEntrySpace = mLegend.getXEntrySpace();
@@ -224,6 +225,7 @@ public class LegendRenderer extends Renderer {
         Legend.LegendVerticalAlignment verticalAlignment = mLegend.getVerticalAlignment();
         Legend.LegendDirection direction = mLegend.getDirection();
         float formSize = mLegend.getFormSize();
+        float formBorderSize = mLegend.getFormBorderSize();
 
         // space between the entries
         float stackSpace = mLegend.getStackSpace();
@@ -322,16 +324,23 @@ public class LegendRenderer extends Renderer {
                     }
 
                     boolean drawingForm = colors[i] != ColorTemplate.COLOR_SKIP;
+                    boolean drawingFormBorder = borderColors != null && borderColors.length > i && borderColors[i] != ColorTemplate.COLOR_SKIP;
                     boolean isStacked = labels[i] == null; // grouped forms have null labels
 
                     if (drawingForm) {
-                        if (direction == Legend.LegendDirection.RIGHT_TO_LEFT)
+                        if (direction == Legend.LegendDirection.RIGHT_TO_LEFT) {
                             posX -= formSize;
+                            if (drawingFormBorder)
+                                posX -= formBorderSize * 2;
+                        }
 
                         drawForm(c, posX, posY + formYOffset, i, mLegend);
 
-                        if (direction == Legend.LegendDirection.LEFT_TO_RIGHT)
+                        if (direction == Legend.LegendDirection.LEFT_TO_RIGHT) {
                             posX += formSize;
+                            if (drawingFormBorder)
+                                posX += formBorderSize * 2;
+                        }
                     }
 
                     if (!isStacked) {
@@ -384,19 +393,27 @@ public class LegendRenderer extends Renderer {
 
                 for (int i = 0; i < labels.length; i++) {
 
-                    Boolean drawingForm = colors[i] != ColorTemplate.COLOR_SKIP;
+                    boolean drawingForm = colors[i] != ColorTemplate.COLOR_SKIP;
+                    boolean drawingFormBorder = borderColors != null && borderColors[i] != ColorTemplate.COLOR_SKIP;
                     float posX = originPosX;
 
                     if (drawingForm) {
                         if (direction == Legend.LegendDirection.LEFT_TO_RIGHT)
                             posX += stack;
-                        else
+                        else {
                             posX -= formSize - stack;
+                            if (drawingFormBorder)
+                                posX -= formBorderSize * 2;
+
+                        }
 
                         drawForm(c, posX, posY + formYOffset, i, mLegend);
 
-                        if (direction == Legend.LegendDirection.LEFT_TO_RIGHT)
+                        if (direction == Legend.LegendDirection.LEFT_TO_RIGHT) {
                             posX += formSize;
+                            if (drawingFormBorder)
+                                posX += formBorderSize * 2;
+                        }
                     }
 
                     if (labels[i] != null) {
@@ -421,7 +438,7 @@ public class LegendRenderer extends Renderer {
                         posY += labelLineHeight + labelLineSpacing;
                         stack = 0f;
                     } else {
-                        stack += formSize + stackSpace;
+                        stack += formSize + formBorderSize * 2 + stackSpace;
                         wasStacked = true;
                     }
                 }
@@ -476,8 +493,6 @@ public class LegendRenderer extends Renderer {
                 break;
             case LINE:
                 c.drawLine(x, y, x + formsize, y, mLegendFormPaint);
-                if (drawBorder)
-                    c.drawLine(x, y, x + formsize, y, mLegendFormBorderPaint);
                 break;
         }
     }

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/LegendRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/LegendRenderer.java
@@ -4,6 +4,7 @@ package com.github.mikephil.charting.renderer;
 import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.Paint.Align;
+import android.graphics.RectF;
 import android.graphics.Typeface;
 
 import com.github.mikephil.charting.components.Legend;
@@ -487,9 +488,11 @@ public class LegendRenderer extends Renderer {
                     c.drawCircle(x + half, y, half, mLegendFormBorderPaint);
                 break;
             case SQUARE:
-                c.drawRect(x, y - half, x + formsize, y + half, mLegendFormPaint);
+                float radius = legend.getFormRadius();
+                RectF formRect = new RectF(x, y - half, x + formsize, y + half);
+                c.drawRoundRect(formRect, radius, radius, mLegendFormPaint);
                 if (drawBorder)
-                    c.drawRect(x, y - half, x + formsize, y + half, mLegendFormBorderPaint);
+                    c.drawRoundRect(formRect, radius, radius, mLegendFormBorderPaint);
                 break;
             case LINE:
                 c.drawLine(x, y, x + formsize, y, mLegendFormPaint);

--- a/MPChartLib/src/com/github/mikephil/charting/utils/ColorTemplate.java
+++ b/MPChartLib/src/com/github/mikephil/charting/utils/ColorTemplate.java
@@ -55,7 +55,7 @@ public class ColorTemplate {
             rgb("#2ecc71"), rgb("#f1c40f"), rgb("#e74c3c"), rgb("#3498db")
     };
     public static final int[] MATERIAL_COLORS_DARK = {
-            rgb("#29b765"), rgb("#d8b00d"), rgb("#e74c3c"), rgb("#2e88c5")
+            rgb("#29b765"), rgb("#d8b00d"), rgb("#cf4436"), rgb("#2e88c5")
     };
 
     /**

--- a/MPChartLib/src/com/github/mikephil/charting/utils/ColorTemplate.java
+++ b/MPChartLib/src/com/github/mikephil/charting/utils/ColorTemplate.java
@@ -54,6 +54,9 @@ public class ColorTemplate {
     public static final int[] MATERIAL_COLORS = {
             rgb("#2ecc71"), rgb("#f1c40f"), rgb("#e74c3c"), rgb("#3498db")
     };
+    public static final int[] MATERIAL_COLORS_DARK = {
+            rgb("#29b765"), rgb("#d8b00d"), rgb("#e74c3c"), rgb("#2e88c5")
+    };
 
     /**
      * Converts the given hex-color-string to rgb.


### PR DESCRIPTION
Hi @PhilJay,

In the spirit of @danielgindi recently merged PR which features [bar border](https://github.com/PhilJay/MPAndroidChart/pull/1670) (and again many thanks to him for doing it!) I have extended this pattern to `Legend`.

This PR allows users to set a border width to all legend forms and set a proper border color per data set exactly as form color was already implemented. Lot of boilerplate code to mimic this behavior but this intends to maintain a coherent logic.

Moreover I added a radius property to the legend model that will be interpreted only for the `SQUARE` form to add rounded corners.

Best regards,
Stephen