### PR TITLE
Prevent spurious garbage collection

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/PieChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/PieChartRenderer.java
@@ -131,9 +131,9 @@ public class PieChartRenderer extends DataRenderer {
                 || (mDrawBitmap.get().getHeight() != height)) {
 
             if (width > 0 && height > 0) {
-
-                mDrawBitmap = new WeakReference<Bitmap>(Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_4444));
-                mBitmapCanvas = new Canvas(mDrawBitmap.get());
+                Bitmap bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_4444);
+                mDrawBitmap = new WeakReference<Bitmap>(bitmap);
+                mBitmapCanvas = new Canvas(bitmap);
             } else
                 return;
         }


### PR DESCRIPTION
I've noticed that in production the Bitmap occasionally goes missing between being turned into a weakreference and where it is extracted again and passed to the canvas - after all there are no references to the object in the short space between the two lines of code.