### PR TITLE
#441 Fill not working

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineChartRenderer.java
@@ -481,7 +481,8 @@ public class LineChartRenderer extends LineRadarRenderer {
      */
     private void generateFilledPath(final ILineDataSet dataSet, final int startIndex, final int endIndex, final Path outputPath) {
 
-        final float fillMin = dataSet.getFillFormatter().getFillLinePosition(dataSet, mChart);
+        // TODO just to check my skills with git+gradle :)
+        final float fillMin = 30;//dataSet.getFillFormatter().getFillLinePosition(dataSet, mChart);
         final float phaseY = mAnimator.getPhaseY();
         final boolean isDrawSteppedEnabled = dataSet.getMode() == LineDataSet.Mode.STEPPED;
 
@@ -489,6 +490,8 @@ public class LineChartRenderer extends LineRadarRenderer {
         filled.reset();
 
         final Entry entry = dataSet.getEntryForIndex(startIndex);
+
+
 
         filled.moveTo(entry.getX(), fillMin);
         filled.lineTo(entry.getX(), entry.getY() * phaseY);

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineChartRenderer.java
@@ -500,11 +500,13 @@ public class LineChartRenderer extends LineRadarRenderer {
 
             currentEntry = dataSet.getEntryForIndex(x);
 
-            if (isDrawSteppedEnabled && previousEntry != null) {
-                filled.lineTo(currentEntry.getX(), previousEntry.getY() * phaseY);
-            }
+            if(!Float.isNaN(currentEntry.getY())) {
+                if (isDrawSteppedEnabled && previousEntry != null) {
+                    filled.lineTo(currentEntry.getX(), previousEntry.getY() * phaseY);
+                }
 
-            filled.lineTo(currentEntry.getX(), currentEntry.getY() * phaseY);
+                filled.lineTo(currentEntry.getX(), currentEntry.getY() * phaseY);
+            }
 
             previousEntry = currentEntry;
         }

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineChartRenderer.java
@@ -502,17 +502,15 @@ public class LineChartRenderer extends LineRadarRenderer {
         Entry currentEntry = null;
         Entry previousEntry = null;
         for (int x = sIdx + 1; x <= endIndex; x++) {
+            // Leave float.NaNs out
+            if(Float.isNaN(dataSet.getEntryForIndex(x).getY())) continue;
 
             currentEntry = dataSet.getEntryForIndex(x);
-
-            // Leave float.NaNs out
-            if(!Float.isNaN(currentEntry.getY())) {
-                if (isDrawSteppedEnabled && previousEntry != null) {
-                    filled.lineTo(currentEntry.getX(), previousEntry.getY() * phaseY);
-                }
-
-                filled.lineTo(currentEntry.getX(), currentEntry.getY() * phaseY);
+            if (isDrawSteppedEnabled && previousEntry != null) {
+                filled.lineTo(currentEntry.getX(), previousEntry.getY() * phaseY);
             }
+
+            filled.lineTo(currentEntry.getX(), currentEntry.getY() * phaseY);
 
             previousEntry = currentEntry;
         }

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineChartRenderer.java
@@ -481,17 +481,19 @@ public class LineChartRenderer extends LineRadarRenderer {
      */
     private void generateFilledPath(final ILineDataSet dataSet, final int startIndex, final int endIndex, final Path outputPath) {
 
-        // TODO just to check my skills with git+gradle :)
-        final float fillMin = 30;//dataSet.getFillFormatter().getFillLinePosition(dataSet, mChart);
+        final float fillMin = dataSet.getFillFormatter().getFillLinePosition(dataSet, mChart);
         final float phaseY = mAnimator.getPhaseY();
         final boolean isDrawSteppedEnabled = dataSet.getMode() == LineDataSet.Mode.STEPPED;
 
         final Path filled = outputPath;
         filled.reset();
 
-        final Entry entry = dataSet.getEntryForIndex(startIndex);
+        // Semirke: we must skip Float.NaNs first
+        int sIdx = startIndex;
+        while(Float.isNaN(dataSet.getEntryForIndex(sIdx).getY())
+            && sIdx < endIndex ) sIdx++;
 
-
+        final Entry entry = dataSet.getEntryForIndex(sIdx);
 
         filled.moveTo(entry.getX(), fillMin);
         filled.lineTo(entry.getX(), entry.getY() * phaseY);
@@ -499,10 +501,11 @@ public class LineChartRenderer extends LineRadarRenderer {
         // create a new path
         Entry currentEntry = null;
         Entry previousEntry = null;
-        for (int x = startIndex + 1; x <= endIndex; x++) {
+        for (int x = sIdx + 1; x <= endIndex; x++) {
 
             currentEntry = dataSet.getEntryForIndex(x);
 
+            // Leave float.NaNs out
             if(!Float.isNaN(currentEntry.getY())) {
                 if (isDrawSteppedEnabled && previousEntry != null) {
                     filled.lineTo(currentEntry.getX(), previousEntry.getY() * phaseY);
@@ -515,7 +518,7 @@ public class LineChartRenderer extends LineRadarRenderer {
         }
 
         // close up
-        if (currentEntry != null) {
+        if (currentEntry != null && !Float.isNaN(currentEntry.getY())) {
             filled.lineTo(currentEntry.getX(), fillMin);
         }
 


### PR DESCRIPTION
This pull request is a proposed to solve #441  (https://github.com/PhilJay/MPAndroidChart/issues/441)
Basically the vanishing fillings were caused by scattered Float.NaNs. 
I tested this solution with NaNs missing from the beginning, end and in  between, however, to much and scattered NaNs could maybe still render a graph useless. 

Ps: sorry for the in between commits, my git is a bit rusty... 