### PR TITLE
Fix for IndexOutOfBoundException of FormattedStringCache

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/formatter/FormattedStringCache.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/formatter/FormattedStringCache.java
@@ -6,59 +6,60 @@ import java.util.HashMap;
 
 /**
  * Created by Tony Patino on 6/29/16.
+ * <p>
+ * COST : Frequently the V type, and the K type will often be passed as primitives (float / int / double)
+ * This will incur an auto-boxing penalty, and an instantiation on each call.
+ * <p>
+ * BENEFIT : Formatting of Strings is one of the costliest operations remaining, and it is larger than the boxing penalty.
+ * Eliminating redundant formats helps more than boxing hurts.
+ * <p>
+ * Possibly want to make some explicit primitive enabled caches, though they can be ugly.
  *
- *      COST : Frequently the V type, and the K type will often be passed as primitives (float / int / double)
- *             This will incur an auto-boxing penalty, and an instantiation on each call.
- *
- *      BENEFIT : Formatting of Strings is one of the costliest operations remaining, and it is larger than the boxing penalty.
- *                Eliminating redundant formats helps more than boxing hurts.
- *
- *      Possibly want to make some explicit primitive enabled caches, though they can be ugly.
- *
+ * @author Lars Schütze <dev@larsschuteze.de>
+ *         Changed implementation slightly to circumvent issue #2083
  */
 public class FormattedStringCache {
 
     protected Format mFormat;
 
-    public Format getFormat(){
-        return mFormat;
-    }
-
-    public FormattedStringCache(Format format){
+    public FormattedStringCache(Format format) {
         this.mFormat = format;
     }
 
+    public Format getFormat() {
+        return mFormat;
+    }
 
     /**
      * Cache a Formatted String, derived from formatting value V in the Format passed to the constructor.
      * Use the object K as a way to quickly look up the string in the cache.
      * If value of V has changed since the last time the cache was accessed, re-format the string.
-     *
+     * <p>
      * NOTE: This version relies on auto-boxing of primitive values.  As a result, it has worse memory performance
      * than the Prim versions.
      *
      * @param <K>
      * @param <V>
      */
-    public static class Generic<K,V> extends FormattedStringCache{
+    public static class Generic<K, V> extends FormattedStringCache {
 
         private HashMap<K, String> mCachedStringsHashMap = new HashMap<>();
         private HashMap<K, V> mCachedValuesHashMap = new HashMap<>();
 
-        public Generic(Format format){
+        public Generic(Format format) {
             super(format);
         }
 
-        public String getFormattedValue(V value, K key){
+        public String getFormattedValue(V value, K key) {
 
             // If we can't find the value at all, create an entry for it, and format the string.
-            if(!mCachedValuesHashMap.containsKey(key)){
+            if (!mCachedValuesHashMap.containsKey(key)) {
                 mCachedStringsHashMap.put(key, mFormat.format(value));
                 mCachedValuesHashMap.put(key, value);
             }
 
             // If the old value and the new one don't match, format the string and store it, because the string's value will be different now.
-            if(!value.equals(mCachedValuesHashMap.get(key))){
+            if (!value.equals(mCachedValuesHashMap.get(key))) {
                 mCachedStringsHashMap.put(key, mFormat.format(value));
                 mCachedValuesHashMap.put(key, value);
             }
@@ -73,27 +74,25 @@ public class FormattedStringCache {
      * Cache a Formatted String, derived from formatting float value in the Format passed to the constructor.
      * Use the integer as a way to quickly look up the string in the cache.
      * If value of V has changed since the last time the cache was accessed, re-format the string.
-     *
      */
-    public static class PrimIntFloat extends FormattedStringCache{
-
-        public PrimIntFloat(Format format){
-            super(format);
-        }
+    public static class PrimIntFloat extends FormattedStringCache {
 
         private ArrayList<Float> cachedValues = new ArrayList<>();
         private ArrayList<String> cachedStrings = new ArrayList<>();
+        public PrimIntFloat(Format format) {
+            super(format);
+        }
 
         public String getFormattedValue(float value, int key) {
 
             boolean hasValueAtdataSetIndex = true;
-            if(cachedValues.size() <= key){
+            if (cachedValues.size() <= key) {
                 int p = key;
-                while(p >= 0){
-                    if(p == 0){
+                while (p >= 0) {
+                    if (p == 0) {
                         cachedValues.add(value);
                         cachedStrings.add("");
-                    }else{
+                    } else {
                         cachedValues.add(Float.NaN);
                         cachedStrings.add("");
                     }
@@ -102,12 +101,12 @@ public class FormattedStringCache {
                 hasValueAtdataSetIndex = false;
             }
 
-            if(hasValueAtdataSetIndex) {
+            if (hasValueAtdataSetIndex) {
                 Float cachedValue = cachedValues.get(key);
                 hasValueAtdataSetIndex = !(cachedValue == null || cachedValue != value);
             }
 
-            if(!hasValueAtdataSetIndex){
+            if (!hasValueAtdataSetIndex) {
                 cachedValues.set(key, value);
                 cachedStrings.set(key, mFormat.format(value));
             }
@@ -120,35 +119,22 @@ public class FormattedStringCache {
     /**
      * Cache a Formatted String, derived from formatting float value in the Format passed to the constructor.
      */
-    public static class PrimFloat extends FormattedStringCache{
+    public static class PrimFloat extends FormattedStringCache {
 
-        public PrimFloat(Format format){
+        private HashMap<Float, String> cachedValues = new HashMap<>();
+
+        public PrimFloat(Format format) {
             super(format);
         }
 
-
-        private ArrayList<Float> cachedValues = new ArrayList<>();
-        private ArrayList<String> cachedStrings = new ArrayList<>();
-
         public String getFormattedValue(float value) {
-
-            boolean alreadyHasValue = false;
-            int vCount =  cachedValues.size();
-            int sIndex = -1;
-            for(int i = 0 ; i < vCount ; i++){
-                if(cachedValues.get(i) == value){
-                    sIndex = i;
-                    alreadyHasValue = true;
-                    break;
-                }
+            Float boxedValue = new Float(value);
+            String result = cachedValues.get(boxedValue);
+            if (result == null) {
+                result = mFormat.format(boxedValue);
+                cachedValues.put(boxedValue, result);
             }
-            if(!alreadyHasValue) {
-                cachedValues.add(value);
-                cachedStrings.add(mFormat.format(value));
-                sIndex = cachedValues.size() - 1;
-            }
-
-            return cachedStrings.get(sIndex);
+            return result;
         }
 
     }
@@ -156,39 +142,22 @@ public class FormattedStringCache {
     /**
      * Cache a Formatted String, derived from formatting double value in the Format passed to the constructor.
      */
-    public static class PrimDouble extends FormattedStringCache{
+    public static class PrimDouble extends FormattedStringCache {
 
-        public PrimDouble(Format format){
+        private HashMap<Double, String> cachedValues = new HashMap<>();
+
+        public PrimDouble(Format format) {
             super(format);
         }
 
-
-        private ArrayList<Double> cachedValues = new ArrayList<>();
-        private ArrayList<String> cachedStrings = new ArrayList<>();
-
         public String getFormattedValue(double value) {
-
-            boolean alreadyHasValue = false;
-            int vCount =  cachedValues.size();
-            int sIndex = -1;
-            for(int i = 0 ; i < vCount ; i++){
-                if(cachedValues.get(i) == value){
-                    sIndex = i;
-                    alreadyHasValue = true;
-                    break;
-                }
+            Double boxedValue = new Double(value);
+            String result = cachedValues.get(boxedValue);
+            if (result == null) {
+                result = mFormat.format(boxedValue);
+                cachedValues.put(boxedValue, result);
             }
-            if(!alreadyHasValue) {
-                cachedValues.add(value);
-                cachedStrings.add(mFormat.format(value));
-                sIndex = cachedValues.size() - 1;
-            }
-
-            return cachedStrings.get(sIndex);
+            return result;
         }
-
     }
-
-
-
 }

--- a/MPChartLib/src/test/java/com/github/mikephil/charting/test/FormattedStringCacheTest.java
+++ b/MPChartLib/src/test/java/com/github/mikephil/charting/test/FormattedStringCacheTest.java
@@ -4,27 +4,24 @@ import com.github.mikephil.charting.formatter.FormattedStringCache;
 
 import junit.framework.Assert;
 
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
 
 /**
  * Created by Tony Patino on 6/30/16.
  */
 public class FormattedStringCacheTest {
 
+    private DecimalFormat decimalFormat;
+
     @Test
-    public void testPrimFloat(){
-        int digits = 2;
-
-        StringBuffer b = new StringBuffer();
-        for (int i = 0; i < digits; i++) {
-            if (i == 0)
-                b.append(".");
-            b.append("0");
-        }
-
-        FormattedStringCache.PrimFloat cache = new FormattedStringCache.PrimFloat(new DecimalFormat("###,###,###,##0" + b.toString()));
+    public void testPrimFloat() {
+        FormattedStringCache.PrimFloat cache = new FormattedStringCache.PrimFloat(decimalFormat);
 
         String s = null;
 
@@ -51,10 +48,10 @@ public class FormattedStringCacheTest {
 
         Assert.assertEquals("1.00", s);
 
-        for(int i = 0 ; i < 100 ; i++){
+        for (int i = 0; i < 100; i++) {
             float f = 0.75f + i;
             s = cache.getFormattedValue(f);
-            Assert.assertEquals(i+".75", s);
+            Assert.assertEquals(i + ".75", s);
         }
 
 
@@ -71,17 +68,8 @@ public class FormattedStringCacheTest {
     }
 
     @Test
-    public void testPrimDouble(){
-        int digits = 2;
-
-        StringBuffer b = new StringBuffer();
-        for (int i = 0; i < digits; i++) {
-            if (i == 0)
-                b.append(".");
-            b.append("0");
-        }
-
-        FormattedStringCache.PrimDouble cache = new FormattedStringCache.PrimDouble(new DecimalFormat("###,###,###,##0" + b.toString()));
+    public void testPrimDouble() {
+        FormattedStringCache.PrimDouble cache = new FormattedStringCache.PrimDouble(decimalFormat);
 
         String s = null;
 
@@ -108,10 +96,10 @@ public class FormattedStringCacheTest {
 
         Assert.assertEquals("1.00", s);
 
-        for(int i = 0 ; i < 100 ; i++){
+        for (int i = 0; i < 100; i++) {
             double f = 0.75f + i;
             s = cache.getFormattedValue(f);
-            Assert.assertEquals(i+".75", s);
+            Assert.assertEquals(i + ".75", s);
         }
 
 
@@ -128,18 +116,10 @@ public class FormattedStringCacheTest {
     }
 
     @Test
-    public void testPrimIntFloat(){
+    public void testPrimIntFloat() {
 
-        int digits = 2;
 
-        StringBuffer b = new StringBuffer();
-        for (int i = 0; i < digits; i++) {
-            if (i == 0)
-                b.append(".");
-            b.append("0");
-        }
-
-        FormattedStringCache.PrimIntFloat cache = new FormattedStringCache.PrimIntFloat(new DecimalFormat("###,###,###,##0" + b.toString()));
+        FormattedStringCache.PrimIntFloat cache = new FormattedStringCache.PrimIntFloat(decimalFormat);
 
         String s = null;
 
@@ -152,7 +132,7 @@ public class FormattedStringCacheTest {
         Assert.assertEquals("1.00", s);
 
 
-        s = cache.getFormattedValue(1.3f ,1);
+        s = cache.getFormattedValue(1.3f, 1);
 
         Assert.assertEquals("1.30", s);
 
@@ -171,10 +151,10 @@ public class FormattedStringCacheTest {
 
         Assert.assertEquals("1.00", s);
 
-        for(int i = 0 ; i < 100 ; i++){
+        for (int i = 0; i < 100; i++) {
             float f = 0.75f + i;
             s = cache.getFormattedValue(f, i);
-            Assert.assertEquals(i+".75", s);
+            Assert.assertEquals(i + ".75", s);
         }
 
 
@@ -209,17 +189,8 @@ public class FormattedStringCacheTest {
         Assert.assertEquals("1.31", s);
     }
 
-    @Test
-    public void testGenericKV(){
-
-        this.genericIntFloat();
-        this.genericDoubleFloat();
-        this.genericObjectFloat();
-    }
-
-    private void genericObjectFloat() {
-
-
+    @Before
+    public void initializeDecimalFormatter() {
         int digits = 2;
 
         StringBuffer b = new StringBuffer();
@@ -229,7 +200,22 @@ public class FormattedStringCacheTest {
             b.append("0");
         }
 
-        FormattedStringCache.Generic<Object, Float> cache = new FormattedStringCache.Generic<>(new DecimalFormat("###,###,###,##0" + b.toString()));
+        DecimalFormatSymbols otherSymbols = new DecimalFormatSymbols(Locale.US);
+        otherSymbols.setDecimalSeparator('.');
+        otherSymbols.setGroupingSeparator(',');
+        decimalFormat = new DecimalFormat("###,###,###,##0" + b.toString(), otherSymbols);
+    }
+
+    @Test
+    public void testGenericKV() {
+
+        this.genericIntFloat();
+        this.genericDoubleFloat();
+        this.genericObjectFloat();
+    }
+
+    private void genericObjectFloat() {
+        FormattedStringCache.Generic<Object, Float> cache = new FormattedStringCache.Generic<>(decimalFormat);
 
         String s = null;
 
@@ -265,19 +251,7 @@ public class FormattedStringCacheTest {
     }
 
     private void genericDoubleFloat() {
-
-
-
-        int digits = 2;
-
-        StringBuffer b = new StringBuffer();
-        for (int i = 0; i < digits; i++) {
-            if (i == 0)
-                b.append(".");
-            b.append("0");
-        }
-
-        FormattedStringCache.Generic<Double, Float> cache = new FormattedStringCache.Generic<>(new DecimalFormat("###,###,###,##0" + b.toString()));
+        FormattedStringCache.Generic<Double, Float> cache = new FormattedStringCache.Generic<>(decimalFormat);
 
         String s = null;
 
@@ -290,7 +264,7 @@ public class FormattedStringCacheTest {
         Assert.assertEquals("1.00", s);
 
 
-        s = cache.getFormattedValue(1.3f ,1d);
+        s = cache.getFormattedValue(1.3f, 1d);
 
         Assert.assertEquals("1.30", s);
 
@@ -309,10 +283,10 @@ public class FormattedStringCacheTest {
 
         Assert.assertEquals("1.00", s);
 
-        for(int i = 0 ; i < 100 ; i++){
+        for (int i = 0; i < 100; i++) {
             float f = 0.75f + i;
-            s = cache.getFormattedValue(f, (double)i);
-            Assert.assertEquals(i+".75", s);
+            s = cache.getFormattedValue(f, (double) i);
+            Assert.assertEquals(i + ".75", s);
         }
 
 
@@ -349,18 +323,7 @@ public class FormattedStringCacheTest {
     }
 
     private void genericIntFloat() {
-
-
-        int digits = 2;
-
-        StringBuffer b = new StringBuffer();
-        for (int i = 0; i < digits; i++) {
-            if (i == 0)
-                b.append(".");
-            b.append("0");
-        }
-
-        FormattedStringCache.Generic<Integer, Float> cache = new FormattedStringCache.Generic<>(new DecimalFormat("###,###,###,##0" + b.toString()));
+        FormattedStringCache.Generic<Integer, Float> cache = new FormattedStringCache.Generic<>(decimalFormat);
 
         String s = null;
 
@@ -373,7 +336,7 @@ public class FormattedStringCacheTest {
         Assert.assertEquals("1.00", s);
 
 
-        s = cache.getFormattedValue(1.3f ,1);
+        s = cache.getFormattedValue(1.3f, 1);
 
         Assert.assertEquals("1.30", s);
 
@@ -392,10 +355,10 @@ public class FormattedStringCacheTest {
 
         Assert.assertEquals("1.00", s);
 
-        for(int i = 0 ; i < 100 ; i++){
+        for (int i = 0; i < 100; i++) {
             float f = 0.75f + i;
             s = cache.getFormattedValue(f, i);
-            Assert.assertEquals(i+".75", s);
+            Assert.assertEquals(i + ".75", s);
         }
 
 


### PR DESCRIPTION
This pull request contains of a fixed version of `FormattedStringCache` and a fix of the respective test class.
`IndexOutOfBoundException` with FormattedStringCache classes have been reported in issue #2083 and #2070. 

### Problem description
The original version hold two `ArrayList` to store a mapping from a value to its formatted String representation. Therefore, the values where iterated to see if a value has already be seen before. The index calculated in the iteration is then used to access the formatted string cache. This resulted sometimes in an `IndexOutOfBoundsException`.

### Solution
 The fix is to use a `HashMap` to store the mapping. This reduces the time to find a value from O(n) to O(1). Furthermore, there are no more two data structures that have to be synced. On top of that the claimed avoidance of auto-boxing is now really forced.

The solution did not change any API. Just internal data structures have been changed.