### PR TITLE
Enable the use of a custom highlight color for selected pie chart segments

### DIFF
--- a/MPChartExample/src/main/java/com/xxmassdeveloper/mpchartexample/PieChartActivity.java
+++ b/MPChartExample/src/main/java/com/xxmassdeveloper/mpchartexample/PieChartActivity.java
@@ -93,7 +93,8 @@ public class PieChartActivity extends DemoBase implements OnSeekBarChangeListene
         // chart.setDrawUnitsInChart(true);
 
         // add a selection listener
-        chart.setOnChartValueSelectedListener(this);
+        mChart.setOnChartValueSelectedListener(this);
+//        mChart.setUseCustomHighLightColor(true);
 
         seekBarX.setProgress(4);
         seekBarY.setProgress(10);
@@ -286,9 +287,64 @@ public class PieChartActivity extends DemoBase implements OnSeekBarChangeListene
         setData(seekBarX.getProgress(), seekBarY.getProgress());
     }
 
-    @Override
-    protected void saveToGallery() {
-        saveToGallery(chart, "PieChartActivity");
+    private void setData(int count, float range) {
+
+        float mult = range;
+
+        ArrayList<PieEntry> entries = new ArrayList<PieEntry>();
+
+        // NOTE: The order of the entries when being added to the entries array determines their position around the center of
+        // the chart.
+        for (int i = 0; i < count ; i++) {
+            entries.add(new PieEntry((float) ((Math.random() * mult) + mult / 5),
+                    mParties[i % mParties.length],
+                    getResources().getDrawable(R.drawable.star)));
+        }
+
+        PieDataSet dataSet = new PieDataSet(entries, "Election Results");
+
+        dataSet.setDrawIcons(false);
+
+        dataSet.setSliceSpace(3f);
+        dataSet.setIconsOffset(new MPPointF(0, 40));
+        dataSet.setSelectionShift(5f);
+//        dataSet.setHighLightColor(Color.BLACK);
+
+        // add a lot of colors
+
+        ArrayList<Integer> colors = new ArrayList<Integer>();
+
+        for (int c : ColorTemplate.VORDIPLOM_COLORS)
+            colors.add(c);
+
+        for (int c : ColorTemplate.JOYFUL_COLORS)
+            colors.add(c);
+
+        for (int c : ColorTemplate.COLORFUL_COLORS)
+            colors.add(c);
+
+        for (int c : ColorTemplate.LIBERTY_COLORS)
+            colors.add(c);
+
+        for (int c : ColorTemplate.PASTEL_COLORS)
+            colors.add(c);
+
+        colors.add(ColorTemplate.getHoloBlue());
+
+        dataSet.setColors(colors);
+        //dataSet.setSelectionShift(0f);
+
+        PieData data = new PieData(dataSet);
+        data.setValueFormatter(new PercentFormatter());
+        data.setValueTextSize(11f);
+        data.setValueTextColor(Color.WHITE);
+        data.setValueTypeface(mTfLight);
+        mChart.setData(data);
+
+        // undo all highlights
+        mChart.highlightValues(null);
+
+        mChart.invalidate();
     }
 
     private SpannableString generateCenterSpannableText() {

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/charts/PieChart.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/charts/PieChart.java
@@ -90,6 +90,12 @@ public class PieChart extends PieRadarChartBase<PieData> {
      */
     private boolean mDrawCenterText = true;
 
+    /**
+     * When useCustomHighLightColor is true, the renderer will use the custom color
+     * instead of the segment's color
+     */
+    private boolean mUseCustomHighLightColor = false;
+
     private float mCenterTextRadiusPercent = 100.f;
 
     protected float mMaxAngle = 360f;
@@ -478,6 +484,20 @@ public class PieChart extends PieRadarChartBase<PieData> {
      */
     public boolean isDrawCenterTextEnabled() {
         return mDrawCenterText;
+    }
+
+    /**
+     * Set this to true to use a custom color for highlighting selected segments
+     * of the pie chart
+     *
+     * @param enabled
+     */
+    public void setUseCustomHighLightColor(boolean enabled) {
+        this.mUseCustomHighLightColor = enabled;
+    }
+
+    public boolean useCustomHighLightColor() {
+        return mUseCustomHighLightColor;
     }
 
     @Override

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/data/PieDataSet.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/data/PieDataSet.java
@@ -24,6 +24,7 @@ public class PieDataSet extends DataSet<PieEntry> implements IPieDataSet {
     private ValuePosition mYValuePosition = ValuePosition.INSIDE_SLICE;
     private boolean mUsingSliceColorAsValueLineColor = false;
     private int mValueLineColor = 0xff000000;
+    private int mHighLightColor = 0xff000000;
     private float mValueLineWidth = 1.0f;
     private float mValueLinePart1OffsetPercentage = 75.f;
     private float mValueLinePart1Length = 0.3f;
@@ -161,6 +162,16 @@ public class PieDataSet extends DataSet<PieEntry> implements IPieDataSet {
     /**
      * When valuePosition is OutsideSlice, indicates line width
      */
+    public void setHighLightColor(int color) {
+        this.mHighLightColor = color;
+    }
+
+    @Override
+    public int getCustomHighlightColor() {
+        return this.mHighLightColor;
+    }
+
+    /** When valuePosition is OutsideSlice, indicates line width */
     @Override
     public float getValueLineWidth() {
         return mValueLineWidth;

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/interfaces/datasets/IPieDataSet.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/interfaces/datasets/IPieDataSet.java
@@ -46,6 +46,11 @@ public interface IPieDataSet extends IDataSet<PieEntry> {
     int getValueLineColor();
 
     /**
+     * Returns the custom highlight color specified when creating the pie data set
+     */
+    int getCustomHighlightColor();
+
+    /**
      *  When valuePosition is OutsideSlice, indicates line width
      *  */
     float getValueLineWidth();

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/PieChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/PieChartRenderer.java
@@ -857,7 +857,11 @@ public class PieChartRenderer extends DataRenderer {
 
             final boolean accountForSliceSpacing = sliceSpace > 0.f && sliceAngle <= 180.f;
 
-            mRenderPaint.setColor(set.getColor(index));
+            if (mChart.useCustomHighLightColor()) {
+                mRenderPaint.setColor(set.getCustomHighlightColor());
+            } else {
+                mRenderPaint.setColor(set.getColor(index));
+            }
 
             final float sliceSpaceAngleOuter = visibleAngleCount == 1 ?
                     0.f :

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/PieChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/PieChartRenderer.java
@@ -494,6 +494,9 @@ public class PieChartRenderer extends DataRenderer {
 
                 angle = angle + angleOffset;
 
+                final float minimumSliceSize = 0.15f * 360.0f;
+                final int entryThresholdForHiding = 2;
+
                 final float transformedAngle = rotationAngle + angle * phaseY;
 
                 float value = mChart.isUsePercentValuesEnabled() ? entry.getY()
@@ -513,7 +516,7 @@ public class PieChartRenderer extends DataRenderer {
                 final boolean drawYInside = drawValues &&
                         yValuePosition == PieDataSet.ValuePosition.INSIDE_SLICE;
 
-                if (drawXOutside || drawYOutside) {
+                if ((drawXOutside || drawYOutside) && !(sliceAngle <= minimumSliceSize && entryCount > entryThresholdForHiding)) {
 
                     final float valueLineLength1 = dataSet.getValueLinePart1Length();
                     final float valueLineLength2 = dataSet.getValueLinePart2Length();


### PR DESCRIPTION
In the current version of the pie chart, a selected segment is denoted by slightly expanding that segment retaining the colour of that segment. 
For my use case, I wanted to have a different highlight colour. I added that functionality to enable highlights but kept defaults to maintain the existing behaviour without any app-side code changes.