### PR TITLE
Fixed Bug in LineChartRenderer

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineChartRenderer.java
@@ -252,8 +252,8 @@ public class LineChartRenderer extends LineRadarRenderer {
         float fillMin = dataSet.getFillFormatter()
                 .getFillLinePosition(dataSet, mChart);
 
-        spline.lineTo(bounds.min + bounds.range, fillMin);
-        spline.lineTo(bounds.min, fillMin);
+        spline.lineTo(dataSet.getEntryForIndex(mXBounds.max).getX(), fillMin);
+        spline.lineTo(dataSet.getEntryForIndex(mXBounds.min).getX(), fillMin);
         spline.close();
 
         trans.pathValueToPixel(spline);

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineChartRenderer.java
@@ -252,8 +252,8 @@ public class LineChartRenderer extends LineRadarRenderer {
         float fillMin = dataSet.getFillFormatter()
                 .getFillLinePosition(dataSet, mChart);
 
-        spline.lineTo(dataSet.getEntryForIndex(mXBounds.max).getX(), fillMin);
-        spline.lineTo(dataSet.getEntryForIndex(mXBounds.min).getX(), fillMin);
+        spline.lineTo(dataSet.getEntryForIndex(bounds.min + bounds.range).getX(), fillMin);
+        spline.lineTo(dataSet.getEntryForIndex(bounds.min).getX(), fillMin);
         spline.close();
 
         trans.pathValueToPixel(spline);


### PR DESCRIPTION
The LineChartRenderer didn't use x values to draw the cubic fill, but the x indices instead. This problem is fixed by my commit.