### PR TITLE
AxisRenderer: Tweaked label interval normalization

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/AxisRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/AxisRenderer.java
@@ -167,16 +167,20 @@ public abstract class AxisRenderer extends Renderer {
 
         // If granularity is enabled, then do not allow the interval to go below specified granularity.
         // This is used to avoid repeated values when rounding values for display.
-        if (mAxis.isGranularityEnabled())
-            interval = interval < mAxis.getGranularity() ? mAxis.getGranularity() : interval;
-
-        // Normalize interval
-        double intervalMagnitude = Utils.roundToNextSignificant(Math.pow(10, (int) Math.log10(interval)));
-        int intervalSigDigit = (int) (interval / intervalMagnitude);
-        if (intervalSigDigit > 5) {
-            // Use one order of magnitude higher, to avoid intervals like 0.9 or
-            // 90
-            interval = Math.floor(10 * intervalMagnitude);
+        if (mAxis.isGranularityEnabled() && interval < mAxis.getGranularity())
+        {
+            interval = mAxis.getGranularity();
+        }
+        else
+        {
+            // Normalize interval
+            double intervalMagnitude = Utils.roundToNextSignificant(Math.pow(10, (int) Math.log10(interval)));
+            int intervalSigDigit = (int) (interval / intervalMagnitude);
+            if (intervalSigDigit > 5) {
+                // Use one order of magnitude higher, to avoid intervals like 0.9 or
+                // 90
+                interval = Math.floor(10 * intervalMagnitude);
+            }
         }
 
         int n = mAxis.isCenterAxisLabelsEnabled() ? 1 : 0;


### PR DESCRIPTION
Made this slight tweak in a project I was working on today. I had a granularity of 60000 (1 minute), but because of the normalization, labels were still being printed with an interval of 100000. I changed it so if the target interval is below the granularity value, it'll skip the normalization step. This allowed the labels to align with my data points when zoomed all the way in, which were also spaced one every 60000. Probably other ways to achieve that result, and this one won't work for irregularly spaced points or X values that aren't multiples of the granularity, but I don't think this one will cause any further issues in those cases.