### PR TITLE
Prevents empty legend from adding meaningless extra spaces.

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LegendRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LegendRenderer.java
@@ -101,18 +101,21 @@ public class LegendRenderer extends Renderer {
                     String[] sLabels = bds.getStackLabels();
 
                     for (int j = 0; j < clrs.size() && j < bds.getStackSize(); j++) {
-
-                        computedEntries.add(new LegendEntry(
-                                sLabels[j % sLabels.length],
-                                dataSet.getForm(),
-                                dataSet.getFormSize(),
-                                dataSet.getFormLineWidth(),
-                                dataSet.getFormLineDashEffect(),
-                                clrs.get(j)
-                        ));
+                        String label = sLabels[j % sLabels.length];
+                        if (dataSet.getForm() != Legend.LegendForm.NONE
+                                || (label != null && label.length() > 0)) {
+                            computedEntries.add(new LegendEntry(
+                                    label,
+                                    dataSet.getForm(),
+                                    dataSet.getFormSize(),
+                                    dataSet.getFormLineWidth(),
+                                    dataSet.getFormLineDashEffect(),
+                                    clrs.get(j)
+                            ));
+                        }
                     }
 
-                    if (bds.getLabel() != null) {
+                    if (bds.getLabel() != null && bds.getLabel().length() > 0) {
                         // add the legend description label
                         computedEntries.add(new LegendEntry(
                                 dataSet.getLabel(),
@@ -129,18 +132,21 @@ public class LegendRenderer extends Renderer {
                     IPieDataSet pds = (IPieDataSet) dataSet;
 
                     for (int j = 0; j < clrs.size() && j < entryCount; j++) {
-
-                        computedEntries.add(new LegendEntry(
-                                pds.getEntryForIndex(j).getLabel(),
-                                dataSet.getForm(),
-                                dataSet.getFormSize(),
-                                dataSet.getFormLineWidth(),
-                                dataSet.getFormLineDashEffect(),
-                                clrs.get(j)
-                        ));
+                        String label = pds.getEntryForIndex(j).getLabel();
+                        if (dataSet.getForm() != Legend.LegendForm.NONE
+                                || (label != null && label.length() > 0)) {
+                            computedEntries.add(new LegendEntry(
+                                    label,
+                                    dataSet.getForm(),
+                                    dataSet.getFormSize(),
+                                    dataSet.getFormLineWidth(),
+                                    dataSet.getFormLineDashEffect(),
+                                    clrs.get(j)
+                            ));
+                        }
                     }
 
-                    if (pds.getLabel() != null) {
+                    if (pds.getLabel() != null && pds.getLabel().length() > 0) {
                         // add the legend description label
                         computedEntries.add(new LegendEntry(
                                 dataSet.getLabel(),
@@ -158,23 +164,26 @@ public class LegendRenderer extends Renderer {
                     int decreasingColor = ((ICandleDataSet) dataSet).getDecreasingColor();
                     int increasingColor = ((ICandleDataSet) dataSet).getIncreasingColor();
 
-                    computedEntries.add(new LegendEntry(
-                            null,
-                            dataSet.getForm(),
-                            dataSet.getFormSize(),
-                            dataSet.getFormLineWidth(),
-                            dataSet.getFormLineDashEffect(),
-                            decreasingColor
-                    ));
+                    if (dataSet.getForm() != Legend.LegendForm.NONE
+                            || (dataSet.getLabel() != null && dataSet.getLabel().length() > 0)) {
+                        computedEntries.add(new LegendEntry(
+                                null,
+                                dataSet.getForm(),
+                                dataSet.getFormSize(),
+                                dataSet.getFormLineWidth(),
+                                dataSet.getFormLineDashEffect(),
+                                decreasingColor
+                        ));
 
-                    computedEntries.add(new LegendEntry(
-                            dataSet.getLabel(),
-                            dataSet.getForm(),
-                            dataSet.getFormSize(),
-                            dataSet.getFormLineWidth(),
-                            dataSet.getFormLineDashEffect(),
-                            increasingColor
-                    ));
+                        computedEntries.add(new LegendEntry(
+                                dataSet.getLabel(),
+                                dataSet.getForm(),
+                                dataSet.getFormSize(),
+                                dataSet.getFormLineWidth(),
+                                dataSet.getFormLineDashEffect(),
+                                increasingColor
+                        ));
+                    }
 
                 } else { // all others
 
@@ -189,14 +198,17 @@ public class LegendRenderer extends Renderer {
                             label = data.getDataSetByIndex(i).getLabel();
                         }
 
-                        computedEntries.add(new LegendEntry(
-                                label,
-                                dataSet.getForm(),
-                                dataSet.getFormSize(),
-                                dataSet.getFormLineWidth(),
-                                dataSet.getFormLineDashEffect(),
-                                clrs.get(j)
-                        ));
+                        if (dataSet.getForm() != Legend.LegendForm.NONE
+                                || (label != null && label.length() > 0)) {
+                            computedEntries.add(new LegendEntry(
+                                    label,
+                                    dataSet.getForm(),
+                                    dataSet.getFormSize(),
+                                    dataSet.getFormLineWidth(),
+                                    dataSet.getFormLineDashEffect(),
+                                    clrs.get(j)
+                            ));
+                        }
                     }
                 }
             }


### PR DESCRIPTION
The width of the empty legend will be zero, but extra margin spaces will still be added.
As a result, meaningless wide blank area may appear before/between non-empty legends.

For example, here is some code that adds 20 data series to a LineChart.
The first 19 data series have no label and no form, and only the last data series has a label and form.

```java
    ArrayList<ILineDataSet> dataSets = new ArrayList<>();
    for (int i = 0; i < 20; i++) {
        String label = (i == 19) ? "Test Data" : null;
        LineDataSet set = new LineDataSet(seriesDataCollection.get(i), label);
        if (label == null) {
            set.setForm(LegendForm.NONE);
        }

        //
        // set LineDataSet's properties...
        //

        dataSets.add(set);
    }

    LineData data = new LineData(dataSets);
    mChart.setData(data);
```
The result is:
![example1](https://user-images.githubusercontent.com/3753969/27016960-81a4fee8-4f5f-11e7-9598-8e7128c0df9c.png)
Expected result is:
![example2](https://user-images.githubusercontent.com/3753969/27016962-92c383d4-4f5f-11e7-8af2-da38bfc029e8.png)

This pull request would resolve the above issue. The empty legends that have no label and no form will not be added to the legend list.