### PR TITLE
BUG:setGranularity is not work

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/AxisRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/AxisRenderer.java
@@ -173,7 +173,7 @@ public abstract class AxisRenderer extends Renderer {
         // Normalize interval
         double intervalMagnitude = Utils.roundToNextSignificant(Math.pow(10, (int) Math.log10(interval)));
         int intervalSigDigit = (int) (interval / intervalMagnitude);
-        if (intervalSigDigit > 5) {
+        if (intervalSigDigit > 6) {
             // Use one order of magnitude higher, to avoid intervals like 0.9 or
             // 90
             interval = Math.floor(10 * intervalMagnitude);


### PR DESCRIPTION
when i use this infomation：

```
XAxis xAxis = mChart.getXAxis();
xAxis.setGranularity(60);
mChart.setVisibleXRange(180, 180);
```
data count ：setData(1440)
and set
`mChart.setVisibleXRange(180, 180);`

the setGranularity is not work，always 100.
I find the AxisRenderer.class line 176 code:

```
       if (intervalSigDigit > 5) {
            // Use one order of magnitude higher, to avoid intervals like 0.9 or
            // 90
            interval = Math.floor(10 * intervalMagnitude);
        }
```
I update the 5 to 6，it is OK。
so，is this the solution？