### PR TITLE
Eliminate allocs, cache images/text (#1892)

### DIFF
--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/StackedBarActivityNegative.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/StackedBarActivityNegative.java
@@ -19,8 +19,6 @@ import com.github.mikephil.charting.data.BarData;
 import com.github.mikephil.charting.data.BarDataSet;
 import com.github.mikephil.charting.data.BarEntry;
 import com.github.mikephil.charting.data.Entry;
-import com.github.mikephil.charting.data.filter.Approximator;
-import com.github.mikephil.charting.data.filter.Approximator.ApproximatorType;
 import com.github.mikephil.charting.interfaces.datasets.IBarDataSet;
 import com.github.mikephil.charting.listener.OnChartValueSelectedListener;
 import com.github.mikephil.charting.highlight.Highlight;
@@ -225,7 +223,7 @@ public class StackedBarActivityNegative extends DemoBase implements
 
         // YAxis
         @Override
-        public String getFormattedValue(float value, YAxis yAxis) {
+        public String getFormattedValue(float value, YAxis yAxis, int position) {
             return mFormat.format(Math.abs(value)) + "m";
         }
     }

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/custom/MyYAxisValueFormatter.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/custom/MyYAxisValueFormatter.java
@@ -14,7 +14,7 @@ public class MyYAxisValueFormatter implements YAxisValueFormatter {
     }
 
     @Override
-    public String getFormattedValue(float value, YAxis yAxis) {
+    public String getFormattedValue(float value, YAxis yAxis, int position) {
         return mFormat.format(value) + " $";
     }
 }

--- a/MPChartLib/src/com/github/mikephil/charting/charts/BarLineChartBase.java
+++ b/MPChartLib/src/com/github/mikephil/charting/charts/BarLineChartBase.java
@@ -527,6 +527,7 @@ public abstract class BarLineChartBase<T extends BarLineScatterCandleBubbleData<
     /**
      * calculates the modulus for x-labels and grid
      */
+    float[] valuesForCalcModulus = new float[9];
     protected void calcModulus() {
 
         if (mXAxis == null || !mXAxis.isEnabled())
@@ -534,7 +535,10 @@ public abstract class BarLineChartBase<T extends BarLineScatterCandleBubbleData<
 
         if (!mXAxis.isAxisModulusCustom()) {
 
-            float[] values = new float[9];
+            float[] values = valuesForCalcModulus;
+            for(int i = 0 ; i < values.length ; i++){
+                values[i] = 0;
+            }
             mViewPortHandler.getMatrixTouch().getValues(values);
 
             mXAxis.mAxisLabelModulus = (int) Math
@@ -1284,10 +1288,11 @@ public abstract class BarLineChartBase<T extends BarLineScatterCandleBubbleData<
      * @param y
      * @return
      */
+    private float[] ptsForGetValuesByTouchPoint = new float[2];
     public PointD getValuesByTouchPoint(float x, float y, AxisDependency axis) {
 
         // create an array of the touch-point
-        float[] pts = new float[2];
+        float[] pts = ptsForGetValuesByTouchPoint;
         pts[0] = x;
         pts[1] = y;
 
@@ -1296,7 +1301,7 @@ public abstract class BarLineChartBase<T extends BarLineScatterCandleBubbleData<
         double xTouchVal = pts[0];
         double yTouchVal = pts[1];
 
-        return new PointD(xTouchVal, yTouchVal);
+        return PointD.getInstance(xTouchVal, yTouchVal);
     }
 
     /**
@@ -1307,15 +1312,16 @@ public abstract class BarLineChartBase<T extends BarLineScatterCandleBubbleData<
      * @param y
      * @return
      */
+    private float[] ptsForGetPixelsForValues = new float[2];
     public PointD getPixelsForValues(float x, float y, AxisDependency axis) {
 
-        float[] pts = new float[]{
-                x, y
-        };
+        float[] pts = ptsForGetPixelsForValues;
+        pts[0] = x;
+        pts[1] = y;
 
         getTransformer(axis).pointValuesToPixel(pts);
 
-        return new PointD(pts[0], pts[1]);
+        return PointD.getInstance(pts[0], pts[1]);
     }
 
     /**
@@ -1366,13 +1372,13 @@ public abstract class BarLineChartBase<T extends BarLineScatterCandleBubbleData<
      *
      * @return
      */
+    private float[] lowestVisibleXIndexPoints = new float[2];
     @Override
     public int getLowestVisibleXIndex() {
-        float[] pts = new float[]{
-                mViewPortHandler.contentLeft(), mViewPortHandler.contentBottom()
-        };
-        getTransformer(AxisDependency.LEFT).pixelsToValue(pts);
-        return (pts[0] <= 0) ? 0 : (int)Math.ceil(pts[0]);
+        lowestVisibleXIndexPoints[0] = mViewPortHandler.contentLeft();
+        lowestVisibleXIndexPoints[1] = mViewPortHandler.contentBottom();
+        getTransformer(AxisDependency.LEFT).pixelsToValue(lowestVisibleXIndexPoints);
+        return (lowestVisibleXIndexPoints[0] <= 0) ? 0 : (int)Math.ceil(lowestVisibleXIndexPoints[0]);
     }
 
     /**
@@ -1381,13 +1387,13 @@ public abstract class BarLineChartBase<T extends BarLineScatterCandleBubbleData<
      *
      * @return
      */
+    private float[] highestVisibleXIndexPoints = new float[2];
     @Override
     public int getHighestVisibleXIndex() {
-        float[] pts = new float[]{
-                mViewPortHandler.contentRight(), mViewPortHandler.contentBottom()
-        };
-        getTransformer(AxisDependency.LEFT).pixelsToValue(pts);
-        return Math.min(mData.getXValCount() - 1, (int)Math.floor(pts[0]));
+        highestVisibleXIndexPoints[0] = mViewPortHandler.contentRight();
+        highestVisibleXIndexPoints[1] = mViewPortHandler.contentBottom();
+        getTransformer(AxisDependency.LEFT).pixelsToValue(highestVisibleXIndexPoints);
+        return Math.min(mData.getXValCount() - 1, (int)Math.floor(highestVisibleXIndexPoints[0]));
     }
 
     /**

--- a/MPChartLib/src/com/github/mikephil/charting/components/Legend.java
+++ b/MPChartLib/src/com/github/mikephil/charting/components/Legend.java
@@ -808,6 +808,11 @@ public class Legend extends ComponentBase {
         return mCalculatedLineSizes;
     }
 
+
+    ArrayList<FSize> calculatedLabelSizes = new ArrayList<FSize>();
+    ArrayList<Boolean> calculatedLabelBreakPoints = new ArrayList<Boolean>();
+    ArrayList<FSize> calculatedLineSizes = new ArrayList<FSize>();
+
     /**
      * Calculates the dimensions of the Legend. This includes the maximum width
      * and height of a single entry, as well as the total width and height of
@@ -882,9 +887,14 @@ public class Legend extends ComponentBase {
                 float contentWidth = viewPortHandler.contentWidth() * mMaxSizePercent;
 
                 // Prepare arrays for calculated layout
-                ArrayList<FSize> calculatedLabelSizes = new ArrayList<FSize>(labelCount);
-                ArrayList<Boolean> calculatedLabelBreakPoints = new ArrayList<Boolean>(labelCount);
-                ArrayList<FSize> calculatedLineSizes = new ArrayList<FSize>();
+                //  TODO : Investigate whether ensureCapacity will help in the long run.
+                FSize.recycleInstances(calculatedLabelSizes);
+                calculatedLabelSizes.clear();
+
+                calculatedLabelBreakPoints.clear();
+
+                FSize.recycleInstances(calculatedLineSizes);
+                calculatedLineSizes.clear();
 
                 // Start calculating layout
                 float maxLineWidth = 0.f;
@@ -913,11 +923,11 @@ public class Legend extends ComponentBase {
 
                         calculatedLabelSizes.add(Utils.calcTextSize(labelpaint, mLabels[i]));
                         requiredWidth += drawingForm ? mFormToTextSpace + mFormSize : 0.f;
-                        requiredWidth += calculatedLabelSizes.get(i).width;
+                        requiredWidth += calculatedLabelSizes.get(i).getWidth();
                     }
                     else {
 
-                        calculatedLabelSizes.add(new FSize(0.f, 0.f));
+                        calculatedLabelSizes.add(FSize.getInstance(0.f, 0.f));
                         requiredWidth += drawingForm ? mFormSize : 0.f;
 
                         if (stackedStartIndex == -1) {
@@ -942,7 +952,7 @@ public class Legend extends ComponentBase {
                         else { // It doesn't fit, we need to wrap a line
 
                             // Add current line size to array
-                            calculatedLineSizes.add(new FSize(currentLineWidth, labelLineHeight));
+                            calculatedLineSizes.add(FSize.getInstance(currentLineWidth, labelLineHeight));
                             maxLineWidth = Math.max(maxLineWidth, currentLineWidth);
 
                             // Start a new line
@@ -954,7 +964,7 @@ public class Legend extends ComponentBase {
 
                         if (i == labelCount - 1) {
                             // Add last line size to array
-                            calculatedLineSizes.add(new FSize(currentLineWidth, labelLineHeight));
+                            calculatedLineSizes.add(FSize.getInstance(currentLineWidth, labelLineHeight));
                             maxLineWidth = Math.max(maxLineWidth, currentLineWidth);
                         }
                     }

--- a/MPChartLib/src/com/github/mikephil/charting/components/YAxis.java
+++ b/MPChartLib/src/com/github/mikephil/charting/components/YAxis.java
@@ -505,7 +505,7 @@ public class YAxis extends AxisBase {
         if (index < 0 || index >= mEntries.length)
             return "";
         else
-            return getValueFormatter().getFormattedValue(mEntries[index], this);
+            return getValueFormatter().getFormattedValue(mEntries[index], this, index);
     }
 
     /**

--- a/MPChartLib/src/com/github/mikephil/charting/data/ChartData.java
+++ b/MPChartLib/src/com/github/mikephil/charting/data/ChartData.java
@@ -233,7 +233,8 @@ public abstract class ChartData<T extends IDataSet<? extends Entry>> {
                 mLeftAxisMax = firstLeft.getYMax();
                 mLeftAxisMin = firstLeft.getYMin();
 
-                for (IDataSet dataSet : mDataSets) {
+                for (int i = 0 ; i < mDataSets.size() ; i++){
+                    IDataSet dataSet = mDataSets.get(i);
                     if (dataSet.getAxisDependency() == AxisDependency.LEFT) {
                         if (dataSet.getYMin() < mLeftAxisMin)
                             mLeftAxisMin = dataSet.getYMin();
@@ -252,7 +253,8 @@ public abstract class ChartData<T extends IDataSet<? extends Entry>> {
                 mRightAxisMax = firstRight.getYMax();
                 mRightAxisMin = firstRight.getYMin();
 
-                for (IDataSet dataSet : mDataSets) {
+                for (int i = 0 ; i < mDataSets.size() ; i++){
+                    IDataSet dataSet = mDataSets.get(i);
                     if (dataSet.getAxisDependency() == AxisDependency.RIGHT) {
                         if (dataSet.getYMin() < mRightAxisMin)
                             mRightAxisMin = dataSet.getYMin();
@@ -810,7 +812,8 @@ public abstract class ChartData<T extends IDataSet<? extends Entry>> {
      * @return
      */
     public T getFirstLeft() {
-        for (T dataSet : mDataSets) {
+        for(int i = 0 ; i < mDataSets.size() ; i++){
+            T dataSet = mDataSets.get(i);
             if (dataSet.getAxisDependency() == AxisDependency.LEFT)
                 return dataSet;
         }
@@ -825,7 +828,8 @@ public abstract class ChartData<T extends IDataSet<? extends Entry>> {
      * @return
      */
     public T getFirstRight() {
-        for (T dataSet : mDataSets) {
+        for(int i = 0 ; i < mDataSets.size() ; i++){
+            T dataSet = mDataSets.get(i);
             if (dataSet.getAxisDependency() == AxisDependency.RIGHT)
                 return dataSet;
         }
@@ -859,7 +863,8 @@ public abstract class ChartData<T extends IDataSet<? extends Entry>> {
         if (f == null)
             return;
         else {
-            for (IDataSet set : mDataSets) {
+            for (int i = 0 ; i < mDataSets.size() ; i++){
+                IDataSet set = mDataSets.get(i);
                 set.setValueFormatter(f);
             }
         }
@@ -872,7 +877,8 @@ public abstract class ChartData<T extends IDataSet<? extends Entry>> {
      * @param color
      */
     public void setValueTextColor(int color) {
-        for (IDataSet set : mDataSets) {
+        for (int i = 0 ; i < mDataSets.size() ; i++){
+            IDataSet set = mDataSets.get(i);
             set.setValueTextColor(color);
         }
     }
@@ -884,7 +890,8 @@ public abstract class ChartData<T extends IDataSet<? extends Entry>> {
      * @param colors
      */
     public void setValueTextColors(List<Integer> colors) {
-        for (IDataSet set : mDataSets) {
+        for (int i = 0 ; i < mDataSets.size() ; i++){
+            IDataSet set = mDataSets.get(i);
             set.setValueTextColors(colors);
         }
     }
@@ -896,7 +903,8 @@ public abstract class ChartData<T extends IDataSet<? extends Entry>> {
      * @param tf
      */
     public void setValueTypeface(Typeface tf) {
-        for (IDataSet set : mDataSets) {
+        for (int i = 0 ; i < mDataSets.size() ; i++){
+            IDataSet set = mDataSets.get(i);
             set.setValueTypeface(tf);
         }
     }
@@ -908,7 +916,8 @@ public abstract class ChartData<T extends IDataSet<? extends Entry>> {
      * @param size
      */
     public void setValueTextSize(float size) {
-        for (IDataSet set : mDataSets) {
+        for (int i = 0 ; i < mDataSets.size() ; i++){
+            IDataSet set = mDataSets.get(i);
             set.setValueTextSize(size);
         }
     }
@@ -920,7 +929,8 @@ public abstract class ChartData<T extends IDataSet<? extends Entry>> {
      * @param enabled
      */
     public void setDrawValues(boolean enabled) {
-        for (IDataSet set : mDataSets) {
+        for (int i = 0 ; i < mDataSets.size() ; i++){
+            IDataSet set = mDataSets.get(i);
             set.setDrawValues(enabled);
         }
     }
@@ -931,7 +941,8 @@ public abstract class ChartData<T extends IDataSet<? extends Entry>> {
      * be highlighted programmatically or by touch gesture.
      */
     public void setHighlightEnabled(boolean enabled) {
-        for (IDataSet set : mDataSets) {
+        for (int i = 0 ; i < mDataSets.size() ; i++){
+            IDataSet set = mDataSets.get(i);
             set.setHighlightEnabled(enabled);
         }
     }
@@ -943,7 +954,8 @@ public abstract class ChartData<T extends IDataSet<? extends Entry>> {
      * @return
      */
     public boolean isHighlightEnabled() {
-        for (IDataSet set : mDataSets) {
+        for (int i = 0 ; i < mDataSets.size() ; i++){
+            IDataSet set = mDataSets.get(i);
             if (!set.isHighlightEnabled())
                 return false;
         }
@@ -969,7 +981,8 @@ public abstract class ChartData<T extends IDataSet<? extends Entry>> {
 //     */
 //    public boolean contains(Entry e) {
 //
-//        for (T set : mDataSets) {
+//        for (int i = 0 ; i < mDataSets.size() ; i++){
+//            IDataSet set = mDataSets.get(i);
 //            if (set.contains(e))
 //                return true;
 //        }
@@ -986,7 +999,8 @@ public abstract class ChartData<T extends IDataSet<? extends Entry>> {
      */
     public boolean contains(T dataSet) {
 
-        for (T set : mDataSets) {
+        for (int i = 0 ; i < mDataSets.size() ; i++){
+            T set = mDataSets.get(i);
             if (set.equals(dataSet))
                 return true;
         }

--- a/MPChartLib/src/com/github/mikephil/charting/data/LineDataSet.java
+++ b/MPChartLib/src/com/github/mikephil/charting/data/LineDataSet.java
@@ -263,6 +263,11 @@ public class LineDataSet extends LineRadarDataSet<Entry> implements ILineDataSet
         return mCircleColors.get(index % mCircleColors.size());
     }
 
+    @Override
+    public int getCircleColorCount(){
+        return mCircleColors.size();
+    }
+
     /**
      * Sets the colors that should be used for the circles of this DataSet.
      * Colors are reused as soon as the number of Entries the DataSet represents

--- a/MPChartLib/src/com/github/mikephil/charting/data/realm/implementation/RealmLineDataSet.java
+++ b/MPChartLib/src/com/github/mikephil/charting/data/realm/implementation/RealmLineDataSet.java
@@ -256,6 +256,11 @@ public class RealmLineDataSet<T extends RealmObject> extends RealmLineRadarDataS
         return mCircleColors.get(index % mCircleColors.size());
     }
 
+    @Override
+    public int getCircleColorCount(){
+        return mCircleColors.size();
+    }
+
     /**
      * Sets the colors that should be used for the circles of this DataSet.
      * Colors are reused as soon as the number of Entries the DataSet represents

--- a/MPChartLib/src/com/github/mikephil/charting/formatter/DefaultValueFormatter.java
+++ b/MPChartLib/src/com/github/mikephil/charting/formatter/DefaultValueFormatter.java
@@ -5,6 +5,7 @@ import com.github.mikephil.charting.data.Entry;
 import com.github.mikephil.charting.utils.ViewPortHandler;
 
 import java.text.DecimalFormat;
+import java.util.ArrayList;
 
 /**
  * Default formatter used for formatting values inside the chart. Uses a DecimalFormat with
@@ -35,12 +36,37 @@ public class DefaultValueFormatter implements ValueFormatter {
         mFormat = new DecimalFormat("###,###,###,##0" + b.toString());
     }
 
+    private ArrayList<Float> cachedValues = new ArrayList<>();
+    private ArrayList<String> cachedStrings = new ArrayList<>();
     @Override
     public String getFormattedValue(float value, Entry entry, int dataSetIndex, ViewPortHandler viewPortHandler) {
 
-        // put more logic here ...
-        // avoid memory allocations here (for performance reasons)
+        boolean hasValueAtdataSetIndex = true;
+        if(cachedValues.size() <= dataSetIndex){
+            int p = dataSetIndex;
+            while(p >= 0){
+                if(p == 0){
+                    cachedValues.add(value);
+                    cachedStrings.add("");
+                }else{
+                    cachedValues.add(Float.NaN);
+                    cachedStrings.add("");
+                }
+                p--;
+            }
+            hasValueAtdataSetIndex = false;
+        }
 
-        return mFormat.format(value);
+        if(hasValueAtdataSetIndex) {
+            Float cachedValue = cachedValues.get(dataSetIndex);
+            hasValueAtdataSetIndex = !(cachedValue == null || cachedValue != value);
+        }
+
+        if(!hasValueAtdataSetIndex){
+            cachedValues.set(dataSetIndex, value);
+            cachedStrings.set(dataSetIndex, mFormat.format(value));
+        }
+
+        return cachedStrings.get(dataSetIndex);
     }
 }

--- a/MPChartLib/src/com/github/mikephil/charting/formatter/DefaultYAxisValueFormatter.java
+++ b/MPChartLib/src/com/github/mikephil/charting/formatter/DefaultYAxisValueFormatter.java
@@ -3,6 +3,7 @@ package com.github.mikephil.charting.formatter;
 import com.github.mikephil.charting.components.YAxis;
 
 import java.text.DecimalFormat;
+import java.util.ArrayList;
 
 /**
  * Created by Philipp Jahoda on 20/09/15.
@@ -32,9 +33,36 @@ public class DefaultYAxisValueFormatter implements YAxisValueFormatter {
         mFormat = new DecimalFormat("###,###,###,##0" + b.toString());
     }
 
+    private ArrayList<Float> cachedValues = new ArrayList<>();
+    private ArrayList<String> cachedStrings = new ArrayList<>();
     @Override
-    public String getFormattedValue(float value, YAxis yAxis) {
-        // avoid memory allocations here (for performance)
-        return mFormat.format(value);
+    public String getFormattedValue(float value, YAxis yAxis, int position) {
+        boolean hasValueAtPosition = true;
+        if(cachedValues.size() <= position){
+            int p = position;
+            while(p >= 0){
+                if(p == 0){
+                    cachedValues.add(value);
+                    cachedStrings.add("");
+                }else{
+                    cachedValues.add(Float.NaN);
+                    cachedStrings.add("");
+                }
+                p--;
+            }
+            hasValueAtPosition = false;
+        }
+
+        if(hasValueAtPosition) {
+            Float cachedValue = cachedValues.get(position);
+            hasValueAtPosition = !(cachedValue == null || cachedValue != value);
+        }
+
+        if(!hasValueAtPosition){
+            cachedValues.set(position, value);
+            cachedStrings.set(position, mFormat.format(value));
+        }
+
+        return cachedStrings.get(position);
     }
 }

--- a/MPChartLib/src/com/github/mikephil/charting/formatter/LargeValueFormatter.java
+++ b/MPChartLib/src/com/github/mikephil/charting/formatter/LargeValueFormatter.java
@@ -48,7 +48,7 @@ public class LargeValueFormatter implements ValueFormatter, YAxisValueFormatter 
 
     // YAxisValueFormatter
     @Override
-    public String getFormattedValue(float value, YAxis yAxis) {
+    public String getFormattedValue(float value, YAxis yAxis, int position) {
         return makePretty(value) + mText;
     }
 

--- a/MPChartLib/src/com/github/mikephil/charting/formatter/PercentFormatter.java
+++ b/MPChartLib/src/com/github/mikephil/charting/formatter/PercentFormatter.java
@@ -38,7 +38,7 @@ public class PercentFormatter implements ValueFormatter, YAxisValueFormatter {
 
     // YAxisValueFormatter
     @Override
-    public String getFormattedValue(float value, YAxis yAxis) {
+    public String getFormattedValue(float value, YAxis yAxis, int position) {
         return mFormat.format(value) + " %";
     }
 }

--- a/MPChartLib/src/com/github/mikephil/charting/formatter/YAxisValueFormatter.java
+++ b/MPChartLib/src/com/github/mikephil/charting/formatter/YAxisValueFormatter.java
@@ -16,7 +16,8 @@ public interface YAxisValueFormatter {
      *
      * @param value the YAxis value to be formatted
      * @param yAxis the YAxis object the value belongs to
+     * @param position
      * @return
      */
-    String getFormattedValue(float value, YAxis yAxis);
+    String getFormattedValue(float value, YAxis yAxis, int position);
 }

--- a/MPChartLib/src/com/github/mikephil/charting/interfaces/datasets/ILineDataSet.java
+++ b/MPChartLib/src/com/github/mikephil/charting/interfaces/datasets/ILineDataSet.java
@@ -53,6 +53,13 @@ public interface ILineDataSet extends ILineRadarDataSet<Entry> {
     int getCircleColor(int index);
 
     /**
+     * Returns the number of colors available to use for circle drawing.
+     *
+     * @return
+     */
+    int getCircleColorCount();
+
+    /**
      * Returns true if drawing circles for this DataSet is enabled, false if not
      *
      * @return

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/LegendRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/LegendRenderer.java
@@ -292,8 +292,8 @@ public class LegendRenderer extends Renderer {
                         horizontalAlignment == Legend.LegendHorizontalAlignment.CENTER &&
                         lineIndex < calculatedLineSizes.length) {
                         posX += (direction == Legend.LegendDirection.RIGHT_TO_LEFT
-                                ? calculatedLineSizes[lineIndex].width
-                                : -calculatedLineSizes[lineIndex].width) / 2.f;
+                                ? calculatedLineSizes[lineIndex].getWidth()
+                                : -calculatedLineSizes[lineIndex].getWidth()) / 2.f;
                         lineIndex++;
                     }
 
@@ -315,12 +315,12 @@ public class LegendRenderer extends Renderer {
                             posX += direction == Legend.LegendDirection.RIGHT_TO_LEFT ? -formToTextSpace : formToTextSpace;
 
                         if (direction == Legend.LegendDirection.RIGHT_TO_LEFT)
-                            posX -= calculatedLabelSizes[i].width;
+                            posX -= calculatedLabelSizes[i].getWidth();
 
                         drawLabel(c, posX, posY + labelLineHeight, labels[i]);
 
                         if (direction == Legend.LegendDirection.LEFT_TO_RIGHT)
-                            posX += calculatedLabelSizes[i].width;
+                            posX += calculatedLabelSizes[i].getWidth();
 
                         posX += direction == Legend.LegendDirection.RIGHT_TO_LEFT ? -xEntrySpace : xEntrySpace;
                     } else

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/XAxisRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/XAxisRenderer.java
@@ -47,7 +47,7 @@ public class XAxisRenderer extends AxisRenderer {
 
         final FSize labelSize = Utils.calcTextSize(mAxisLabelPaint, widthText.toString());
 
-        final float labelWidth = labelSize.width;
+        final float labelWidth = labelSize.getWidth();
         final float labelHeight = Utils.calcTextHeight(mAxisLabelPaint, "Q");
 
         final FSize labelRotatedSize = Utils.getSizeOfRotatedRectangleByDegrees(
@@ -64,14 +64,17 @@ public class XAxisRenderer extends AxisRenderer {
 
         final FSize spaceSize = Utils.calcTextSize(mAxisLabelPaint, space.toString());
 
-        mXAxis.mLabelWidth = Math.round(labelWidth + spaceSize.width);
+        mXAxis.mLabelWidth = Math.round(labelWidth + spaceSize.getWidth());
         mXAxis.mLabelHeight = Math.round(labelHeight);
-        mXAxis.mLabelRotatedWidth = Math.round(labelRotatedSize.width + spaceSize.width);
-        mXAxis.mLabelRotatedHeight = Math.round(labelRotatedSize.height);
+        mXAxis.mLabelRotatedWidth = Math.round(labelRotatedSize.getWidth() + spaceSize.getWidth());
+        mXAxis.mLabelRotatedHeight = Math.round(labelRotatedSize.getHeight());
 
         mXAxis.setValues(xValues);
+
+        FSize.recycleInstance(labelSize);
     }
 
+    PointF pointForRenderAxisLabels = new PointF(0,0);
     @Override
     public void renderAxisLabels(Canvas c) {
 
@@ -85,31 +88,32 @@ public class XAxisRenderer extends AxisRenderer {
         mAxisLabelPaint.setColor(mXAxis.getTextColor());
 
         if (mXAxis.getPosition() == XAxisPosition.TOP) {
-
+            pointForRenderAxisLabels.set(0.5f, 1.0f);
             drawLabels(c, mViewPortHandler.contentTop() - yoffset,
-                    new PointF(0.5f, 1.0f));
+                    pointForRenderAxisLabels);
 
         } else if (mXAxis.getPosition() == XAxisPosition.TOP_INSIDE) {
-
+            pointForRenderAxisLabels.set(0.5f, 1.0f);
             drawLabels(c, mViewPortHandler.contentTop() + yoffset + mXAxis.mLabelRotatedHeight,
-                    new PointF(0.5f, 1.0f));
+                    pointForRenderAxisLabels);
 
         } else if (mXAxis.getPosition() == XAxisPosition.BOTTOM) {
-
+            pointForRenderAxisLabels.set(0.5f, 0.0f);
             drawLabels(c, mViewPortHandler.contentBottom() + yoffset,
-                    new PointF(0.5f, 0.0f));
+                    pointForRenderAxisLabels);
 
         } else if (mXAxis.getPosition() == XAxisPosition.BOTTOM_INSIDE) {
-
+            pointForRenderAxisLabels.set(0.5f, 0.0f);
             drawLabels(c, mViewPortHandler.contentBottom() - yoffset - mXAxis.mLabelRotatedHeight,
-                    new PointF(0.5f, 0.0f));
+                    pointForRenderAxisLabels);
 
         } else { // BOTH SIDED
-
+            pointForRenderAxisLabels.set(0.5f, 1.0f);
             drawLabels(c, mViewPortHandler.contentTop() - yoffset,
-                    new PointF(0.5f, 1.0f));
+                    pointForRenderAxisLabels);
+            pointForRenderAxisLabels.set(0.5f, 0.0f);
             drawLabels(c, mViewPortHandler.contentBottom() + yoffset,
-                    new PointF(0.5f, 0.0f));
+                    pointForRenderAxisLabels);
         }
     }
 
@@ -144,14 +148,15 @@ public class XAxisRenderer extends AxisRenderer {
      *
      * @param pos
      */
+    float[] positionsForDrawLabels = new float[2];
     protected void drawLabels(Canvas c, float pos, PointF anchor) {
 
         final float labelRotationAngleDegrees = mXAxis.getLabelRotationAngle();
 
         // pre allocate to save performance (dont allocate in loop)
-        float[] position = new float[] {
-                0f, 0f
-        };
+        float[] position = positionsForDrawLabels;
+        positionsForDrawLabels[0] = 0;
+        positionsForDrawLabels[1] = 1;
 
         for (int i = mMinX; i <= mMaxX; i += mXAxis.mAxisLabelModulus) {
 

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/XAxisRendererHorizontalBarChart.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/XAxisRendererHorizontalBarChart.java
@@ -37,18 +37,20 @@ public class XAxisRendererHorizontalBarChart extends XAxisRendererBarChart {
 
         final FSize labelSize = Utils.calcTextSize(mAxisLabelPaint, longest);
 
-        final float labelWidth = (int)(labelSize.width + mXAxis.getXOffset() * 3.5f);
-        final float labelHeight = labelSize.height;
+        final float labelWidth = (int)(labelSize.getWidth() + mXAxis.getXOffset() * 3.5f);
+        final float labelHeight = labelSize.getHeight();
 
         final FSize labelRotatedSize = Utils.getSizeOfRotatedRectangleByDegrees(
-                labelSize.width,
+                labelSize.getWidth(),
                 labelHeight,
                 mXAxis.getLabelRotationAngle());
 
         mXAxis.mLabelWidth = Math.round(labelWidth);
         mXAxis.mLabelHeight = Math.round(labelHeight);
-        mXAxis.mLabelRotatedWidth = (int)(labelRotatedSize.width + mXAxis.getXOffset() * 3.5f);
-        mXAxis.mLabelRotatedHeight = Math.round(labelRotatedSize.height);
+        mXAxis.mLabelRotatedWidth = (int)(labelRotatedSize.getWidth() + mXAxis.getXOffset() * 3.5f);
+        mXAxis.mLabelRotatedHeight = Math.round(labelRotatedSize.getHeight());
+
+        FSize.recycleInstance(labelRotatedSize);
     }
 
     @Override

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/YAxisRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/YAxisRenderer.java
@@ -60,6 +60,10 @@ public class YAxisRenderer extends AxisRenderer {
                 yMin = (float) p1.y;
                 yMax = (float) p2.y;
             }
+
+            PointD.recycleInstance(p1);
+            PointD.recycleInstance(p2);
+
         }
 
         computeAxisValues(yMin, yMax);
@@ -174,15 +178,20 @@ public class YAxisRenderer extends AxisRenderer {
     /**
      * draws the y-axis labels to the screen
      */
+    float[] positionsForRenderAxisLabels = new float[1];
     @Override
     public void renderAxisLabels(Canvas c) {
 
         if (!mYAxis.isEnabled() || !mYAxis.isDrawLabelsEnabled())
             return;
 
-        float[] positions = new float[mYAxis.mEntryCount * 2];
+        if(positionsForRenderAxisLabels.length <= mYAxis.mEntryCount * 2){
+            positionsForRenderAxisLabels = new float[mYAxis.mEntryCount * 4];
+        }
+        float[] positions = positionsForRenderAxisLabels;
 
-        for (int i = 0; i < positions.length; i += 2) {
+
+        for (int i = 0; i < mYAxis.mEntries.length; i += 2) {
             // only fill y values, x values are not needed since the y-labels
             // are
             // static on the x-axis
@@ -265,6 +274,8 @@ public class YAxisRenderer extends AxisRenderer {
         }
     }
 
+    Path pathForRenderGridLines = new Path();
+    float[] positionsForRenderGridLines = new float[2];
     @Override
     public void renderGridLines(Canvas c) {
 
@@ -272,7 +283,9 @@ public class YAxisRenderer extends AxisRenderer {
             return;
 
         // pre alloc
-        float[] position = new float[2];
+        float[] position = positionsForRenderGridLines;
+        position[0] = 0;
+        position[1] = 0;
 
         if (mYAxis.isDrawGridLinesEnabled()) {
 
@@ -280,7 +293,7 @@ public class YAxisRenderer extends AxisRenderer {
             mGridPaint.setStrokeWidth(mYAxis.getGridLineWidth());
             mGridPaint.setPathEffect(mYAxis.getGridDashPathEffect());
 
-            Path gridLinePath = new Path();
+            Path gridLinePath = pathForRenderGridLines;
 
             // draw the horizontal grid
             for (int i = 0; i < mYAxis.mEntryCount; i++) {

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/YAxisRendererHorizontalBarChart.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/YAxisRendererHorizontalBarChart.java
@@ -51,6 +51,9 @@ public class YAxisRendererHorizontalBarChart extends YAxisRenderer {
                 yMin = (float) p2.x;
                 yMax = (float) p1.x;
             }
+
+            PointD.recycleInstance(p1);
+            PointD.recycleInstance(p2);
         }
 
         computeAxisValues(yMin, yMax);

--- a/MPChartLib/src/com/github/mikephil/charting/utils/ObjectPool.java
+++ b/MPChartLib/src/com/github/mikephil/charting/utils/ObjectPool.java
@@ -1,0 +1,122 @@
+package com.github.mikephil.charting.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * An object pool for recycling of object instances implementing Poolable.
+ *
+ * Created by Tony Patino on 6/20/16.
+ */
+public class ObjectPool<T extends ObjectPool.Poolable> {
+
+    private static int ids = 0;
+
+    private int poolId;
+    private int desiredCapacity;
+    private Object[] objects;
+    private int objectsPointer;
+    private T modelObject;
+
+
+    public int getPoolId(){
+        return poolId;
+    }
+
+    public static synchronized ObjectPool create(int withCapacity, Poolable object){
+        ObjectPool result = new ObjectPool(withCapacity, object);
+        result.poolId = ids;
+        ids++;
+
+        return result;
+    }
+
+    private ObjectPool(int withCapacity, T object){
+        this.desiredCapacity = withCapacity;
+        this.objects = new Object[this.desiredCapacity];
+        this.objectsPointer = 0;
+        this.modelObject = object;
+        this.refillPool();
+    }
+
+    private void refillPool(){
+        for(int i = 0 ; i < desiredCapacity ; i++){
+            this.objects[i] = (T)modelObject.instantiate();
+        }
+        objectsPointer = this.desiredCapacity - 1;
+    }
+
+    public synchronized T get(){
+
+        if(this.objectsPointer == -1){
+            this.refillPool();
+        }
+
+        T result = (T)objects[this.objectsPointer];
+        result.currentOwnerId = Poolable.NO_OWNER;
+        this.objectsPointer--;
+
+        return result;
+    }
+
+    public synchronized void recycle(T object){
+        if(object.currentOwnerId != Poolable.NO_OWNER){
+            if(object.currentOwnerId == this.poolId){
+                throw new IllegalArgumentException("The object passed is already stored in this pool!");
+            }else {
+                throw new IllegalArgumentException("The object to recycle already belongs to poolId " + object.currentOwnerId + ".  Object cannot belong to two different pool instances simultaneously!");
+            }
+        }
+
+        this.objectsPointer++;
+        if(this.objectsPointer >= objects.length){
+            this.resizePool();
+        }
+
+        object.currentOwnerId = this.poolId;
+        objects[this.objectsPointer] = object;
+
+    }
+
+    public synchronized void recycle(List<T> objects){
+        while(objects.size() + this.objectsPointer + 1 > this.desiredCapacity){
+            this.resizePool();
+        }
+        final int objectsListSize = objects.size();
+
+        // Not relying on recycle(T object) because this is more performant.
+        for(int i = 0 ; i < objectsListSize ; i++){
+            T object = objects.get(i);
+            if(object.currentOwnerId != Poolable.NO_OWNER){
+                if(object.currentOwnerId == this.poolId){
+                    throw new IllegalArgumentException("The object passed is already stored in this pool!");
+                }else {
+                    throw new IllegalArgumentException("The object to recycle already belongs to poolId " + object.currentOwnerId + ".  Object cannot belong to two different pool instances simultaneously!");
+                }
+            }
+            object.currentOwnerId = this.poolId;
+            this.objects[this.objectsPointer + 1 + i] = object;
+        }
+        this.objectsPointer += objectsListSize;
+    }
+
+    private void resizePool() {
+        final int oldCapacity = this.desiredCapacity;
+        this.desiredCapacity *= 2;
+        Object[] temp = new Object[this.desiredCapacity];
+        for(int i = 0 ; i < oldCapacity ; i++){
+            temp[i] = this.objects[i];
+        }
+        this.objects = temp;
+    }
+
+
+    public static abstract class Poolable{
+
+        public static int NO_OWNER = -1;
+        int currentOwnerId = NO_OWNER;
+
+        abstract Poolable instantiate();
+
+    }
+}

--- a/MPChartLib/src/com/github/mikephil/charting/utils/PointD.java
+++ b/MPChartLib/src/com/github/mikephil/charting/utils/PointD.java
@@ -1,17 +1,44 @@
 
 package com.github.mikephil.charting.utils;
 
+import java.util.List;
+
 /**
  * Point encapsulating two double values.
  *
  * @author Philipp Jahoda
  */
-public class PointD {
+public class PointD extends ObjectPool.Poolable {
+
+    private static ObjectPool<PointD> pool;
+
+    static {
+        pool = ObjectPool.create(500, new PointD(0,0));
+    }
+
+    public static PointD getInstance(double x, double y){
+        PointD result = pool.get();
+        result.x = x;
+        result.y = y;
+        return result;
+    }
+
+    public static void recycleInstance(PointD instance){
+        pool.recycle(instance);
+    }
+
+    public static void recycleInstances(List<PointD> instances){
+        pool.recycle(instances);
+    }
 
     public double x;
     public double y;
 
-    public PointD(double x, double y) {
+    ObjectPool.Poolable instantiate(){
+        return new PointD(0,0);
+    }
+
+    private PointD(double x, double y) {
         this.x = x;
         this.y = y;
     }

--- a/MPChartLib/src/com/github/mikephil/charting/utils/Transformer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/utils/Transformer.java
@@ -398,9 +398,11 @@ public class Transformer {
      *
      * @param pixels
      */
+    final Matrix matrixForPixelsToValue = new Matrix();
     public void pixelsToValue(float[] pixels) {
 
-        Matrix tmp = new Matrix();
+        matrixForPixelsToValue.reset();
+        Matrix tmp = matrixForPixelsToValue;
 
         // invert all matrixes to convert back to the original value
         mMatrixOffset.invert(tmp);
@@ -423,10 +425,11 @@ public class Transformer {
      * @param y
      * @return
      */
+    float[] ptsForGetValuesByTouchPoint = new float[2];
     public PointD getValuesByTouchPoint(float x, float y) {
 
         // create an array of the touch-point
-        float[] pts = new float[2];
+        float[] pts = ptsForGetValuesByTouchPoint;
         pts[0] = x;
         pts[1] = y;
 
@@ -435,7 +438,7 @@ public class Transformer {
         double xTouchVal = pts[0];
         double yTouchVal = pts[1];
 
-        return new PointD(xTouchVal, yTouchVal);
+        return PointD.getInstance(xTouchVal, yTouchVal);
     }
 
     public Matrix getValueMatrix() {

--- a/MPChartLib/src/com/github/mikephil/charting/utils/Utils.java
+++ b/MPChartLib/src/com/github/mikephil/charting/utils/Utils.java
@@ -159,20 +159,26 @@ public abstract class Utils {
      * @param demoText
      * @return
      */
+    private static Rect rectForCalcTextHeight = new Rect();
     public static int calcTextHeight(Paint paint, String demoText) {
-
-        Rect r = new Rect();
+        Rect r = rectForCalcTextHeight;
+        r.set(0,0,0,0);
         paint.getTextBounds(demoText, 0, demoText.length(), r);
         return r.height();
     }
 
+
+    final static private Paint.FontMetrics fontMetricsLineHeight = new Paint.FontMetrics();
     public static float getLineHeight(Paint paint) {
-        Paint.FontMetrics metrics = paint.getFontMetrics();
+        paint.getFontMetrics(fontMetricsLineHeight);
+        Paint.FontMetrics metrics = fontMetricsLineHeight;
         return metrics.descent - metrics.ascent;
     }
 
+    final static private Paint.FontMetrics fontMetricsLineSpacing = new Paint.FontMetrics();
     public static float getLineSpacing(Paint paint) {
-        Paint.FontMetrics metrics = paint.getFontMetrics();
+        paint.getFontMetrics(fontMetricsLineSpacing);
+        Paint.FontMetrics metrics = fontMetricsLineSpacing;
         return metrics.ascent - metrics.top + metrics.bottom;
     }
 
@@ -188,7 +194,7 @@ public abstract class Utils {
 
         Rect r = new Rect();
         paint.getTextBounds(demoText, 0, demoText.length(), r);
-        return new FSize(r.width(), r.height());
+        return FSize.getInstance(r.width(), r.height());
     }
 
     /**
@@ -642,8 +648,10 @@ public abstract class Utils {
                         lineHeight,
                         angleDegrees);
 
-                translateX -= rotatedSize.width * (anchor.x - 0.5f);
-                translateY -= rotatedSize.height * (anchor.y - 0.5f);
+                translateX -= rotatedSize.getWidth() * (anchor.x - 0.5f);
+                translateY -= rotatedSize.getHeight() * (anchor.y - 0.5f);
+
+                FSize.recycleInstance(rotatedSize);
             }
 
             c.save();
@@ -712,8 +720,9 @@ public abstract class Utils {
                         drawHeight,
                         angleDegrees);
 
-                translateX -= rotatedSize.width * (anchor.x - 0.5f);
-                translateY -= rotatedSize.height * (anchor.y - 0.5f);
+                translateX -= rotatedSize.getWidth() * (anchor.x - 0.5f);
+                translateY -= rotatedSize.getHeight() * (anchor.y - 0.5f);
+                FSize.recycleInstance(rotatedSize);
             }
 
             c.save();
@@ -754,7 +763,7 @@ public abstract class Utils {
         StaticLayout textLayout = new StaticLayout(
                 text, 0, text.length(),
                 paint,
-                (int) Math.max(Math.ceil(constrainedToSize.width), 1.f),
+                (int) Math.max(Math.ceil(constrainedToSize.getWidth()), 1.f),
                 Layout.Alignment.ALIGN_NORMAL, 1.f, 0.f, false);
 
 
@@ -763,12 +772,12 @@ public abstract class Utils {
 
     public static FSize getSizeOfRotatedRectangleByDegrees(FSize rectangleSize, float degrees) {
         final float radians = degrees * FDEG2RAD;
-        return getSizeOfRotatedRectangleByRadians(rectangleSize.width, rectangleSize.height,
+        return getSizeOfRotatedRectangleByRadians(rectangleSize.getWidth(), rectangleSize.getHeight(),
                 radians);
     }
 
     public static FSize getSizeOfRotatedRectangleByRadians(FSize rectangleSize, float radians) {
-        return getSizeOfRotatedRectangleByRadians(rectangleSize.width, rectangleSize.height,
+        return getSizeOfRotatedRectangleByRadians(rectangleSize.getWidth(), rectangleSize.getHeight(),
                 radians);
     }
 
@@ -780,12 +789,10 @@ public abstract class Utils {
 
     public static FSize getSizeOfRotatedRectangleByRadians(float rectangleWidth, float
             rectangleHeight, float radians) {
-        return new FSize(
-                Math.abs(rectangleWidth * (float) Math.cos(radians)) + Math.abs(rectangleHeight *
+        return FSize.getInstance(Math.abs(rectangleWidth * (float) Math.cos(radians)) + Math.abs(rectangleHeight *
                         (float) Math.sin(radians)),
                 Math.abs(rectangleWidth * (float) Math.sin(radians)) + Math.abs(rectangleHeight *
-                        (float) Math.cos(radians))
-        );
+                        (float) Math.cos(radians)));
     }
 
     public static int getSDKInt() {

--- a/MPChartLib/src/com/github/mikephil/charting/utils/ViewPortHandler.java
+++ b/MPChartLib/src/com/github/mikephil/charting/utils/ViewPortHandler.java
@@ -338,9 +338,11 @@ public class ViewPortHandler {
      * @param view
      * @return save
      */
+    Matrix saveMatrixForCenterViewPort = new Matrix();
     public void centerViewPort(final float[] transformedPts, final View view) {
 
-        Matrix save = new Matrix();
+        Matrix save = saveMatrixForCenterViewPort;
+        save.reset();
         save.set(mMatrixTouch);
 
         final float x = transformedPts[0] - offsetLeft();


### PR DESCRIPTION
As detailed in ticket 1892, this change set implements many changes to reduce allocations during Realtime chart rendering.  Among the changes:

1. ValueFormatters getFormattedValue property now accepts an int position property to facilitate caching of formatted strings.

2. Many methods that instantiated temp variables now rely on instance-level fields instead, and only instantiate once.  Temp variables are reset instead of reinstantiated.

3. ObjectPool implemented for frequently instantiated value objects, such as PointD and FSize.
    NOTE: FSize is no longer truly immutable, but its fields are encapsulated with getters-only.  This is to facilitate pooling.  Field access would have faster performance, but I wanted to err on the side of keeping the class read-only as far as owners of an instance are concerned.

4. LineDataSet offers a getCircleColorCount() method, for use in caching of circle bitmaps.

5. Change convenience for:in arrays into for(;;) arrays.  Convenience array iteration has a memory cost, and allocates an object for each item in the List.

6. Caching of bitmap circles in the line chart renderer.  This makes ticket #1897 redundant (as well as its pull request).