### PR TITLE
Fix an Activity leak

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/jobs/MoveViewJob.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/jobs/MoveViewJob.java
@@ -30,6 +30,7 @@ public class MoveViewJob extends ViewPortJob {
     }
 
     public static void recycleInstance(MoveViewJob instance){
+        instance.recycle();
         pool.recycle(instance);
     }
 

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/jobs/ViewPortJob.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/jobs/ViewPortJob.java
@@ -44,4 +44,10 @@ public abstract class ViewPortJob extends ObjectPool.Poolable implements Runnabl
     public float getYValue() {
         return yValue;
     }
+
+    protected void recycle() {
+        mViewPortHandler = null;
+        mTrans = null;
+        view = null;
+    }
 }


### PR DESCRIPTION
If a ViewPortJob returns to the pool while holding a reference to a View, it will leak the Activity.

When we're recycling the jobs, we should just clear out all the object references.