### PR TITLE
Fix "closestToY" functionality in DataSet.getEntryIndex

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/data/DataSet.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/data/DataSet.java
@@ -359,7 +359,7 @@ public abstract class DataSet<T extends Entry> extends BaseDataSet<T> {
                         break;
 
                     if (Math.abs(value.getY() - closestToY) < Math.abs(closestYValue - closestToY)) {
-                        closestYValue = closestToY;
+                        closestYValue = value.getY();
                         closestYIndex = closest;
                     }
                 }


### PR DESCRIPTION
getEntryIndex has a "closestToY" parameter that appears to be for disambiguating cases where points have the same X value but different Y positions. The loop that searches entries with matching X values for the closest Y value is bugged, and will not correctly locate the nearest entry due to a bug on line 362. This corrects that behavior, and consequently, allows the user to select the intended point when several entries have the same X value.