### PR TITLE
Enable viewport rect bigger than chart by using scale

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/utils/ViewPortHandler.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/utils/ViewPortHandler.java
@@ -482,7 +482,7 @@ public class ViewPortHandler {
      */
     public void setMinimumScaleX(float xScale) {
 
-        if (xScale < 1f)
+        if (xScale <= 0.f)
             xScale = 1f;
 
         mMinScaleX = xScale;
@@ -513,7 +513,7 @@ public class ViewPortHandler {
      */
     public void setMinMaxScaleX(float minScaleX, float maxScaleX) {
 
-        if (minScaleX < 1f)
+        if (minScaleX <= 0.f)
             minScaleX = 1f;
 
         if (maxScaleX == 0.f)
@@ -532,7 +532,7 @@ public class ViewPortHandler {
      */
     public void setMinimumScaleY(float yScale) {
 
-        if (yScale < 1f)
+        if (yScale <= 0.f)
             yScale = 1f;
 
         mMinScaleY = yScale;
@@ -557,7 +557,7 @@ public class ViewPortHandler {
 
     public void setMinMaxScaleY(float minScaleY, float maxScaleY) {
 
-        if (minScaleY < 1f)
+        if (minScaleY <= 0.f)
             minScaleY = 1f;
 
         if (maxScaleY == 0.f)


### PR DESCRIPTION
Enables to set viewport rectangle as bigger than chart range by using
viewport scale.
Feature can be accessed by direct viewport handler manipulation.
In the current code it can be achived with setting mMaxScale < 1, but it
also blocks zomming in/out.
In order to unblock this feature, there is a need for change in
condition for mMinScale as to be possible to be smaller than 1 (but
bigger than 0 -> case 0 is infinite zoom out).

Users who manipulate viewport are expected to know what they are looking
for, so they shouldn't be limited to fixed zoom out value. This way
charts have option to set viewport rect outside chart range and keep
zoom availiability at the same time.