### PR TITLE
Remove YAxis Custom Min/Max Check for Padding

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/components/YAxis.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/components/YAxis.java
@@ -373,19 +373,11 @@ public class YAxis extends AxisBase {
             min = min - 1f;
         }
 
-        // bottom-space only effects non-custom min
-        if (!mCustomAxisMin) {
-
-            float bottomSpace = range / 100f * getSpaceBottom();
-            this.mAxisMinimum = (min - bottomSpace);
-        }
-
-        // top-space only effects non-custom max
-        if (!mCustomAxisMax) {
-
-            float topSpace = range / 100f * getSpaceTop();
-            this.mAxisMaximum = (max + topSpace);
-        }
+        float bottomSpace = range / 100f * getSpaceBottom();
+        this.mAxisMinimum = (min - bottomSpace);
+            
+        float topSpace = range / 100f * getSpaceTop();
+        this.mAxisMaximum = (max + topSpace);
 
         // calc actual range
         this.mAxisRange = Math.abs(this.mAxisMaximum - this.mAxisMinimum);


### PR DESCRIPTION
I noticed that while trying to add spacing to the bottom of a chart, to allow for the interior labels enough room that they don't overlap the data, nothing was happening. I was confused as to why setting the bottom spacing was doing literally nothing, and discovered it was disabled if the min was manually changed.

I thought it strange to disable this without mentioning anywhere in the documentation that this behavior was intentional. Adding percentage based padding let's developers easily add this extra space, but disabling it doesn't make sense. If developers don't want that extra spacing, they'll do what they would've done anyway, set the spacing to 0, as the default is 10%.

Since this behavior of disabling the spacing if custom values are set, even though the calculated range is BASED on those custom values, is not mentioned in documentation, I doubt this will cause any current compatibility issues, especially since the change will likely not be visually noticeable in the first place.

I really hope you can push this into the main library, as I think it makes more logical sense this way. Currently, I'm just re-calculating the min value myself, and then setting the new min with padding.