### PR TITLE
Implementation of equals() and hashcode() for class Entry

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/data/BaseEntry.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/data/BaseEntry.java
@@ -129,11 +129,19 @@ public abstract class BaseEntry {
         return false;
       }
 
-      if ((other.getData() != null && getData() == null) && !other.getData().equals(getData())) {
+      if (getData() != null && !getData().equals(other.getData())) {
         return false;
       }
 
-      if ((other.getIcon() != null && getIcon() != null) && !other.getIcon().equals(getIcon())) {
+      if (other.getData() != null && !other.getData().equals(getData())) {
+        return false;
+      }
+
+      if (getIcon() != null && !getIcon().equals(other.getIcon())) {
+        return false;
+      }
+
+      if (other.getIcon() != null && !other.getIcon().equals(getIcon())) {
         return false;
       }
 

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/data/BaseEntry.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/data/BaseEntry.java
@@ -2,6 +2,8 @@ package com.github.mikephil.charting.data;
 
 import android.graphics.drawable.Drawable;
 
+import com.github.mikephil.charting.utils.Utils;
+
 /**
  * Created by Philipp Jahoda on 02/06/16.
  */
@@ -94,4 +96,48 @@ public abstract class BaseEntry {
     public void setData(Object data) {
         this.mData = data;
     }
+
+    @Override
+    public int hashCode() {
+      int hashCode = 5;
+      int multiplier = 17;
+
+      hashCode = hashCode * multiplier + ((getY() == 0.0f) ? 0 : Float.floatToIntBits(getY()));
+      hashCode = hashCode * multiplier + ((getData() == null) ? 0 : getData().hashCode());
+      hashCode = hashCode * multiplier + ((getIcon() == null) ? 0 : getIcon().hashCode());
+
+      return hashCode;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (obj == null) {
+        return false;
+      }
+
+      if (obj == this) {
+        return true;
+      }
+
+      if (!getClass().isAssignableFrom(obj.getClass())) {
+        return false;
+      }
+
+      BaseEntry other = (BaseEntry) obj;
+
+      if (Math.abs(other.getY() - this.getY()) > Utils.FLOAT_EPSILON) {
+        return false;
+      }
+
+      if ((other.getData() != null && getData() == null) && !other.getData().equals(getData())) {
+        return false;
+      }
+
+      if ((other.getIcon() != null && getIcon() != null) && !other.getIcon().equals(getIcon())) {
+        return false;
+      }
+
+      return true;
+    }
+
 }

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/data/Entry.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/data/Entry.java
@@ -170,4 +170,45 @@ public class Entry extends BaseEntry implements Parcelable {
             return new Entry[size];
         }
     };
+
+
+
+  /**
+   * Check if another object <code>obj</code> is equal to this instance.
+   *
+   * @param obj The object "this" should be compared with.
+   * @return true if both objects are equal, false otherwise.
+   */
+    @Override
+    public boolean equals(Object obj) {
+        if (!super.equals(obj)) {
+            return false;
+        }
+
+        if (!obj.getClass().equals(getClass())) {
+            return false;
+        }
+
+        Entry other = (Entry) obj;
+
+        if (Math.abs(other.getX() - this.getX()) > Utils.FLOAT_EPSILON) {
+            return false;
+        }
+
+        return true;
+    }
+
+
+    /**
+   * Compute hashcode for Entry instance.
+   *
+   * @return The hashcode for this instance.
+   */
+  @Override
+    public int hashCode() {
+        int multiplier = 17;
+        int hashCode = super.hashCode();
+        hashCode = multiplier * hashCode + ((getX() == 0.0f) ? 0 : Float.floatToIntBits(getX()));
+        return hashCode;
+    }
 }

--- a/MPChartLib/src/test/java/com/github/mikephil/charting/test/EntryTest.java
+++ b/MPChartLib/src/test/java/com/github/mikephil/charting/test/EntryTest.java
@@ -1,0 +1,119 @@
+package com.github.mikephil.charting.test;
+
+import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.*;
+
+import com.github.mikephil.charting.data.Entry;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * This is a test class for {@link Entry}.
+ *
+ * @author patrick.kleindienst (@PaddySmalls)
+ */
+
+public class EntryTest {
+
+  @Test
+  public void testEntryInstanceIsEqualToItself() {
+    Entry entry = new Entry(0.0f, 0.0f);
+
+    assertThat(entry.equals(entry), is(true));
+  }
+
+  @Test
+  public void testTwoEmptyEntryInstancesAreEqual() {
+    Entry entry1 = new Entry();
+    Entry entry2 = new Entry();
+
+    assertThat(entry1.equals(entry2), is(true));
+  }
+
+  @Test
+  public void testEntriesWithSamePropValuesAreEqual() {
+    Entry entry1 = new Entry(1.0f, 0.0f);
+    Entry entry2 = new Entry(1.0f, 0.0f);
+
+    assertThat(entry1.equals(entry2), is(true));
+  }
+
+  @Test
+  public void testEntriesWithDifferentPropValuesAreNotEqual() {
+    // Different x value, same y value.
+    Entry entry1 = new Entry(1.0f, 0.0f);
+    Entry entry2 = new Entry(0.0f, 0.0f);
+
+    assertThat(entry1.equals(entry2), is(false));
+
+    // Same x value, different y value.
+    entry1 = new Entry(0.0f, 1.0f);
+    entry2 = new Entry(0.0f, 0.0f);
+
+    assertThat(entry1.equals(entry2), is(false));
+
+    // Different x and y value.
+    entry1 = new Entry(1.0f, 1.0f);
+    entry2 = new Entry(0.0f, 0.0f);
+
+    assertThat(entry1.equals(entry2), is(false));
+  }
+
+  @Test
+  public void testListsContainingEqualEntriesAreEqual() {
+    List<Entry> entries1 = new LinkedList<>();
+    entries1.addAll(Arrays.asList(new Entry(1.0f, 0.0f), new Entry(0.0f, 1.0f)));
+
+    List<Entry> entries2 = new LinkedList<>();
+    entries2.addAll(Arrays.asList(new Entry(1.0f, 0.0f), new Entry(0.0f, 1.0f)));
+
+    assertThat(entries1.equals(entries2), is(true));
+  }
+
+  @Test
+  public void testEmptyEntryProducesHashcodeDifferentFromZero() {
+    Entry entry = new Entry();
+
+    assertThat(entry.hashCode(), is(not(0)));
+  }
+
+  @Test
+  public void testSameEmptyEntryInstanceProducesSameHashcode() {
+    Entry entry = new Entry();
+
+    assertThat(entry.hashCode() == entry.hashCode(), equalTo(true));
+  }
+
+  @Test
+  public void testEntriesWithSamePropValuesProducesSameHashcode() {
+    Entry entry1 = new Entry(1.0f, 0.0f);
+    Entry entry2 = new Entry(1.0f, 0.0f);
+
+    assertThat(entry1.hashCode() == entry2.hashCode(), is(true));
+  }
+
+  @Test
+  public void testEntriesWithDifferentPropValuesProduceDifferentHashcodes() {
+    // Different x value, same y value.
+    Entry entry1 = new Entry(1.0f, 0.0f);
+    Entry entry2 = new Entry(0.0f, 0.0f);
+
+    assertThat(entry1.hashCode() == entry2.hashCode(), is(false));
+
+    // Same x value, different y value.
+    entry1 = new Entry(0.0f, 1.0f);
+    entry2 = new Entry(0.0f, 0.0f);
+
+    assertThat(entry1.hashCode() == entry2.hashCode(), is(false));
+
+    // Different x and y value.
+    entry1 = new Entry(0.0f, 1.0f);
+    entry2 = new Entry(1.0f, 0.0f);
+
+    assertThat(entry1.hashCode() == entry2.hashCode(), is(false));
+  }
+
+}


### PR DESCRIPTION
Hi,
I recently ran into into an issue when I implemented some unit tests for our university project ["Zeitfresser"](https://github.com/slipke/Zeitfresser). I had to LinkedLists containing two Entry instances with the exact same property values. However, comparing these two Lists always have me _false_ as a return value, since every call to _equals()_ on class _Entry_ is delegated to _Object_.
I thought that implementing these methods for _Entry_ and its base class _BaseEntry_ might be valuable not just for my own use case. Having and comparing Lists of Entries seems like a common scenario from my perspective. 
For the implementation of both methods, I followed common standards and best practices.
In oder to verify _equals()_ as well as _hashcode()_ work properly, I also added a test class _EntryTest_.  
This class covers the most basic cases for Entry comparison. Of course I also made sure that my changes don't break any other running tests.  

Cheers, Patrick