### PR TITLE
Set javadoc character encoding to utf8

### DIFF
--- a/MPChartLib/build.gradle
+++ b/MPChartLib/build.gradle
@@ -55,6 +55,7 @@ task sourcesJar(type: Jar) {
 }
 
 task javadoc(type: Javadoc) {
+    options.charSet = 'UTF-8'
     failOnError  false
     source = android.sourceSets.main.java.sourceFiles
     classpath += project.files(android.getBootClasspath().join(File.pathSeparator))


### PR DESCRIPTION
Fix https://github.com/PhilJay/MPAndroidChart/issues/2813 by setting [javadoc character encoding to utf8](http://stackoverflow.com/a/25917146/1413900 ).