### PR TITLE
Add a y-coordinate parameter to avoid description text overlapping

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/data/PieDataSet.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/data/PieDataSet.java
@@ -24,6 +24,9 @@ public class PieDataSet extends DataSet<PieEntry> implements IPieDataSet {
     private float mValueLinePart1Length = 0.3f;
     private float mValueLinePart2Length = 0.4f;
     private boolean mValueLineVariableLength = true;
+    
+    /** this variable determines whether to draw the yValue,  default value is 0, it means draw all of the yValue */
+    private float mYValueVisibleBoundary = 0;
 
     public PieDataSet(List<PieEntry> yVals, String label) {
         super(yVals, label);
@@ -204,6 +207,21 @@ public class PieDataSet extends DataSet<PieEntry> implements IPieDataSet {
     public void setValueLineVariableLength(boolean valueLineVariableLength)
     {
         this.mValueLineVariableLength = valueLineVariableLength;
+    }
+    
+    @Override
+    public float getYValueVisibleBoundary() {
+        return mYValueVisibleBoundary;
+    }
+
+    /**
+     * Set the boundary which determines whether to draw the yValue
+     *
+     * @param YValueVisibleBoundary the value should be >= 0. default is 0, it means draw all of the yValue.
+     *                              otherwise, only draw the yValue which greater than boundary
+     */
+    public void setYValueVisibleBoundary(float YValueVisibleBoundary) {
+        mYValueVisibleBoundary = YValueVisibleBoundary;
     }
 
     public enum ValuePosition {

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/interfaces/datasets/IPieDataSet.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/interfaces/datasets/IPieDataSet.java
@@ -65,6 +65,8 @@ public interface IPieDataSet extends IDataSet<PieEntry> {
      * When valuePosition is OutsideSlice, this allows variable line length
      * */
     boolean isValueLineVariableLength();
+    
+    float getYValueVisibleBoundary();
 
 }
 

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/PieChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/PieChartRenderer.java
@@ -536,8 +536,14 @@ public class PieChartRenderer extends DataRenderer {
                     }
 
                     if (dataSet.getValueLineColor() != ColorTemplate.COLOR_NONE) {
-                        c.drawLine(pt0x, pt0y, pt1x, pt1y, mValueLinePaint);
-                        c.drawLine(pt1x, pt1y, pt2x, pt2y, mValueLinePaint);
+                        
+                        if (dataSet.getYValueVisibleBoundary() <= 0) {
+                            c.drawLine(pt0x, pt0y, pt1x, pt1y, mValueLinePaint);
+                            c.drawLine(pt1x, pt1y, pt2x, pt2y, mValueLinePaint);
+                        } else if (value >= dataSet.getYValueVisibleBoundary()) {
+                            c.drawLine(pt0x, pt0y, pt1x, pt1y, mValueLinePaint);
+                            c.drawLine(pt1x, pt1y, pt2x, pt2y, mValueLinePaint);
+                        }
                     }
 
                     // draw everything, depending on settings
@@ -562,8 +568,13 @@ public class PieChartRenderer extends DataRenderer {
                         }
                     } else if (drawYOutside) {
 
-                        drawValue(c, formatter, value, entry, 0, labelPtx, labelPty + lineHeight / 2.f, dataSet
-                                .getValueTextColor(j));
+                        if (dataSet.getYValueVisibleBoundary() <= 0) {
+                            drawValue(c, formatter, value, entry, 0, labelPtx, labelPty + lineHeight / 2.f, dataSet
+                                    .getValueTextColor(j));
+                        } else if (value >= dataSet.getYValueVisibleBoundary()) {
+                            drawValue(c, formatter, value, entry, 0, labelPtx, labelPty + lineHeight / 2.f, dataSet
+                                    .getValueTextColor(j));
+                        }
                     }
                 }
 
@@ -589,7 +600,11 @@ public class PieChartRenderer extends DataRenderer {
                         }
                     } else if (drawYInside) {
 
-                        drawValue(c, formatter, value, entry, 0, x, y + lineHeight / 2f, dataSet.getValueTextColor(j));
+                        if (dataSet.getYValueVisibleBoundary() <= 0) {
+                            drawValue(c, formatter, value, entry, 0, x, y + lineHeight / 2f, dataSet.getValueTextColor(j));
+                        } else if (value >= dataSet.getYValueVisibleBoundary()) {
+                            drawValue(c, formatter, value, entry, 0, x, y + lineHeight / 2f, dataSet.getValueTextColor(j));
+                        }
                     }
                 }
 


### PR DESCRIPTION
Add a new parameter that affects only the y-coordinate drawing of **PieChart**. Use #_setYValueVisibleBoundary()_ to set the threshold, which determines whether to display the description text, and avoiding description text overlapping when you set a tiny percentage.