### PR TITLE
Fix for crash we were getting when using MPAndroidChart library

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/data/DataSet.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/data/DataSet.java
@@ -283,7 +283,7 @@ public abstract class DataSet<T extends Entry> extends BaseDataSet<T> {
 
     @Override
     public T getEntryForIndex(int index) {
-		if(index<0)
+	if(index<0)
             return null;
         if(index>=mValues.size())
             return null;

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/data/DataSet.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/data/DataSet.java
@@ -283,6 +283,10 @@ public abstract class DataSet<T extends Entry> extends BaseDataSet<T> {
 
     @Override
     public T getEntryForIndex(int index) {
+		if(index<0)
+            return null;
+        if(index>=mValues.size())
+            return null;
         return mValues.get(index);
     }
 


### PR DESCRIPTION
Hey, this may be very little but from the crash reports we were getting there was a couple of crashes in this method. Usually array out of bounds exception