### PR TITLE
Update PieChart.java to include a transparent hole

### DIFF
--- a/MPChartLib/src/com/github/mikephil/charting/charts/PieChart.java
+++ b/MPChartLib/src/com/github/mikephil/charting/charts/PieChart.java
@@ -645,6 +645,30 @@ public class PieChart extends PieRadarChartBase<PieData> {
         this.mMaxAngle = maxangle;
     }
 
+    /**
+     * Set the hole in the center of the PieChart transparent.
+     *
+     * @param enable
+     */
+    public void setHoleColorTransparent(boolean enable) {
+        if (enable) {
+            ((PieChartRenderer) mRenderer).getPaintHole().setColor(0xFFFFFFFF);
+            ((PieChartRenderer) mRenderer).getPaintHole().setXfermode(
+                    new PorterDuffXfermode(PorterDuff.Mode.CLEAR));
+        } else {
+            ((PieChartRenderer) mRenderer).getPaintHole().setXfermode(null);
+        }
+    }
+
+    /**
+     * Returns true if the hole in the center of the PieChart is transparent,
+     * false if not.
+     *
+     * @return true if hole is transparent.
+     */
+    public boolean isHoleTransparent() {
+        return ((PieChartRenderer) mRenderer).getPaintHole().getXfermode() != null;
+    }
     @Override
     protected void onDetachedFromWindow() {
         // releases the bitmap in the renderer to avoid oom error


### PR DESCRIPTION
This was removed in commit 1a0e90aacf97ea84944b434400b59674819a9ba2. I don't know why it was removed, other than maybe someone thought that it was redundant because you could set the color to #FFFFFFFF for a transparent hole or just set the hole color to your background color. Neither of these solutions work. If I set the color to #FFFFFFFF, I get a white hole. And if I set the color to my background color. For some reason the colors don't quite match up. See the scrrenshot : http://i.imgur.com/sYBRMP5.png. The chart on the right is what happens if I call setHoleColor(R.color.backgroundGray);
Chart on the left is what I get if I do : 
((PieChartRenderer) mRenderer).getPaintHole().setColor(0xFFFFFFFF);
((PieChartRenderer) mRenderer).getPaintHole().setXfermode(new PorterDuffXfermode(PorterDuff.Mode.CLEAR));