### PR TITLE
Fix NPEs with WeakReference usage in PieChart

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/PieChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/PieChartRenderer.java
@@ -634,6 +634,8 @@ public class PieChartRenderer extends DataRenderer {
     @Override
     public void drawExtras(Canvas c) {
         // drawCircles(c);
+        int width = (int) mViewPortHandler.getChartWidth();
+        int height = (int) mViewPortHandler.getChartHeight();
         if (width == 0 || height == 0) {
             return;
         }

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/PieChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/PieChartRenderer.java
@@ -634,6 +634,10 @@ public class PieChartRenderer extends DataRenderer {
     @Override
     public void drawExtras(Canvas c) {
         // drawCircles(c);
+        if (width == 0 || height == 0) {
+            return;
+        }
+
         drawHole(c);
         c.drawBitmap(mDrawBitmap.get(), 0, 0, null);
         drawCenterText(c);


### PR DESCRIPTION
The issue happens because PieChart is added into scroll view of any kind of lazy init view.
When the view is lazy loading, its width and height is not available yet.
and NPE at [mDrawBitmap](https://github.com/PhilJay/MPAndroidChart/blob/master/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/PieChartRenderer.java#L638) which can only be created in [drawData](https://github.com/PhilJay/MPAndroidChart/blob/master/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/PieChartRenderer.java#L133) when ```width > 0 && height > 0```.

And got same problem and It works in my app.
This should fixes #3470 
