### PR TITLE
Remove nullcheck for known non-null variable

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/components/MarkerImage.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/components/MarkerImage.java
@@ -142,10 +142,10 @@ public class MarkerImage implements IMarker {
         float width = mSize.width;
         float height = mSize.height;
 
-        if (width == 0.f && mDrawable != null) {
+        if (width == 0.f) {
             width = mDrawable.getIntrinsicWidth();
         }
-        if (height == 0.f && mDrawable != null) {
+        if (height == 0.f) {
             height = mDrawable.getIntrinsicHeight();
         }
 


### PR DESCRIPTION
`mDrawable` is already checked for `null` in line 138 of the `draw(...)` method:

`if (mDrawable == null) return;`
