### PR TITLE
Make LargeValueFormatter Locale aware / fixed corresponding Test 

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/formatter/LargeValueFormatter.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/formatter/LargeValueFormatter.java
@@ -6,6 +6,8 @@ import com.github.mikephil.charting.data.Entry;
 import com.github.mikephil.charting.utils.ViewPortHandler;
 
 import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.util.Locale;
 
 /**
  * Predefined value-formatter that formats large numbers in a pretty way.
@@ -23,12 +25,19 @@ public class LargeValueFormatter implements IValueFormatter, IAxisValueFormatter
     private static String[] SUFFIX = new String[]{
             "", "k", "m", "b", "t"
     };
+
+    private static final String PATTERN = "###E00";
     private static final int MAX_LENGTH = 5;
     private DecimalFormat mFormat;
     private String mText = "";
 
+    public LargeValueFormatter(final Locale locale) {
+        mFormat = (DecimalFormat) NumberFormat.getNumberInstance(locale);
+        mFormat.applyPattern(PATTERN);
+    }
+
     public LargeValueFormatter() {
-        mFormat = new DecimalFormat("###E00");
+        mFormat = new DecimalFormat(PATTERN);
     }
 
     /**

--- a/MPChartLib/src/test/java/com/github/mikephil/charting/test/LargeValueFormatterTest.java
+++ b/MPChartLib/src/test/java/com/github/mikephil/charting/test/LargeValueFormatterTest.java
@@ -4,6 +4,8 @@ import com.github.mikephil.charting.formatter.LargeValueFormatter;
 
 import org.junit.Test;
 
+import java.util.Locale;
+
 import static junit.framework.Assert.assertEquals;
 
 /**
@@ -14,7 +16,7 @@ public class LargeValueFormatterTest {
     @Test
     public void test() {
 
-        LargeValueFormatter formatter = new LargeValueFormatter();
+        LargeValueFormatter formatter = new LargeValueFormatter(Locale.ENGLISH);
 
         String result = formatter.getFormattedValue(5f, null);
         assertEquals("5", result);


### PR DESCRIPTION
In case that default Locale is not English but e.g. German, the LargeValueFormatterTest would fail due to expecting the result "5.5" but getting "5,5"!
This prevented building the project for german developers (and maybe in some other countries too).