### PR TITLE
PieChart#setCenterText does not work in subclass's init method

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/charts/PieChart.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/charts/PieChart.java
@@ -70,7 +70,7 @@ public class PieChart extends PieRadarChartBase<PieData> {
     /**
      * variable for the text that is drawn in the center of the pie-chart
      */
-    private CharSequence mCenterText = "";
+    private CharSequence mCenterText;
 
     private MPPointF mCenterTextOffset = MPPointF.getInstance(0, 0);
 

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/interfaces/dataprovider/ChartInterface.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/interfaces/dataprovider/ChartInterface.java
@@ -47,7 +47,7 @@ public interface ChartInterface {
     float getYChartMax();
 
     /**
-     * Returns the maximum distance in scren dp a touch can be away from an entry to cause it to get highlighted.
+     * Returns the maximum distance in screen dp a touch can be away from an entry to cause it to get highlighted.
      *
      * @return
      */


### PR DESCRIPTION
for example:

```java
public class MyPieChart extends PieChart {
  @Override
  protected void init() {
    super.init();
    setCenterText("hello world"); // -> does not work.
  } 
}
```