### PR TITLE
Fix for default text size being set in PX instead of DP

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/components/ComponentBase.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/components/ComponentBase.java
@@ -36,7 +36,7 @@ public abstract class ComponentBase {
     /**
      * the text size of the labels
      */
-    protected float mTextSize = 10f;
+    protected float mTextSize = Utils.convertDpToPixel(10f);
 
     /**
      * the text color to use for the labels


### PR DESCRIPTION
The default text size in ComponentBase was defined as 10px instead of 10dp, which caused tiny text rendering and did not reflect the javadoc or the general behavior of setTextSize(...).