### PR TITLE
PieChart: Add option for using slice color as value line color

### DIFF
--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/PiePolylineChartActivity.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/PiePolylineChartActivity.java
@@ -19,7 +19,6 @@ import android.widget.TextView;
 import com.github.mikephil.charting.animation.Easing;
 import com.github.mikephil.charting.charts.PieChart;
 import com.github.mikephil.charting.components.Legend;
-import com.github.mikephil.charting.components.Legend.LegendPosition;
 import com.github.mikephil.charting.data.Entry;
 import com.github.mikephil.charting.data.PieData;
 import com.github.mikephil.charting.data.PieDataSet;
@@ -226,6 +225,8 @@ public class PiePolylineChartActivity extends DemoBase implements OnSeekBarChang
         dataSet.setValueLinePart1OffsetPercentage(80.f);
         dataSet.setValueLinePart1Length(0.2f);
         dataSet.setValueLinePart2Length(0.4f);
+        //dataSet.setUsingSliceColorAsValueLineColor(true);
+
         //dataSet.setXValuePosition(PieDataSet.ValuePosition.OUTSIDE_SLICE);
         dataSet.setYValuePosition(PieDataSet.ValuePosition.OUTSIDE_SLICE);
 

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/data/PieDataSet.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/data/PieDataSet.java
@@ -18,6 +18,7 @@ public class PieDataSet extends DataSet<PieEntry> implements IPieDataSet {
 
     private ValuePosition mXValuePosition = ValuePosition.INSIDE_SLICE;
     private ValuePosition mYValuePosition = ValuePosition.INSIDE_SLICE;
+    private boolean mUsingSliceColorAsValueLineColor = false;
     private int mValueLineColor = 0xff000000;
     private float mValueLineWidth = 1.0f;
     private float mValueLinePart1OffsetPercentage = 75.f;
@@ -134,6 +135,18 @@ public class PieDataSet extends DataSet<PieEntry> implements IPieDataSet {
         this.mYValuePosition = yValuePosition;
     }
 
+    /**
+     * When valuePosition is OutsideSlice, use slice colors as line color if true
+     * */
+    @Override
+    public boolean isUsingSliceColorAsValueLineColor() {
+        return mUsingSliceColorAsValueLineColor;
+    }
+
+    public void setUsingSliceColorAsValueLineColor(boolean usingSliceColorAsValueLineColor) {
+        this.mUsingSliceColorAsValueLineColor = usingSliceColorAsValueLineColor;
+    }
+
     /** When valuePosition is OutsideSlice, indicates line color */
     @Override
     public int getValueLineColor()
@@ -141,8 +154,7 @@ public class PieDataSet extends DataSet<PieEntry> implements IPieDataSet {
         return mValueLineColor;
     }
 
-    public void setValueLineColor(int valueLineColor)
-    {
+    public void setValueLineColor(int valueLineColor) {
         this.mValueLineColor = valueLineColor;
     }
 

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/interfaces/datasets/IPieDataSet.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/interfaces/datasets/IPieDataSet.java
@@ -1,6 +1,5 @@
 package com.github.mikephil.charting.interfaces.datasets;
 
-import com.github.mikephil.charting.data.Entry;
 import com.github.mikephil.charting.data.PieDataSet;
 import com.github.mikephil.charting.data.PieEntry;
 
@@ -35,6 +34,11 @@ public interface IPieDataSet extends IDataSet<PieEntry> {
 
     PieDataSet.ValuePosition getXValuePosition();
     PieDataSet.ValuePosition getYValuePosition();
+
+    /**
+     * When valuePosition is OutsideSlice, use slice colors as line color if true
+     * */
+    boolean isUsingSliceColorAsValueLineColor();
 
     /**
      * When valuePosition is OutsideSlice, indicates line color

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/PieChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/PieChartRenderer.java
@@ -536,6 +536,11 @@ public class PieChartRenderer extends DataRenderer {
                     }
 
                     if (dataSet.getValueLineColor() != ColorTemplate.COLOR_NONE) {
+
+                        if (dataSet.isUsingSliceColorAsValueLineColor()) {
+                            mValueLinePaint.setColor(dataSet.getColor(j));
+                        }
+
                         c.drawLine(pt0x, pt0y, pt1x, pt1y, mValueLinePaint);
                         c.drawLine(pt1x, pt1y, pt2x, pt2y, mValueLinePaint);
                     }


### PR DESCRIPTION
Fixes: #3897

If `dataSet.setUsingSliceColorAsValueLineColor(true);` is called, value line color will be the same color with slice.