### PR TITLE
Fix spacing between horizontal legend and x-axis

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/charts/BarLineChartBase.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/charts/BarLineChartBase.java
@@ -426,18 +426,12 @@ public abstract class BarLineChartBase<T extends BarLineScatterCandleBubbleData<
                             offsets.top += Math.min(mLegend.mNeededHeight,
                                     mViewPortHandler.getChartHeight() * mLegend.getMaxSizePercent())
                                     + mLegend.getYOffset();
-
-                            if (getXAxis().isEnabled() && getXAxis().isDrawLabelsEnabled())
-                                offsets.top += getXAxis().mLabelRotatedHeight;
                             break;
 
                         case BOTTOM:
                             offsets.bottom += Math.min(mLegend.mNeededHeight,
                                     mViewPortHandler.getChartHeight() * mLegend.getMaxSizePercent())
                                     + mLegend.getYOffset();
-
-                            if (getXAxis().isEnabled() && getXAxis().isDrawLabelsEnabled())
-                                offsets.bottom += getXAxis().mLabelRotatedHeight;
                             break;
 
                         default:


### PR DESCRIPTION
The position of horizontal legend is incorrect because the height of X-axis is added twice.
When X-axis labels were rotated, large space will appear above the legend like this:
![barchart](https://cloud.githubusercontent.com/assets/3753969/25275362/e19efe42-26cf-11e7-870b-312e90aee8e6.png)

This commit fixes the issue.
The legend will be displayed too close to X-axis labels, but it would be another issue.
It seems that no property specifies spacing between the legend and axis.
In LegendRenderer#renderLegend(), yOffset of Legend is used as the margin from the outer edge of the chart.