### PR TITLE
Fix for missing setters in getInstance method

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/jobs/AnimatedZoomJob.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/jobs/AnimatedZoomJob.java
@@ -33,6 +33,8 @@ public class AnimatedZoomJob extends AnimatedViewPortJob implements Animator.Ani
         result.view = v;
         result.xOrigin = xOrigin;
         result.yOrigin = yOrigin;
+        result.yAxis = axis;
+        result.xAxisRange = xAxisRange;
         result.resetAnimator();
         result.animator.setDuration(duration);
         return result;


### PR DESCRIPTION
The zoomAndCenterAnimated method in BarLineChartBase crashes with a NullPointer exception because the yAxis variable is null when onAnimationUpdate is called. The yAxis is null because of missing setters in the getInstance method of AnimatedZoomJob.