### PR TITLE
Animations management, overlapping

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/animation/ChartAnimator.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/animation/ChartAnimator.java
@@ -50,7 +50,8 @@ public class ChartAnimator {
      * Animates the drawing / rendering of the chart on both x- and y-axis with
      * the specified animation time. If animate(...) is called, no further
      * calling of invalidate() is necessary to refresh the chart.
-     * If an animation is already running the chart will be redraw
+     * If an animation is already running the chart will be redraw from the point it stopped
+     * you can also force the restart by canceling the animation manually
      *
      * @param durationMillisX
      * @param durationMillisY
@@ -58,18 +59,45 @@ public class ChartAnimator {
      * @param easingY
      */
     public void animateXY(int durationMillisX, int durationMillisY, EasingFunction easingX,
-            EasingFunction easingY) {
+                          EasingFunction easingY) {
+        animateXY(durationMillisX, durationMillisY, easingX, easingY, false);
+    }
+
+    /**
+     * Animates the drawing / rendering of the chart on both x- and y-axis with
+     * the specified animation time. If animate(...) is called, no further
+     * calling of invalidate() is necessary to refresh the chart.
+     * You can force the restart of the chart with the 'forceRestart' params
+     *
+     * @param durationMillisX
+     * @param durationMillisY
+     * @param easingX
+     * @param easingY
+     * @param forceRestart
+     */
+    public void animateXY(int durationMillisX, int durationMillisY, EasingFunction easingX,
+            EasingFunction easingY, boolean forceRestart) {
 
         if (android.os.Build.VERSION.SDK_INT < 11)
             return;
 
+        float startingPhaseYValue = 0f;
+        if (!forceRestart && mPhaseY != 1f) {
+            startingPhaseYValue = mPhaseY;
+        }
+
+        float startingPhaseXValue = 0f;
+        if (!forceRestart && mPhaseX != 1f) {
+            startingPhaseXValue = mPhaseX;
+        }
+
         cancelAnimationXY();
 
-        animatorY = ObjectAnimator.ofFloat(this, "phaseY", 0f, 1f);
+        animatorY = ObjectAnimator.ofFloat(this, "phaseY", startingPhaseYValue, 1f);
         animatorY.setInterpolator(easingY);
         animatorY.setDuration(
                 durationMillisY);
-        animatorX = ObjectAnimator.ofFloat(this, "phaseX", 0f, 1f);
+        animatorX = ObjectAnimator.ofFloat(this, "phaseX", startingPhaseXValue, 1f);
         animatorX.setInterpolator(easingX);
         animatorX.setDuration(
                 durationMillisX);
@@ -90,19 +118,39 @@ public class ChartAnimator {
      * Animates the rendering of the chart on the x-axis with the specified
      * animation time. If animate(...) is called, no further calling of
      * invalidate() is necessary to refresh the chart.
-     * If an animation is already running the chart will be redraw
+     * If an animation is already running the chart will be redraw from the point it stopped
+     * you can also force the restart by canceling the animation manually
      *
      * @param durationMillis
      * @param easing
      */
     public void animateX(int durationMillis, EasingFunction easing) {
+        animateX(durationMillis, easing, false);
+    }
+
+    /**
+     * Animates the rendering of the chart on the x-axis with the specified
+     * animation time. If animate(...) is called, no further calling of
+     * invalidate() is necessary to refresh the chart.
+     * You can force the restart of the chart with the 'forceRestart' params
+     *
+     * @param durationMillis
+     * @param easing
+     * @param forceRestart
+     */
+    public void animateX(int durationMillis, EasingFunction easing, boolean forceRestart) {
 
         if (android.os.Build.VERSION.SDK_INT < 11)
             return;
 
+        float startingPhaseXValue = 0f;
+        if (!forceRestart && mPhaseX != 1f) {
+            startingPhaseXValue = mPhaseX;
+        }
+
         cancelAnimationX();
 
-        animatorX = ObjectAnimator.ofFloat(this, "phaseX", 0f, 1f);
+        animatorX = ObjectAnimator.ofFloat(this, "phaseX", startingPhaseXValue, 1f);
         animatorX.setInterpolator(easing);
         animatorX.setDuration(durationMillis);
         animatorX.addUpdateListener(mListener);
@@ -113,19 +161,39 @@ public class ChartAnimator {
      * Animates the rendering of the chart on the y-axis with the specified
      * animation time. If animate(...) is called, no further calling of
      * invalidate() is necessary to refresh the chart.
-     * If an animation is already running the chart will be redraw
+     * If an animation is already running the chart will be redraw from the point it stopped
+     * you can also force the restart by canceling the animation manually
      *
      * @param durationMillis
      * @param easing
      */
     public void animateY(int durationMillis, EasingFunction easing) {
+        animateY(durationMillis, easing, false);
+    }
+
+    /**
+     * Animates the rendering of the chart on the y-axis with the specified
+     * animation time. If animate(...) is called, no further calling of
+     * invalidate() is necessary to refresh the chart.
+     * You can force the restart of the chart with the 'forceRestart' params
+     *
+     * @param durationMillis
+     * @param easing
+     * @param forceRestart
+     */
+    public void animateY(int durationMillis, EasingFunction easing, boolean forceRestart) {
 
         if (android.os.Build.VERSION.SDK_INT < 11)
             return;
 
+        float startingPhaseYValue = 0f;
+        if (!forceRestart && mPhaseY != 1f) {
+            startingPhaseYValue = mPhaseY;
+        }
+
         cancelAnimationY();
 
-        animatorY = ObjectAnimator.ofFloat(this, "phaseY", 0f, 1f);
+        animatorY = ObjectAnimator.ofFloat(this, "phaseY", startingPhaseYValue, 1f);
         animatorY.setInterpolator(easing);
         animatorY.setDuration(durationMillis);
         animatorY.addUpdateListener(mListener);
@@ -141,7 +209,8 @@ public class ChartAnimator {
      * Animates the drawing / rendering of the chart on both x- and y-axis with
      * the specified animation time. If animate(...) is called, no further
      * calling of invalidate() is necessary to refresh the chart.
-     * If an animation is already running the chart will be redraw
+     * If an animation is already running the chart will be redraw from the point it stopped
+     * you can also force the restart by canceling the animation manually
      *
      * @param durationMillisX
      * @param durationMillisY
@@ -149,18 +218,44 @@ public class ChartAnimator {
      * @param easingY
      */
     public void animateXY(int durationMillisX, int durationMillisY, Easing.EasingOption easingX,
-            Easing.EasingOption easingY) {
+                          Easing.EasingOption easingY) {
+        animateXY(durationMillisX, durationMillisY, easingX, easingY, false);
+    }
+    /**
+     * Animates the drawing / rendering of the chart on both x- and y-axis with
+     * the specified animation time. If animate(...) is called, no further
+     * calling of invalidate() is necessary to refresh the chart.
+     * You can force the restart of the chart with the 'forceRestart' params
+     *
+     * @param durationMillisX
+     * @param durationMillisY
+     * @param easingX
+     * @param easingY
+     * @param forceRestart
+     */
+    public void animateXY(int durationMillisX, int durationMillisY, Easing.EasingOption easingX,
+            Easing.EasingOption easingY, boolean forceRestart) {
 
         if (android.os.Build.VERSION.SDK_INT < 11)
             return;
 
+        float startingPhaseYValue = 0f;
+        if (!forceRestart && mPhaseY != 1f) {
+            startingPhaseYValue = mPhaseY;
+        }
+
+        float startingPhaseXValue = 0f;
+        if (!forceRestart && mPhaseX != 1f) {
+            startingPhaseXValue = mPhaseX;
+        }
+
         cancelAnimationXY();
 
-        animatorY = ObjectAnimator.ofFloat(this, "phaseY", 0f, 1f);
+        animatorY = ObjectAnimator.ofFloat(this, "phaseY", startingPhaseYValue, 1f);
         animatorY.setInterpolator(Easing.getEasingFunctionFromOption(easingY));
         animatorY.setDuration(
                 durationMillisY);
-        animatorX = ObjectAnimator.ofFloat(this, "phaseX", 0f, 1f);
+        animatorX = ObjectAnimator.ofFloat(this, "phaseX", startingPhaseXValue, 1f);
         animatorX.setInterpolator(Easing.getEasingFunctionFromOption(easingX));
         animatorX.setDuration(
                 durationMillisX);
@@ -181,19 +276,39 @@ public class ChartAnimator {
      * Animates the rendering of the chart on the x-axis with the specified
      * animation time. If animate(...) is called, no further calling of
      * invalidate() is necessary to refresh the chart.
-     * If an animation is already running the chart will be redraw
+     * If an animation is already running the chart will be redraw from the point it stopped
+     * you can also force the restart by canceling the animation manually
      *
      * @param durationMillis
      * @param easing
      */
     public void animateX(int durationMillis, Easing.EasingOption easing) {
+        animateX(durationMillis, easing, false);
+    }
+
+    /**
+     * Animates the rendering of the chart on the x-axis with the specified
+     * animation time. If animate(...) is called, no further calling of
+     * invalidate() is necessary to refresh the chart.
+     * You can force the restart of the chart with the 'forceRestart' params
+     *
+     * @param durationMillis
+     * @param easing
+     * @param forceRestart
+     */
+    public void animateX(int durationMillis, Easing.EasingOption easing, boolean forceRestart) {
 
         if (android.os.Build.VERSION.SDK_INT < 11)
             return;
 
+        float startingPhaseXValue = 0f;
+        if (!forceRestart && mPhaseX != 1f) {
+            startingPhaseXValue = mPhaseX;
+        }
+
         cancelAnimationX();
 
-        animatorX = ObjectAnimator.ofFloat(this, "phaseX", 0f, 1f);
+        animatorX = ObjectAnimator.ofFloat(this, "phaseX", startingPhaseXValue, 1f);
         animatorX.setInterpolator(Easing.getEasingFunctionFromOption(easing));
         animatorX.setDuration(durationMillis);
         animatorX.addUpdateListener(mListener);
@@ -204,19 +319,39 @@ public class ChartAnimator {
      * Animates the rendering of the chart on the y-axis with the specified
      * animation time. If animate(...) is called, no further calling of
      * invalidate() is necessary to refresh the chart.
-     * If an animation is already running the chart will be redraw
+     * If an animation is already running the chart will be redraw from the point it stopped
+     * you can also force the restart by canceling the animation manually
      *
      * @param durationMillis
      * @param easing
      */
     public void animateY(int durationMillis, Easing.EasingOption easing) {
+        animateY(durationMillis, easing, false);
+    }
+
+    /**
+     * Animates the rendering of the chart on the y-axis with the specified
+     * animation time. If animate(...) is called, no further calling of
+     * invalidate() is necessary to refresh the chart.
+     * You can force the restart of the chart with the 'forceRestart' params
+     *
+     * @param durationMillis
+     * @param easing
+     * @param forceRestart
+     */
+    public void animateY(int durationMillis, Easing.EasingOption easing, boolean forceRestart) {
 
         if (android.os.Build.VERSION.SDK_INT < 11)
             return;
 
+        float startingPhaseYValue = 0f;
+        if (!forceRestart && mPhaseY != 1f) {
+            startingPhaseYValue = mPhaseY;
+        }
+
         cancelAnimationY();
 
-        animatorY = ObjectAnimator.ofFloat(this, "phaseY", 0f, 1f);
+        animatorY = ObjectAnimator.ofFloat(this, "phaseY", startingPhaseYValue, 1f);
         animatorY.setInterpolator(Easing.getEasingFunctionFromOption(easing));
         animatorY.setDuration(durationMillis);
         animatorY.addUpdateListener(mListener);
@@ -232,22 +367,47 @@ public class ChartAnimator {
      * Animates the drawing / rendering of the chart on both x- and y-axis with
      * the specified animation time. If animate(...) is called, no further
      * calling of invalidate() is necessary to refresh the chart.
-     * If an animation is already running the chart will be redraw
+     * If an animation is already running the chart will be redraw from the point it stopped
+     * you can also force the restart by canceling the animation manually
      *
      * @param durationMillisX
      * @param durationMillisY
      */
     public void animateXY(int durationMillisX, int durationMillisY) {
+        animateXY(durationMillisX, durationMillisY, false);
+    }
+
+    /**
+     * Animates the drawing / rendering of the chart on both x- and y-axis with
+     * the specified animation time. If animate(...) is called, no further
+     * calling of invalidate() is necessary to refresh the chart.
+     * You can force the restart of the chart with the 'forceRestart' params
+     *
+     * @param durationMillisX
+     * @param durationMillisY
+     * @param forceRestart
+     */
+    public void animateXY(int durationMillisX, int durationMillisY, boolean forceRestart) {
 
         if (android.os.Build.VERSION.SDK_INT < 11)
             return;
 
+        float startingPhaseYValue = 0f;
+        if (!forceRestart && mPhaseY != 1f) {
+            startingPhaseYValue = mPhaseY;
+        }
+
+        float startingPhaseXValue = 0f;
+        if (!forceRestart && mPhaseX != 1f) {
+            startingPhaseXValue = mPhaseX;
+        }
+
         cancelAnimationXY();
 
-        animatorY = ObjectAnimator.ofFloat(this, "phaseY", 0f, 1f);
+        animatorY = ObjectAnimator.ofFloat(this, "phaseY", startingPhaseYValue, 1f);
         animatorY.setDuration(
                 durationMillisY);
-        animatorX = ObjectAnimator.ofFloat(this, "phaseX", 0f, 1f);
+        animatorX = ObjectAnimator.ofFloat(this, "phaseX", startingPhaseXValue, 1f);
         animatorX.setDuration(
                 durationMillisX);
 
@@ -267,18 +427,37 @@ public class ChartAnimator {
      * Animates the rendering of the chart on the x-axis with the specified
      * animation time. If animate(...) is called, no further calling of
      * invalidate() is necessary to refresh the chart.
-     * If an animation is already running the chart will be redraw
+     * If an animation is already running the chart will be redraw from the point it stopped
+     * you can also force the restart by canceling the animation manually
      *
      * @param durationMillis
      */
     public void animateX(int durationMillis) {
+        animateX(durationMillis, false);
+    }
+
+    /**
+     * Animates the rendering of the chart on the x-axis with the specified
+     * animation time. If animate(...) is called, no further calling of
+     * invalidate() is necessary to refresh the chart.
+     * You can force the restart of the chart with the 'forceRestart' params
+     *
+     * @param durationMillis
+     * @param forceRestart
+     */
+    public void animateX(int durationMillis, boolean forceRestart) {
 
         if (android.os.Build.VERSION.SDK_INT < 11)
             return;
 
+        float startingPhaseXValue = 0f;
+        if (!forceRestart && mPhaseX != 1f) {
+            startingPhaseXValue = mPhaseX;
+        }
+
         cancelAnimationX();
 
-        animatorX = ObjectAnimator.ofFloat(this, "phaseX", 0f, 1f);
+        animatorX = ObjectAnimator.ofFloat(this, "phaseX", startingPhaseXValue, 1f);
         animatorX.setDuration(durationMillis);
         animatorX.addUpdateListener(mListener);
         animatorX.start();
@@ -288,18 +467,37 @@ public class ChartAnimator {
      * Animates the rendering of the chart on the y-axis with the specified
      * animation time. If animate(...) is called, no further calling of
      * invalidate() is necessary to refresh the chart.
-     * If an animation is already running the chart will be redraw
+     * If an animation is already running the chart will be redraw from the point it stopped
+     * you can also force the restart by canceling the animation manually
      *
      * @param durationMillis
      */
     public void animateY(int durationMillis) {
+        animateY(durationMillis, false);
+    }
+
+    /**
+     * Animates the rendering of the chart on the y-axis with the specified
+     * animation time. If animate(...) is called, no further calling of
+     * invalidate() is necessary to refresh the chart.
+     * You can force the restart of the chart with the 'forceRestart' params
+     *
+     * @param durationMillis
+     * @param forceRestart
+     */
+    public void animateY(int durationMillis, boolean forceRestart) {
 
         if (android.os.Build.VERSION.SDK_INT < 11)
             return;
 
+        float startingPhaseYValue = 0f;
+        if (!forceRestart && mPhaseY != 1f) {
+            startingPhaseYValue = mPhaseY;
+        }
+
         cancelAnimationY();
 
-        animatorY = ObjectAnimator.ofFloat(this, "phaseY", 0f, 1f);
+        animatorY = ObjectAnimator.ofFloat(this, "phaseY", startingPhaseYValue, 1f);
         animatorY.setDuration(durationMillis);
         animatorY.addUpdateListener(mListener);
         animatorY.start();

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/animation/ChartAnimator.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/animation/ChartAnimator.java
@@ -35,6 +35,12 @@ public class ChartAnimator {
     /** the phase that is animated and influences the drawn values on the x-axis */
     protected float mPhaseX = 1f;
 
+    /** the object animator which animate the values on the y-axis */
+    protected ObjectAnimator animatorY;
+
+    /** the object animator which animate the values on the x-axis */
+    protected ObjectAnimator animatorX;
+
     /**
      * ################ ################ ################ ################
      */
@@ -44,6 +50,7 @@ public class ChartAnimator {
      * Animates the drawing / rendering of the chart on both x- and y-axis with
      * the specified animation time. If animate(...) is called, no further
      * calling of invalidate() is necessary to refresh the chart.
+     * If an animation is already running the chart will be redraw
      *
      * @param durationMillisX
      * @param durationMillisY
@@ -56,11 +63,13 @@ public class ChartAnimator {
         if (android.os.Build.VERSION.SDK_INT < 11)
             return;
 
-        ObjectAnimator animatorY = ObjectAnimator.ofFloat(this, "phaseY", 0f, 1f);
+        cancelAnimationXY();
+
+        animatorY = ObjectAnimator.ofFloat(this, "phaseY", 0f, 1f);
         animatorY.setInterpolator(easingY);
         animatorY.setDuration(
                 durationMillisY);
-        ObjectAnimator animatorX = ObjectAnimator.ofFloat(this, "phaseX", 0f, 1f);
+        animatorX = ObjectAnimator.ofFloat(this, "phaseX", 0f, 1f);
         animatorX.setInterpolator(easingX);
         animatorX.setDuration(
                 durationMillisX);
@@ -81,6 +90,7 @@ public class ChartAnimator {
      * Animates the rendering of the chart on the x-axis with the specified
      * animation time. If animate(...) is called, no further calling of
      * invalidate() is necessary to refresh the chart.
+     * If an animation is already running the chart will be redraw
      *
      * @param durationMillis
      * @param easing
@@ -90,7 +100,9 @@ public class ChartAnimator {
         if (android.os.Build.VERSION.SDK_INT < 11)
             return;
 
-        ObjectAnimator animatorX = ObjectAnimator.ofFloat(this, "phaseX", 0f, 1f);
+        cancelAnimationX();
+
+        animatorX = ObjectAnimator.ofFloat(this, "phaseX", 0f, 1f);
         animatorX.setInterpolator(easing);
         animatorX.setDuration(durationMillis);
         animatorX.addUpdateListener(mListener);
@@ -101,6 +113,7 @@ public class ChartAnimator {
      * Animates the rendering of the chart on the y-axis with the specified
      * animation time. If animate(...) is called, no further calling of
      * invalidate() is necessary to refresh the chart.
+     * If an animation is already running the chart will be redraw
      *
      * @param durationMillis
      * @param easing
@@ -110,7 +123,9 @@ public class ChartAnimator {
         if (android.os.Build.VERSION.SDK_INT < 11)
             return;
 
-        ObjectAnimator animatorY = ObjectAnimator.ofFloat(this, "phaseY", 0f, 1f);
+        cancelAnimationY();
+
+        animatorY = ObjectAnimator.ofFloat(this, "phaseY", 0f, 1f);
         animatorY.setInterpolator(easing);
         animatorY.setDuration(durationMillis);
         animatorY.addUpdateListener(mListener);
@@ -126,6 +141,7 @@ public class ChartAnimator {
      * Animates the drawing / rendering of the chart on both x- and y-axis with
      * the specified animation time. If animate(...) is called, no further
      * calling of invalidate() is necessary to refresh the chart.
+     * If an animation is already running the chart will be redraw
      *
      * @param durationMillisX
      * @param durationMillisY
@@ -138,11 +154,13 @@ public class ChartAnimator {
         if (android.os.Build.VERSION.SDK_INT < 11)
             return;
 
-        ObjectAnimator animatorY = ObjectAnimator.ofFloat(this, "phaseY", 0f, 1f);
+        cancelAnimationXY();
+
+        animatorY = ObjectAnimator.ofFloat(this, "phaseY", 0f, 1f);
         animatorY.setInterpolator(Easing.getEasingFunctionFromOption(easingY));
         animatorY.setDuration(
                 durationMillisY);
-        ObjectAnimator animatorX = ObjectAnimator.ofFloat(this, "phaseX", 0f, 1f);
+        animatorX = ObjectAnimator.ofFloat(this, "phaseX", 0f, 1f);
         animatorX.setInterpolator(Easing.getEasingFunctionFromOption(easingX));
         animatorX.setDuration(
                 durationMillisX);
@@ -163,6 +181,7 @@ public class ChartAnimator {
      * Animates the rendering of the chart on the x-axis with the specified
      * animation time. If animate(...) is called, no further calling of
      * invalidate() is necessary to refresh the chart.
+     * If an animation is already running the chart will be redraw
      *
      * @param durationMillis
      * @param easing
@@ -172,7 +191,9 @@ public class ChartAnimator {
         if (android.os.Build.VERSION.SDK_INT < 11)
             return;
 
-        ObjectAnimator animatorX = ObjectAnimator.ofFloat(this, "phaseX", 0f, 1f);
+        cancelAnimationX();
+
+        animatorX = ObjectAnimator.ofFloat(this, "phaseX", 0f, 1f);
         animatorX.setInterpolator(Easing.getEasingFunctionFromOption(easing));
         animatorX.setDuration(durationMillis);
         animatorX.addUpdateListener(mListener);
@@ -183,6 +204,7 @@ public class ChartAnimator {
      * Animates the rendering of the chart on the y-axis with the specified
      * animation time. If animate(...) is called, no further calling of
      * invalidate() is necessary to refresh the chart.
+     * If an animation is already running the chart will be redraw
      *
      * @param durationMillis
      * @param easing
@@ -192,7 +214,9 @@ public class ChartAnimator {
         if (android.os.Build.VERSION.SDK_INT < 11)
             return;
 
-        ObjectAnimator animatorY = ObjectAnimator.ofFloat(this, "phaseY", 0f, 1f);
+        cancelAnimationY();
+
+        animatorY = ObjectAnimator.ofFloat(this, "phaseY", 0f, 1f);
         animatorY.setInterpolator(Easing.getEasingFunctionFromOption(easing));
         animatorY.setDuration(durationMillis);
         animatorY.addUpdateListener(mListener);
@@ -208,6 +232,7 @@ public class ChartAnimator {
      * Animates the drawing / rendering of the chart on both x- and y-axis with
      * the specified animation time. If animate(...) is called, no further
      * calling of invalidate() is necessary to refresh the chart.
+     * If an animation is already running the chart will be redraw
      *
      * @param durationMillisX
      * @param durationMillisY
@@ -217,10 +242,12 @@ public class ChartAnimator {
         if (android.os.Build.VERSION.SDK_INT < 11)
             return;
 
-        ObjectAnimator animatorY = ObjectAnimator.ofFloat(this, "phaseY", 0f, 1f);
+        cancelAnimationXY();
+
+        animatorY = ObjectAnimator.ofFloat(this, "phaseY", 0f, 1f);
         animatorY.setDuration(
                 durationMillisY);
-        ObjectAnimator animatorX = ObjectAnimator.ofFloat(this, "phaseX", 0f, 1f);
+        animatorX = ObjectAnimator.ofFloat(this, "phaseX", 0f, 1f);
         animatorX.setDuration(
                 durationMillisX);
 
@@ -240,6 +267,7 @@ public class ChartAnimator {
      * Animates the rendering of the chart on the x-axis with the specified
      * animation time. If animate(...) is called, no further calling of
      * invalidate() is necessary to refresh the chart.
+     * If an animation is already running the chart will be redraw
      *
      * @param durationMillis
      */
@@ -248,7 +276,9 @@ public class ChartAnimator {
         if (android.os.Build.VERSION.SDK_INT < 11)
             return;
 
-        ObjectAnimator animatorX = ObjectAnimator.ofFloat(this, "phaseX", 0f, 1f);
+        cancelAnimationX();
+
+        animatorX = ObjectAnimator.ofFloat(this, "phaseX", 0f, 1f);
         animatorX.setDuration(durationMillis);
         animatorX.addUpdateListener(mListener);
         animatorX.start();
@@ -258,6 +288,7 @@ public class ChartAnimator {
      * Animates the rendering of the chart on the y-axis with the specified
      * animation time. If animate(...) is called, no further calling of
      * invalidate() is necessary to refresh the chart.
+     * If an animation is already running the chart will be redraw
      *
      * @param durationMillis
      */
@@ -266,10 +297,77 @@ public class ChartAnimator {
         if (android.os.Build.VERSION.SDK_INT < 11)
             return;
 
-        ObjectAnimator animatorY = ObjectAnimator.ofFloat(this, "phaseY", 0f, 1f);
+        cancelAnimationY();
+
+        animatorY = ObjectAnimator.ofFloat(this, "phaseY", 0f, 1f);
         animatorY.setDuration(durationMillis);
         animatorY.addUpdateListener(mListener);
         animatorY.start();
+    }
+
+    /**
+     * Check if a animation on the x-axis is currently running
+     *
+     */
+    public boolean isAnimationXRunning() {
+        if (android.os.Build.VERSION.SDK_INT < 11)
+            return false;
+        return animatorX != null && animatorX.isStarted() && animatorX.isRunning();
+    }
+
+    /**
+     * Check if a animation on the Y-axis is currently running
+     *
+     */
+    public boolean isAnimationYRunning() {
+        if (android.os.Build.VERSION.SDK_INT < 11)
+            return false;
+        return animatorY != null && animatorY.isStarted() && animatorY.isRunning();
+    }
+
+    /**
+     *  Cancel the animation on the x-axis and on the y-axis.
+     *  No need to check if the animation is still running
+     *
+     */
+    public void cancelAnimationXY() {
+        if (android.os.Build.VERSION.SDK_INT < 11)
+            return;
+
+        cancelAnimationX();
+        cancelAnimationY();
+    }
+
+    /**
+     *  Cancel the animation on the x-axis.
+     *  No need to check if the animation is still running
+     *
+     */
+    public void cancelAnimationX() {
+        if (android.os.Build.VERSION.SDK_INT < 11)
+            return;
+
+        if (isAnimationXRunning()) {
+            animatorX.cancel();
+            animatorX = null;
+            mPhaseX = 1f;
+        }
+    }
+
+    /**
+     *  Cancel the animation on the y-axis.
+     *  No need to check if the animation is still running
+     *
+     */
+    public void cancelAnimationY() {
+        if (android.os.Build.VERSION.SDK_INT < 11)
+            return;
+
+        if (isAnimationYRunning()) {
+            animatorY.cancel();
+            animatorY = null;
+            mPhaseY = 1f;
+        }
     }
 
     /**

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/charts/Chart.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/charts/Chart.java
@@ -827,7 +827,8 @@ public abstract class Chart<T extends ChartData<? extends IDataSet<? extends Ent
     /**
      * Animates the drawing / rendering of the chart on both x- and y-axis with
      * the specified animation time. If animate(...) is called, no further
-     * calling of invalidate() is necessary to refresh the chart. ANIMATIONS
+     * calling of invalidate() is necessary to refresh the chart.
+     * If an animation is already running the chart will be redraw. ANIMATIONS
      * ONLY WORK FOR API LEVEL 11 (Android 3.0.x) AND HIGHER.
      *
      * @param durationMillisX
@@ -843,7 +844,8 @@ public abstract class Chart<T extends ChartData<? extends IDataSet<? extends Ent
     /**
      * Animates the rendering of the chart on the x-axis with the specified
      * animation time. If animate(...) is called, no further calling of
-     * invalidate() is necessary to refresh the chart. ANIMATIONS ONLY WORK FOR
+     * invalidate() is necessary to refresh the chart.
+     * If an animation is already running the chart will be redraw. ANIMATIONS ONLY WORK FOR
      * API LEVEL 11 (Android 3.0.x) AND HIGHER.
      *
      * @param durationMillis
@@ -856,7 +858,8 @@ public abstract class Chart<T extends ChartData<? extends IDataSet<? extends Ent
     /**
      * Animates the rendering of the chart on the y-axis with the specified
      * animation time. If animate(...) is called, no further calling of
-     * invalidate() is necessary to refresh the chart. ANIMATIONS ONLY WORK FOR
+     * invalidate() is necessary to refresh the chart.
+     * If an animation is already running the chart will be redraw. ANIMATIONS ONLY WORK FOR
      * API LEVEL 11 (Android 3.0.x) AND HIGHER.
      *
      * @param durationMillis
@@ -875,7 +878,8 @@ public abstract class Chart<T extends ChartData<? extends IDataSet<? extends Ent
     /**
      * Animates the drawing / rendering of the chart on both x- and y-axis with
      * the specified animation time. If animate(...) is called, no further
-     * calling of invalidate() is necessary to refresh the chart. ANIMATIONS
+     * calling of invalidate() is necessary to refresh the chart.
+     * If an animation is already running the chart will be redraw. ANIMATIONS
      * ONLY WORK FOR API LEVEL 11 (Android 3.0.x) AND HIGHER.
      *
      * @param durationMillisX
@@ -891,7 +895,8 @@ public abstract class Chart<T extends ChartData<? extends IDataSet<? extends Ent
     /**
      * Animates the rendering of the chart on the x-axis with the specified
      * animation time. If animate(...) is called, no further calling of
-     * invalidate() is necessary to refresh the chart. ANIMATIONS ONLY WORK FOR
+     * invalidate() is necessary to refresh the chart.
+     * If an animation is already running the chart will be redraw. ANIMATIONS ONLY WORK FOR
      * API LEVEL 11 (Android 3.0.x) AND HIGHER.
      *
      * @param durationMillis
@@ -904,7 +909,8 @@ public abstract class Chart<T extends ChartData<? extends IDataSet<? extends Ent
     /**
      * Animates the rendering of the chart on the y-axis with the specified
      * animation time. If animate(...) is called, no further calling of
-     * invalidate() is necessary to refresh the chart. ANIMATIONS ONLY WORK FOR
+     * invalidate() is necessary to refresh the chart.
+     * If an animation is already running the chart will be redraw. ANIMATIONS ONLY WORK FOR
      * API LEVEL 11 (Android 3.0.x) AND HIGHER.
      *
      * @param durationMillis
@@ -923,7 +929,8 @@ public abstract class Chart<T extends ChartData<? extends IDataSet<? extends Ent
     /**
      * Animates the rendering of the chart on the x-axis with the specified
      * animation time. If animate(...) is called, no further calling of
-     * invalidate() is necessary to refresh the chart. ANIMATIONS ONLY WORK FOR
+     * invalidate() is necessary to refresh the chart.
+     * If an animation is already running the chart will be redraw. ANIMATIONS ONLY WORK FOR
      * API LEVEL 11 (Android 3.0.x) AND HIGHER.
      *
      * @param durationMillis
@@ -935,7 +942,8 @@ public abstract class Chart<T extends ChartData<? extends IDataSet<? extends Ent
     /**
      * Animates the rendering of the chart on the y-axis with the specified
      * animation time. If animate(...) is called, no further calling of
-     * invalidate() is necessary to refresh the chart. ANIMATIONS ONLY WORK FOR
+     * invalidate() is necessary to refresh the chart.
+     * If an animation is already running the chart will be redraw. ANIMATIONS ONLY WORK FOR
      * API LEVEL 11 (Android 3.0.x) AND HIGHER.
      *
      * @param durationMillis
@@ -947,7 +955,8 @@ public abstract class Chart<T extends ChartData<? extends IDataSet<? extends Ent
     /**
      * Animates the drawing / rendering of the chart on both x- and y-axis with
      * the specified animation time. If animate(...) is called, no further
-     * calling of invalidate() is necessary to refresh the chart. ANIMATIONS
+     * calling of invalidate() is necessary to refresh the chart.
+     * If an animation is already running the chart will be redraw. ANIMATIONS
      * ONLY WORK FOR API LEVEL 11 (Android 3.0.x) AND HIGHER.
      *
      * @param durationMillisX
@@ -955,6 +964,42 @@ public abstract class Chart<T extends ChartData<? extends IDataSet<? extends Ent
      */
     public void animateXY(int durationMillisX, int durationMillisY) {
         mAnimator.animateXY(durationMillisX, durationMillisY);
+    }
+
+    /**
+     * ################ ################ ################ ################
+     * ANIMATIONS ONLY WORK FOR API LEVEL 11 (Android 3.0.x) AND HIGHER.
+     */
+    /** CODE BELOW FOR PROVIDING cancelable animation */
+
+    /**
+     * Cancel the animation on the x-axis.
+     * No need to check if the animation is still running. ANIMATIONS
+     * ONLY WORK FOR API LEVEL 11 (Android 3.0.x) AND HIGHER.
+     *
+     */
+    public void cancelAnimationX() {
+        mAnimator.cancelAnimationX();
+    }
+
+    /**
+     * Cancel the animation on the y-axis.
+     * No need to check if the animation is still running. ANIMATIONS
+     * ONLY WORK FOR API LEVEL 11 (Android 3.0.x) AND HIGHER.
+     *
+     */
+    public void cancelAnimationY() {
+        mAnimator.cancelAnimationY();
+    }
+
+    /**
+     * Cancel the animation on the x-axis and y-axis.
+     * No need to check if the animation is still running. ANIMATIONS
+     * ONLY WORK FOR API LEVEL 11 (Android 3.0.x) AND HIGHER.
+     *
+     */
+    public void cancelAnimationXY() {
+        mAnimator.cancelAnimationXY();
     }
 
     /**

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/charts/Chart.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/charts/Chart.java
@@ -828,7 +828,8 @@ public abstract class Chart<T extends ChartData<? extends IDataSet<? extends Ent
      * Animates the drawing / rendering of the chart on both x- and y-axis with
      * the specified animation time. If animate(...) is called, no further
      * calling of invalidate() is necessary to refresh the chart.
-     * If an animation is already running the chart will be redraw. ANIMATIONS
+     * If an animation is already running the chart will be redraw from the point it stopped
+     * you can also force the restart by canceling the animation manually. ANIMATIONS
      * ONLY WORK FOR API LEVEL 11 (Android 3.0.x) AND HIGHER.
      *
      * @param durationMillisX
@@ -842,10 +843,28 @@ public abstract class Chart<T extends ChartData<? extends IDataSet<? extends Ent
     }
 
     /**
+     * Animates the drawing / rendering of the chart on both x- and y-axis with
+     * the specified animation time. If animate(...) is called, no further
+     * calling of invalidate() is necessary to refresh the chart. ANIMATIONS
+     * ONLY WORK FOR API LEVEL 11 (Android 3.0.x) AND HIGHER.
+     *
+     * @param durationMillisX
+     * @param durationMillisY
+     * @param easingX         a custom easing function to be used on the animation phase
+     * @param easingY         a custom easing function to be used on the animation phase
+     * @param forceRestart    force the restart from the beginning of the animations if the a previous one is still running
+     */
+    public void animateXY(int durationMillisX, int durationMillisY, EasingFunction easingX,
+                          EasingFunction easingY, boolean forceRestart) {
+        mAnimator.animateXY(durationMillisX, durationMillisY, easingX, easingY, forceRestart);
+    }
+
+    /**
      * Animates the rendering of the chart on the x-axis with the specified
      * animation time. If animate(...) is called, no further calling of
      * invalidate() is necessary to refresh the chart.
-     * If an animation is already running the chart will be redraw. ANIMATIONS ONLY WORK FOR
+     * If an animation is already running the chart will be redraw from the point it stopped
+     * you can also force the restart by canceling the animation manually. ANIMATIONS ONLY WORK FOR
      * API LEVEL 11 (Android 3.0.x) AND HIGHER.
      *
      * @param durationMillis
@@ -856,10 +875,25 @@ public abstract class Chart<T extends ChartData<? extends IDataSet<? extends Ent
     }
 
     /**
+     * Animates the rendering of the chart on the x-axis with the specified
+     * animation time. If animate(...) is called, no further calling of
+     * invalidate() is necessary to refresh the chart. ANIMATIONS ONLY WORK FOR
+     * API LEVEL 11 (Android 3.0.x) AND HIGHER.
+     *
+     * @param durationMillis
+     * @param easing         a custom easing function to be used on the animation phase
+     * @param forceRestart    force the restart from the beginning of the animations if the a previous one is still running
+     */
+    public void animateX(int durationMillis, EasingFunction easing, boolean forceRestart) {
+        mAnimator.animateX(durationMillis, easing, forceRestart);
+    }
+
+    /**
      * Animates the rendering of the chart on the y-axis with the specified
      * animation time. If animate(...) is called, no further calling of
      * invalidate() is necessary to refresh the chart.
-     * If an animation is already running the chart will be redraw. ANIMATIONS ONLY WORK FOR
+     * If an animation is already running the chart will be redraw from the point it stopped
+     * you can also force the restart by canceling the animation manually. ANIMATIONS ONLY WORK FOR
      * API LEVEL 11 (Android 3.0.x) AND HIGHER.
      *
      * @param durationMillis
@@ -867,6 +901,20 @@ public abstract class Chart<T extends ChartData<? extends IDataSet<? extends Ent
      */
     public void animateY(int durationMillis, EasingFunction easing) {
         mAnimator.animateY(durationMillis, easing);
+    }
+
+    /**
+     * Animates the rendering of the chart on the y-axis with the specified
+     * animation time. If animate(...) is called, no further calling of
+     * invalidate() is necessary to refresh the chart. ANIMATIONS ONLY WORK FOR
+     * API LEVEL 11 (Android 3.0.x) AND HIGHER.
+     *
+     * @param durationMillis
+     * @param easing         a custom easing function to be used on the animation phase
+     * @param forceRestart    force the restart from the beginning of the animations if the a previous one is still running
+     */
+    public void animateY(int durationMillis, EasingFunction easing, boolean forceRestart) {
+        mAnimator.animateY(durationMillis, easing, forceRestart);
     }
 
     /**
@@ -879,7 +927,8 @@ public abstract class Chart<T extends ChartData<? extends IDataSet<? extends Ent
      * Animates the drawing / rendering of the chart on both x- and y-axis with
      * the specified animation time. If animate(...) is called, no further
      * calling of invalidate() is necessary to refresh the chart.
-     * If an animation is already running the chart will be redraw. ANIMATIONS
+     * If an animation is already running the chart will be redraw from the point it stopped
+     * you can also force the restart by canceling the animation manually. ANIMATIONS
      * ONLY WORK FOR API LEVEL 11 (Android 3.0.x) AND HIGHER.
      *
      * @param durationMillisX
@@ -893,10 +942,28 @@ public abstract class Chart<T extends ChartData<? extends IDataSet<? extends Ent
     }
 
     /**
+     * Animates the drawing / rendering of the chart on both x- and y-axis with
+     * the specified animation time. If animate(...) is called, no further
+     * calling of invalidate() is necessary to refresh the chart. ANIMATIONS
+     * ONLY WORK FOR API LEVEL 11 (Android 3.0.x) AND HIGHER.
+     *
+     * @param durationMillisX
+     * @param durationMillisY
+     * @param easingX         a predefined easing option
+     * @param easingY         a predefined easing option
+     * @param forceRestart    force the restart from the beginning of the animations if the a previous one is still running
+     */
+    public void animateXY(int durationMillisX, int durationMillisY, Easing.EasingOption easingX,
+                          Easing.EasingOption easingY, boolean forceRestart) {
+        mAnimator.animateXY(durationMillisX, durationMillisY, easingX, easingY, forceRestart);
+    }
+
+    /**
      * Animates the rendering of the chart on the x-axis with the specified
      * animation time. If animate(...) is called, no further calling of
      * invalidate() is necessary to refresh the chart.
-     * If an animation is already running the chart will be redraw. ANIMATIONS ONLY WORK FOR
+     * If an animation is already running the chart will be redraw from the point it stopped
+     * you can also force the restart by canceling the animation manually. ANIMATIONS ONLY WORK FOR
      * API LEVEL 11 (Android 3.0.x) AND HIGHER.
      *
      * @param durationMillis
@@ -907,10 +974,25 @@ public abstract class Chart<T extends ChartData<? extends IDataSet<? extends Ent
     }
 
     /**
+     * Animates the rendering of the chart on the x-axis with the specified
+     * animation time. If animate(...) is called, no further calling of
+     * invalidate() is necessary to refresh the chart. ANIMATIONS ONLY WORK FOR
+     * API LEVEL 11 (Android 3.0.x) AND HIGHER.
+     *
+     * @param durationMillis
+     * @param easing         a predefined easing option
+     * @param forceRestart    force the restart from the beginning of the animations if the a previous one is still running
+     */
+    public void animateX(int durationMillis, Easing.EasingOption easing, boolean forceRestart) {
+        mAnimator.animateX(durationMillis, easing, forceRestart);
+    }
+
+    /**
      * Animates the rendering of the chart on the y-axis with the specified
      * animation time. If animate(...) is called, no further calling of
      * invalidate() is necessary to refresh the chart.
-     * If an animation is already running the chart will be redraw. ANIMATIONS ONLY WORK FOR
+     * If an animation is already running the chart will be redraw from the point it stopped
+     * you can also force the restart by canceling the animation manually. ANIMATIONS ONLY WORK FOR
      * API LEVEL 11 (Android 3.0.x) AND HIGHER.
      *
      * @param durationMillis
@@ -918,6 +1000,20 @@ public abstract class Chart<T extends ChartData<? extends IDataSet<? extends Ent
      */
     public void animateY(int durationMillis, Easing.EasingOption easing) {
         mAnimator.animateY(durationMillis, easing);
+    }
+
+    /**
+     * Animates the rendering of the chart on the y-axis with the specified
+     * animation time. If animate(...) is called, no further calling of
+     * invalidate() is necessary to refresh the chart. ANIMATIONS ONLY WORK FOR
+     * API LEVEL 11 (Android 3.0.x) AND HIGHER.
+     *
+     * @param durationMillis
+     * @param easing         a predefined easing option
+     * @param forceRestart    force the restart from the beginning of the animations if the a previous one is still running
+     */
+    public void animateY(int durationMillis, Easing.EasingOption easing, boolean forceRestart) {
+        mAnimator.animateY(durationMillis, easing, forceRestart);
     }
 
     /**
@@ -930,7 +1026,8 @@ public abstract class Chart<T extends ChartData<? extends IDataSet<? extends Ent
      * Animates the rendering of the chart on the x-axis with the specified
      * animation time. If animate(...) is called, no further calling of
      * invalidate() is necessary to refresh the chart.
-     * If an animation is already running the chart will be redraw. ANIMATIONS ONLY WORK FOR
+     * If an animation is already running the chart will be redraw from the point it stopped
+     * you can also force the restart by canceling the animation manually. ANIMATIONS ONLY WORK FOR
      * API LEVEL 11 (Android 3.0.x) AND HIGHER.
      *
      * @param durationMillis
@@ -940,10 +1037,24 @@ public abstract class Chart<T extends ChartData<? extends IDataSet<? extends Ent
     }
 
     /**
+     * Animates the rendering of the chart on the x-axis with the specified
+     * animation time. If animate(...) is called, no further calling of
+     * invalidate() is necessary to refresh the chart. ANIMATIONS ONLY WORK FOR
+     * API LEVEL 11 (Android 3.0.x) AND HIGHER.
+     *
+     * @param durationMillis
+     * @param forceRestart    force the restart from the beginning of the animations if the a previous one is still running
+     */
+    public void animateX(int durationMillis, boolean forceRestart) {
+        mAnimator.animateX(durationMillis, forceRestart);
+    }
+
+    /**
      * Animates the rendering of the chart on the y-axis with the specified
      * animation time. If animate(...) is called, no further calling of
      * invalidate() is necessary to refresh the chart.
-     * If an animation is already running the chart will be redraw. ANIMATIONS ONLY WORK FOR
+     * If an animation is already running the chart will be redraw from the point it stopped
+     * you can also force the restart by canceling the animation manually. ANIMATIONS ONLY WORK FOR
      * API LEVEL 11 (Android 3.0.x) AND HIGHER.
      *
      * @param durationMillis
@@ -953,10 +1064,24 @@ public abstract class Chart<T extends ChartData<? extends IDataSet<? extends Ent
     }
 
     /**
+     * Animates the rendering of the chart on the y-axis with the specified
+     * animation time. If animate(...) is called, no further calling of
+     * invalidate() is necessary to refresh the chart. ANIMATIONS ONLY WORK FOR
+     * API LEVEL 11 (Android 3.0.x) AND HIGHER.
+     *
+     * @param durationMillis
+     * @param forceRestart    force the restart from the beginning of the animations if the a previous one is still running
+     */
+    public void animateY(int durationMillis, boolean forceRestart) {
+        mAnimator.animateY(durationMillis, forceRestart);
+    }
+
+    /**
      * Animates the drawing / rendering of the chart on both x- and y-axis with
      * the specified animation time. If animate(...) is called, no further
      * calling of invalidate() is necessary to refresh the chart.
-     * If an animation is already running the chart will be redraw. ANIMATIONS
+     * If an animation is already running the chart will be redraw from the point it stopped
+     * you can also force the restart by canceling the animation manually. ANIMATIONS
      * ONLY WORK FOR API LEVEL 11 (Android 3.0.x) AND HIGHER.
      *
      * @param durationMillisX
@@ -964,6 +1089,20 @@ public abstract class Chart<T extends ChartData<? extends IDataSet<? extends Ent
      */
     public void animateXY(int durationMillisX, int durationMillisY) {
         mAnimator.animateXY(durationMillisX, durationMillisY);
+    }
+
+    /**
+     * Animates the drawing / rendering of the chart on both x- and y-axis with
+     * the specified animation time. If animate(...) is called, no further
+     * calling of invalidate() is necessary to refresh the chart. ANIMATIONS
+     * ONLY WORK FOR API LEVEL 11 (Android 3.0.x) AND HIGHER.
+     *
+     * @param durationMillisX
+     * @param durationMillisY
+     * @param forceRestart    force the restart from the beginning of the animations if the a previous one is still running
+     */
+    public void animateXY(int durationMillisX, int durationMillisY, boolean forceRestart) {
+        mAnimator.animateXY(durationMillisX, durationMillisY, forceRestart);
     }
 
     /**


### PR DESCRIPTION
Hi,

I have encounter the same problem as k-misztal in the issue #2220.
So basically I made the change.

Now if you change the animations options of a chart the previous animations will not overlap the second one.

Exemple :
```
mChart.animateX(10000);
    new Handler().postDelayed(new Runnable() {
    @Override
    public void run() {
        mChart.animateX(1000, true);
    }
}, 4000);
```
In the case of my application I just had a long animation, and the user had the possibility to switch theirs data. So the two animation are overlapping.


By default, the second animation will continue at the same point that the first one stopped.
You can also force the restart of the full animation by passing 'true' in the last parameters of all the functions (animateX, animateY, animateXY). Or you can manually cancel the animation by calling 

`myChart.cancelAnimationXY();`


All the previous methods signatures are conserved.
The default behaviour is now to continue from the point it stopped and not to overlap all the animations.

Florian.


