### PR TITLE
Pie chart, fix for small values appearing as background

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/PieChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/PieChartRenderer.java
@@ -263,15 +263,13 @@ public class PieChartRenderer extends DataRenderer {
 
                     mPathBuffer.reset();
 
-                    float arcStartPointX = 0.f, arcStartPointY = 0.f;
+                    float arcStartPointX = center.x + radius * (float) Math.cos(startAngleOuter * Utils.FDEG2RAD);
+                    float arcStartPointY = center.y + radius * (float) Math.sin(startAngleOuter * Utils.FDEG2RAD);
 
                     if (sweepAngleOuter % 360f <= Utils.FLOAT_EPSILON) {
                         // Android is doing "mod 360"
                         mPathBuffer.addCircle(center.x, center.y, radius, Path.Direction.CW);
                     } else {
-
-                        arcStartPointX = center.x + radius * (float) Math.cos(startAngleOuter * Utils.FDEG2RAD);
-                        arcStartPointY = center.y + radius * (float) Math.sin(startAngleOuter * Utils.FDEG2RAD);
 
                         mPathBuffer.moveTo(arcStartPointX, arcStartPointY);
 


### PR DESCRIPTION
This fix is so small values won't appear as "background" (which really is a huge circle) when slice space is used.
I've found out that because sweepAngleOuter is negative it gets set to 0 which then causes arcStartPointX and arcStartPointY not to be set. Both arcStartPointX and arcStartPointY are used in calculateMinimumRadiusForSpacedSlice which calculates huge negative value because of that, which is then turned into huge positive value in the next line.
In the end we end up with a tiny value creating huge circle that looks like a background.