### PR TITLE
Use WeakHashMap instead of Hashmap (Fixes #2941)

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineChartRenderer.java
@@ -24,7 +24,7 @@ import com.github.mikephil.charting.utils.Utils;
 import com.github.mikephil.charting.utils.ViewPortHandler;
 
 import java.lang.ref.WeakReference;
-import java.util.HashMap;
+import java.util.WeakHashMap;
 import java.util.List;
 
 public class LineChartRenderer extends LineRadarRenderer {
@@ -596,7 +596,7 @@ public class LineChartRenderer extends LineRadarRenderer {
     /**
      * cache for the circle bitmaps of all datasets
      */
-    private HashMap<IDataSet, DataSetImageCache> mImageCaches = new HashMap<>();
+    private WeakHashMap<IDataSet, DataSetImageCache> mImageCaches = new WeakHashMap<>();
 
     /**
      * buffer for drawing the circles


### PR DESCRIPTION
As a HashMap, mImageCaches was not evicting unneeded entries, which could
gradually lead to running out of memory.

I tested this for about 2 hours with new data sets multiple times a second with no increase in heap.