### PR TITLE
Modification method  setVisibleYRangeMaximum()

### DIFF
--- a/MPChartLib/src/com/github/mikephil/charting/charts/BarLineChartBase.java
+++ b/MPChartLib/src/com/github/mikephil/charting/charts/BarLineChartBase.java
@@ -836,10 +836,9 @@ public abstract class BarLineChartBase<T extends BarLineScatterCandleBubbleData<
      * visible at once.
      *
      * @param maxYRange the maximum visible range on the y-axis
-     * @param axis      - the axis for which this limit should apply
      */
-    public void setVisibleYRangeMaximum(float maxYRange, AxisDependency axis) {
-        float yScale = getDeltaY(axis) / maxYRange;
+    public void setVisibleYRangeMaximum(float maxYRange) {
+        float yScale = mXAxis.mAxisRange / maxYRange;
         mViewPortHandler.setMinimumScaleY(yScale);
     }
 


### PR DESCRIPTION
setVisibleYRangeMaximum(float maxYRange, AxisDependency axis)

When the  BarLineChart is horizontal orientation , mXAxis.mAxisRange is y-axis values , mAxisLeft.mAxisRange and mAxisRight.mAxisRange is x-axis values  . in setVisibleYRangeMaximum() method  "mXAxis.mAxisRange / maxYRange" should be used to calculate "yScale"