### PR TITLE
Cache circles in LineChartRenderer instead of recreating them (#1897)

### DIFF
--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/RealtimeLineChartActivity.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/RealtimeLineChartActivity.java
@@ -165,7 +165,10 @@ public class RealtimeLineChartActivity extends DemoBase implements
         LineDataSet set = new LineDataSet(null, "Dynamic Data");
         set.setAxisDependency(AxisDependency.LEFT);
         set.setColor(ColorTemplate.getHoloBlue());
-        set.setCircleColor(Color.WHITE);
+        set.setCircleColors(new int[]{Color.RED, Color.GREEN, Color.BLUE, Color.BLACK, Color.WHITE});
+        set.setDrawCircleHole(true);
+        set.setCircleHoleRadius(2f);
+        set.setCircleColorHole(Color.parseColor("#44aaeeaa"));
         set.setLineWidth(2f);
         set.setCircleRadius(4f);
         set.setFillAlpha(65);

--- a/MPChartLib/src/com/github/mikephil/charting/data/BaseDataSet.java
+++ b/MPChartLib/src/com/github/mikephil/charting/data/BaseDataSet.java
@@ -22,6 +22,11 @@ import java.util.List;
 public abstract class BaseDataSet<T extends Entry> implements IDataSet<T> {
 
     /**
+     * Miscellaneous user data.
+     */
+    protected Object mUserData = null;
+
+    /**
      * List representing all colors that are used for this DataSet
      */
     protected List<Integer> mColors = null;
@@ -378,5 +383,15 @@ public abstract class BaseDataSet<T extends Entry> implements IDataSet<T> {
         }
 
         return false;
+    }
+
+    @Override
+    public Object getUserData(){
+        return mUserData;
+    }
+
+    @Override
+    public void setUserData(Object value){
+        mUserData = value;
     }
 }

--- a/MPChartLib/src/com/github/mikephil/charting/data/BaseDataSet.java
+++ b/MPChartLib/src/com/github/mikephil/charting/data/BaseDataSet.java
@@ -22,11 +22,6 @@ import java.util.List;
 public abstract class BaseDataSet<T extends Entry> implements IDataSet<T> {
 
     /**
-     * Miscellaneous user data.
-     */
-    protected Object mUserData = null;
-
-    /**
      * List representing all colors that are used for this DataSet
      */
     protected List<Integer> mColors = null;
@@ -385,13 +380,4 @@ public abstract class BaseDataSet<T extends Entry> implements IDataSet<T> {
         return false;
     }
 
-    @Override
-    public Object getUserData(){
-        return mUserData;
-    }
-
-    @Override
-    public void setUserData(Object value){
-        mUserData = value;
-    }
 }

--- a/MPChartLib/src/com/github/mikephil/charting/data/LineDataSet.java
+++ b/MPChartLib/src/com/github/mikephil/charting/data/LineDataSet.java
@@ -106,7 +106,7 @@ public class LineDataSet extends LineRadarDataSet<Entry> implements ILineDataSet
     /**
      * Sets the intensity for cubic lines (if enabled). Max = 1f = very cubic,
      * Min = 0.05f = low cubic effect, Default: 0.2f
-     * 
+     *
      * @param intensity
      */
     public void setCubicIntensity(float intensity) {
@@ -182,7 +182,7 @@ public class LineDataSet extends LineRadarDataSet<Entry> implements ILineDataSet
      * Enables the line to be drawn in dashed mode, e.g. like this
      * "- - - - - -". THIS ONLY WORKS IF HARDWARE-ACCELERATION IS TURNED OFF.
      * Keep in mind that hardware acceleration boosts performance.
-     * 
+     *
      * @param lineLength the length of the line pieces
      * @param spaceLength the length of space in between the pieces
      * @param phase offset, in degrees (normally, use 0)
@@ -213,7 +213,7 @@ public class LineDataSet extends LineRadarDataSet<Entry> implements ILineDataSet
     /**
      * set this to true to enable the drawing of circle indicators for this
      * DataSet, default true
-     * 
+     *
      * @param enabled
      */
     public void setDrawCircles(boolean enabled) {
@@ -251,7 +251,7 @@ public class LineDataSet extends LineRadarDataSet<Entry> implements ILineDataSet
 
     /**
      * returns all colors specified for the circles
-     * 
+     *
      * @return
      */
     public List<Integer> getCircleColors() {
@@ -263,13 +263,18 @@ public class LineDataSet extends LineRadarDataSet<Entry> implements ILineDataSet
         return mCircleColors.get(index % mCircleColors.size());
     }
 
+    @Override
+    public int getCircleColorCount(){
+        return mCircleColors.size();
+    }
+
     /**
      * Sets the colors that should be used for the circles of this DataSet.
      * Colors are reused as soon as the number of Entries the DataSet represents
      * is higher than the size of the colors array. Make sure that the colors
      * are already prepared (by calling getResources().getColor(...)) before
      * adding them to the DataSet.
-     * 
+     *
      * @param colors
      */
     public void setCircleColors(List<Integer> colors) {
@@ -282,7 +287,7 @@ public class LineDataSet extends LineRadarDataSet<Entry> implements ILineDataSet
      * is higher than the size of the colors array. Make sure that the colors
      * are already prepared (by calling getResources().getColor(...)) before
      * adding them to the DataSet.
-     * 
+     *
      * @param colors
      */
     public void setCircleColors(int[] colors) {
@@ -296,7 +301,7 @@ public class LineDataSet extends LineRadarDataSet<Entry> implements ILineDataSet
      * "new String[] { R.color.red, R.color.green, ... }" to provide colors for
      * this method. Internally, the colors are resolved using
      * getResources().getColor(...)
-     * 
+     *
      * @param colors
      */
     public void setCircleColors(int[] colors, Context c) {
@@ -313,7 +318,7 @@ public class LineDataSet extends LineRadarDataSet<Entry> implements ILineDataSet
     /**
      * Sets the one and ONLY color that should be used for this DataSet.
      * Internally, this recreates the colors array and adds the specified color.
-     * 
+     *
      * @param color
      */
     public void setCircleColor(int color) {
@@ -330,7 +335,7 @@ public class LineDataSet extends LineRadarDataSet<Entry> implements ILineDataSet
 
     /**
      * Sets the color of the inner circle of the line-circles.
-     * 
+     *
      * @param color
      */
     public void setCircleColorHole(int color) {
@@ -344,7 +349,7 @@ public class LineDataSet extends LineRadarDataSet<Entry> implements ILineDataSet
 
     /**
      * Set this to true to allow drawing a hole in each data circle.
-     * 
+     *
      * @param enabled
      */
     public void setDrawCircleHole(boolean enabled) {

--- a/MPChartLib/src/com/github/mikephil/charting/data/realm/implementation/RealmLineDataSet.java
+++ b/MPChartLib/src/com/github/mikephil/charting/data/realm/implementation/RealmLineDataSet.java
@@ -256,6 +256,11 @@ public class RealmLineDataSet<T extends RealmObject> extends RealmLineRadarDataS
         return mCircleColors.get(index % mCircleColors.size());
     }
 
+    @Override
+    public int getCircleColorCount(){
+        return mCircleColors.size();
+    }
+
     /**
      * Sets the colors that should be used for the circles of this DataSet.
      * Colors are reused as soon as the number of Entries the DataSet represents

--- a/MPChartLib/src/com/github/mikephil/charting/interfaces/datasets/IDataSet.java
+++ b/MPChartLib/src/com/github/mikephil/charting/interfaces/datasets/IDataSet.java
@@ -393,15 +393,4 @@ public interface IDataSet<T extends Entry> {
      */
     boolean isVisible();
 
-    /**
-     * Returns miscellaneous data stored by this IDataSet instance.
-     *
-     * @return
-     */
-    Object getUserData();
-
-    /**
-     * Set miscellaneous data in this IDataSet instance.
-     */
-    void setUserData(Object value);
 }

--- a/MPChartLib/src/com/github/mikephil/charting/interfaces/datasets/IDataSet.java
+++ b/MPChartLib/src/com/github/mikephil/charting/interfaces/datasets/IDataSet.java
@@ -392,4 +392,16 @@ public interface IDataSet<T extends Entry> {
      * @return
      */
     boolean isVisible();
+
+    /**
+     * Returns miscellaneous data stored by this IDataSet instance.
+     *
+     * @return
+     */
+    Object getUserData();
+
+    /**
+     * Set miscellaneous data in this IDataSet instance.
+     */
+    void setUserData(Object value);
 }

--- a/MPChartLib/src/com/github/mikephil/charting/interfaces/datasets/ILineDataSet.java
+++ b/MPChartLib/src/com/github/mikephil/charting/interfaces/datasets/ILineDataSet.java
@@ -53,6 +53,13 @@ public interface ILineDataSet extends ILineRadarDataSet<Entry> {
     int getCircleColor(int index);
 
     /**
+     * Returns the number of colors available to use for circle drawing.
+     *
+     * @return
+     */
+    int getCircleColorCount();
+
+    /**
      * Returns true if drawing circles for this DataSet is enabled, false if not
      *
      * @return


### PR DESCRIPTION
IDataSet now has a UserData object which can store caches of data that may be expensive to calculate on-the-fly.  In this case, LineChartRenderer defines a UserData object to pre-draw and cache the circles that would be drawn inside of drawCircles().  Since canvas.drawBitmap() offers significant savings over the previous canvas.drawCircle()/canvas.drawPath(), we reduce the worst case rendering times by up to 40%.  This savings is noticeable in the RealtimeLineChartActivity.  Said activity is updated to contain many different colors, to ensure that the bitmap caching properly and correctly paints the circles as expected.

See ticket 1897 : https://github.com/PhilJay/MPAndroidChart/issues/1897