### PR TITLE
Use Property classes instead of reflection to handle animations

### DIFF
--- a/MPChartLib/build.gradle
+++ b/MPChartLib/build.gradle
@@ -8,7 +8,7 @@ android {
     buildToolsVersion '23.0.3'
     // resourcePrefix 'mpcht'
     defaultConfig {
-        minSdkVersion 9
+        minSdkVersion 14
         targetSdkVersion 24
         versionCode 3
         versionName '3.0.1'

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/animation/ChartAnimator.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/animation/ChartAnimator.java
@@ -3,7 +3,7 @@ package com.github.mikephil.charting.animation;
 
 import android.animation.ObjectAnimator;
 import android.animation.ValueAnimator.AnimatorUpdateListener;
-import android.annotation.SuppressLint;
+import android.util.Property;
 
 /**
  * Object responsible for all animations in the Chart. ANIMATIONS ONLY WORK FOR
@@ -56,11 +56,11 @@ public class ChartAnimator {
         if (android.os.Build.VERSION.SDK_INT < 11)
             return;
 
-        ObjectAnimator animatorY = ObjectAnimator.ofFloat(this, "phaseY", 0f, 1f);
+        ObjectAnimator animatorY = ObjectAnimator.ofFloat(this, PhaseYProperty.INSTANCE, 0f, 1f);
         animatorY.setInterpolator(easingY);
         animatorY.setDuration(
                 durationMillisY);
-        ObjectAnimator animatorX = ObjectAnimator.ofFloat(this, "phaseX", 0f, 1f);
+        ObjectAnimator animatorX = ObjectAnimator.ofFloat(this, PhaseXProperty.INSTANCE, 0f, 1f);
         animatorX.setInterpolator(easingX);
         animatorX.setDuration(
                 durationMillisX);
@@ -90,7 +90,7 @@ public class ChartAnimator {
         if (android.os.Build.VERSION.SDK_INT < 11)
             return;
 
-        ObjectAnimator animatorX = ObjectAnimator.ofFloat(this, "phaseX", 0f, 1f);
+        ObjectAnimator animatorX = ObjectAnimator.ofFloat(this, PhaseXProperty.INSTANCE, 0f, 1f);
         animatorX.setInterpolator(easing);
         animatorX.setDuration(durationMillis);
         animatorX.addUpdateListener(mListener);
@@ -110,7 +110,7 @@ public class ChartAnimator {
         if (android.os.Build.VERSION.SDK_INT < 11)
             return;
 
-        ObjectAnimator animatorY = ObjectAnimator.ofFloat(this, "phaseY", 0f, 1f);
+        ObjectAnimator animatorY = ObjectAnimator.ofFloat(this, PhaseYProperty.INSTANCE, 0f, 1f);
         animatorY.setInterpolator(easing);
         animatorY.setDuration(durationMillis);
         animatorY.addUpdateListener(mListener);
@@ -138,11 +138,11 @@ public class ChartAnimator {
         if (android.os.Build.VERSION.SDK_INT < 11)
             return;
 
-        ObjectAnimator animatorY = ObjectAnimator.ofFloat(this, "phaseY", 0f, 1f);
+        ObjectAnimator animatorY = ObjectAnimator.ofFloat(this, PhaseYProperty.INSTANCE, 0f, 1f);
         animatorY.setInterpolator(Easing.getEasingFunctionFromOption(easingY));
         animatorY.setDuration(
                 durationMillisY);
-        ObjectAnimator animatorX = ObjectAnimator.ofFloat(this, "phaseX", 0f, 1f);
+        ObjectAnimator animatorX = ObjectAnimator.ofFloat(this, PhaseXProperty.INSTANCE, 0f, 1f);
         animatorX.setInterpolator(Easing.getEasingFunctionFromOption(easingX));
         animatorX.setDuration(
                 durationMillisX);
@@ -172,7 +172,7 @@ public class ChartAnimator {
         if (android.os.Build.VERSION.SDK_INT < 11)
             return;
 
-        ObjectAnimator animatorX = ObjectAnimator.ofFloat(this, "phaseX", 0f, 1f);
+        ObjectAnimator animatorX = ObjectAnimator.ofFloat(this, PhaseXProperty.INSTANCE, 0f, 1f);
         animatorX.setInterpolator(Easing.getEasingFunctionFromOption(easing));
         animatorX.setDuration(durationMillis);
         animatorX.addUpdateListener(mListener);
@@ -192,7 +192,7 @@ public class ChartAnimator {
         if (android.os.Build.VERSION.SDK_INT < 11)
             return;
 
-        ObjectAnimator animatorY = ObjectAnimator.ofFloat(this, "phaseY", 0f, 1f);
+        ObjectAnimator animatorY = ObjectAnimator.ofFloat(this, PhaseYProperty.INSTANCE, 0f, 1f);
         animatorY.setInterpolator(Easing.getEasingFunctionFromOption(easing));
         animatorY.setDuration(durationMillis);
         animatorY.addUpdateListener(mListener);
@@ -217,10 +217,10 @@ public class ChartAnimator {
         if (android.os.Build.VERSION.SDK_INT < 11)
             return;
 
-        ObjectAnimator animatorY = ObjectAnimator.ofFloat(this, "phaseY", 0f, 1f);
+        ObjectAnimator animatorY = ObjectAnimator.ofFloat(this, PhaseYProperty.INSTANCE, 0f, 1f);
         animatorY.setDuration(
                 durationMillisY);
-        ObjectAnimator animatorX = ObjectAnimator.ofFloat(this, "phaseX", 0f, 1f);
+        ObjectAnimator animatorX = ObjectAnimator.ofFloat(this, PhaseXProperty.INSTANCE, 0f, 1f);
         animatorX.setDuration(
                 durationMillisX);
 
@@ -248,7 +248,7 @@ public class ChartAnimator {
         if (android.os.Build.VERSION.SDK_INT < 11)
             return;
 
-        ObjectAnimator animatorX = ObjectAnimator.ofFloat(this, "phaseX", 0f, 1f);
+        ObjectAnimator animatorX = ObjectAnimator.ofFloat(this, PhaseXProperty.INSTANCE, 0f, 1f);
         animatorX.setDuration(durationMillis);
         animatorX.addUpdateListener(mListener);
         animatorX.start();
@@ -266,7 +266,7 @@ public class ChartAnimator {
         if (android.os.Build.VERSION.SDK_INT < 11)
             return;
 
-        ObjectAnimator animatorY = ObjectAnimator.ofFloat(this, "phaseY", 0f, 1f);
+        ObjectAnimator animatorY = ObjectAnimator.ofFloat(this, PhaseYProperty.INSTANCE, 0f, 1f);
         animatorY.setDuration(durationMillis);
         animatorY.addUpdateListener(mListener);
         animatorY.start();
@@ -282,7 +282,7 @@ public class ChartAnimator {
     }
 
     /**
-     * This modifys the y-phase that is used to animate the values.
+     * This modifies the y-phase that is used to animate the values.
      *
      * @param phase
      */
@@ -300,11 +300,47 @@ public class ChartAnimator {
     }
 
     /**
-     * This modifys the x-phase that is used to animate the values.
+     * This modifies the x-phase that is used to animate the values.
      *
      * @param phase
      */
     public void setPhaseX(float phase) {
         mPhaseX = phase;
+    }
+
+    private static class PhaseYProperty extends Property<ChartAnimator, Float> {
+        private static final PhaseYProperty INSTANCE = new PhaseYProperty();
+        
+        private PhaseYProperty() {
+            super(Float.class, "phaseY");
+        }
+
+        @Override
+        public Float get(ChartAnimator object) {
+            return object.getPhaseY();
+        }
+
+        @Override
+        public void set(ChartAnimator object, Float value) {
+            object.setPhaseY(value);
+        }
+    }
+
+    private static class PhaseXProperty extends Property<ChartAnimator, Float> {
+        private static final PhaseXProperty INSTANCE = new PhaseXProperty();
+        
+        private PhaseXProperty() {
+            super(Float.class, "phaseX");
+        }
+
+        @Override
+        public Float get(ChartAnimator object) {
+            return object.getPhaseX();
+        }
+
+        @Override
+        public void set(ChartAnimator object, Float value) {
+            object.setPhaseX(value);
+        }
     }
 }

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/charts/PieRadarChartBase.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/charts/PieRadarChartBase.java
@@ -9,6 +9,7 @@ import android.content.Context;
 import android.graphics.RectF;
 import android.util.AttributeSet;
 import android.util.Log;
+import android.util.Property;
 import android.view.MotionEvent;
 
 import com.github.mikephil.charting.animation.Easing;
@@ -484,7 +485,7 @@ public abstract class PieRadarChartBase<T extends ChartData<? extends IDataSet<?
 
         setRotationAngle(fromangle);
 
-        ObjectAnimator spinAnimator = ObjectAnimator.ofFloat(this, "rotationAngle", fromangle,
+        ObjectAnimator spinAnimator = ObjectAnimator.ofFloat(this, RotationAngleProperty.INSTANCE, fromangle,
                 toangle);
         spinAnimator.setDuration(durationmillis);
         spinAnimator.setInterpolator(Easing.getEasingFunctionFromOption(easing));
@@ -497,5 +498,23 @@ public abstract class PieRadarChartBase<T extends ChartData<? extends IDataSet<?
             }
         });
         spinAnimator.start();
+    }
+
+    private static class RotationAngleProperty extends Property<PieRadarChartBase, Float> {
+        private static final RotationAngleProperty INSTANCE = new RotationAngleProperty();
+
+        private RotationAngleProperty() {
+            super(Float.class, "rotationAngle");
+        }
+
+        @Override
+        public Float get(PieRadarChartBase object) {
+            return object.getRotationAngle();
+        }
+
+        @Override
+        public void set(PieRadarChartBase object, Float value) {
+            object.setRotationAngle(value);
+        }
     }
 }

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/jobs/AnimatedViewPortJob.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/jobs/AnimatedViewPortJob.java
@@ -4,6 +4,7 @@ import android.animation.Animator;
 import android.animation.ObjectAnimator;
 import android.animation.ValueAnimator;
 import android.annotation.SuppressLint;
+import android.util.Property;
 import android.view.View;
 
 import com.github.mikephil.charting.utils.Transformer;
@@ -26,7 +27,7 @@ public abstract class AnimatedViewPortJob extends ViewPortJob implements ValueAn
         super(viewPortHandler, xValue, yValue, trans, v);
         this.xOrigin = xOrigin;
         this.yOrigin = yOrigin;
-        animator = ObjectAnimator.ofFloat(this, "phase", 0f, 1f);
+        animator = ObjectAnimator.ofFloat(this, PhaseProperty.INSTANCE, 0f, 1f);
         animator.setDuration(duration);
         animator.addUpdateListener(this);
         animator.addListener(this);
@@ -95,5 +96,23 @@ public abstract class AnimatedViewPortJob extends ViewPortJob implements ValueAn
     @Override
     public void onAnimationUpdate(ValueAnimator animation) {
 
+    }
+
+    private static final class PhaseProperty extends Property<AnimatedViewPortJob, Float> {
+        private static final PhaseProperty INSTANCE = new PhaseProperty();
+
+        private PhaseProperty() {
+            super(Float.class, "phase");
+        }
+
+        @Override
+        public Float get(AnimatedViewPortJob object) {
+            return object.getPhase();
+        }
+
+        @Override
+        public void set(AnimatedViewPortJob object, Float value) {
+            object.setPhase(value);
+        }
     }
 }


### PR DESCRIPTION
This should remove any necessity to declare ProGuard rules for this library as this removes the reflection lookup needed when animating the four different properties here that are currently specified by strings. The downside to this change is that the minimum SDK required for the library would need to change to 14.

I'm putting this out there in case changing the minimum SDK to 14 is acceptable.