### PR TITLE
add method to release static pool inside of MoveViewJob to avoid memory leak

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/jobs/MoveViewJob.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/jobs/MoveViewJob.java
@@ -53,4 +53,11 @@ public class MoveViewJob extends ViewPortJob {
     protected ObjectPool.Poolable instantiate() {
         return new MoveViewJob(mViewPortHandler, xValue, yValue, mTrans, view);
     }
+
+    /**
+     * release of poll and it objects
+     */
+    public static void release(){
+        pool = ObjectPool.create(2, new MoveViewJob(null,0,0,null,null));
+    }
 }


### PR DESCRIPTION
Hi 

This fix is for avoid memory leak by release of static ObjectPool instance ( and it array ) on activity onDestroy().
 
I attach chain of memory leak that happens in my activity.
With current fix, I have no more memory leaks.


![mem_leak_stack](https://user-images.githubusercontent.com/425429/34220861-4fe22e1a-e5b6-11e7-852e-cee155c3665d.png)


Best,
