### PR TITLE
Fix null pointer exception in draw markers

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/charts/Chart.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/charts/Chart.java
@@ -726,6 +726,8 @@ public abstract class Chart<T extends ChartData<? extends IDataSet<? extends Ent
             Highlight highlight = mIndicesToHighlight[i];
 
             IDataSet set = mData.getDataSetByIndex(highlight.getDataSetIndex());
+			if (set == null) 
+				continue;
 
             Entry e = mData.getEntryForHighlight(mIndicesToHighlight[i]);
             int entryIndex = set.getEntryIndex(e);

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineChartRenderer.java
@@ -495,7 +495,7 @@ public class LineChartRenderer extends LineRadarRenderer {
 
         // create a new path
         Entry currentEntry = null;
-        Entry previousEntry = null;
+        Entry previousEntry = entry;
         for (int x = startIndex + 1; x <= endIndex; x++) {
 
             currentEntry = dataSet.getEntryForIndex(x);


### PR DESCRIPTION
Fixed this issue: https://github.com/PhilJay/MPAndroidChart/issues/2917

We get crashes from our customers, but we are not able to reproduce the issues. Added a null check, for the variable set, which can be null.