### PR TITLE
Add ability to change formatter in LargeValueFormatter

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/formatter/LargeValueFormatter.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/formatter/LargeValueFormatter.java
@@ -71,6 +71,16 @@ public class LargeValueFormatter implements IValueFormatter, IAxisValueFormatter
     public void setSuffix(String[] suff) {
         SUFFIX = suff;
     }
+	
+	/**
+     * Set custom DecimalFormat for formatting number.
+     * Default mFormat: DecimalFormat("###E00")
+     *
+     * @param format the new DecimalFormat
+     */
+    public void setDecimalFormatter(DecimalFormat format) {
+        mFormat = format;
+    }
 
     /**
      * Formats each number properly. Special thanks to Roman Gromov


### PR DESCRIPTION
I was testing my app when the default locale is Arabic, LargeValueFormatter returned me a non-meaning string, I wrote my own format class that default the DecimalFromat (mFormat) to use English instead of Arabic.
I thought it would be great if LargeValueFormatter class allows me to change the DecimalFormat object so I added it wishing that would be useful for other developers using this great library.
If my changes were useful I would be happy, So please let me know if that was a good thing to do or not.

Thanks
Ammar Atef