### PR TITLE
Remove mLabelRotatedHeight counted twice, when calculating legend offset

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/charts/BarLineChartBase.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/charts/BarLineChartBase.java
@@ -427,18 +427,12 @@ public abstract class BarLineChartBase<T extends BarLineScatterCandleBubbleData<
                             offsets.top += Math.min(mLegend.mNeededHeight,
                                     mViewPortHandler.getChartHeight() * mLegend.getMaxSizePercent())
                                     + mLegend.getYOffset();
-
-                            if (getXAxis().isEnabled() && getXAxis().isDrawLabelsEnabled())
-                                offsets.top += getXAxis().mLabelRotatedHeight;
                             break;
 
                         case BOTTOM:
                             offsets.bottom += Math.min(mLegend.mNeededHeight,
                                     mViewPortHandler.getChartHeight() * mLegend.getMaxSizePercent())
                                     + mLegend.getYOffset();
-
-                            if (getXAxis().isEnabled() && getXAxis().isDrawLabelsEnabled())
-                                offsets.bottom += getXAxis().mLabelRotatedHeight;
                             break;
 
                         default:
@@ -478,21 +472,21 @@ public abstract class BarLineChartBase<T extends BarLineScatterCandleBubbleData<
 
             if (mXAxis.isEnabled() && mXAxis.isDrawLabelsEnabled()) {
 
-                float xlabelheight = mXAxis.mLabelRotatedHeight + mXAxis.getYOffset();
+                float xLabelHeight = mXAxis.mLabelRotatedHeight + mXAxis.getYOffset();
 
                 // offsets for x-labels
                 if (mXAxis.getPosition() == XAxisPosition.BOTTOM) {
 
-                    offsetBottom += xlabelheight;
+                    offsetBottom += xLabelHeight;
 
                 } else if (mXAxis.getPosition() == XAxisPosition.TOP) {
 
-                    offsetTop += xlabelheight;
+                    offsetTop += xLabelHeight;
 
                 } else if (mXAxis.getPosition() == XAxisPosition.BOTH_SIDED) {
 
-                    offsetBottom += xlabelheight;
-                    offsetTop += xlabelheight;
+                    offsetBottom += xLabelHeight;
+                    offsetTop += xLabelHeight;
                 }
             }
 
@@ -1224,7 +1218,7 @@ public abstract class BarLineChartBase<T extends BarLineScatterCandleBubbleData<
 
     /**
      * When enabled, the values will be clipped to contentRect,
-     *   otherwise they can bleed outside the content rect.
+     * otherwise they can bleed outside the content rect.
      *
      * @param enabled
      */
@@ -1234,7 +1228,7 @@ public abstract class BarLineChartBase<T extends BarLineScatterCandleBubbleData<
 
     /**
      * When enabled, the values will be clipped to contentRect,
-     *   otherwise they can bleed outside the content rect.
+     * otherwise they can bleed outside the content rect.
      *
      * @return
      */


### PR DESCRIPTION
Fix for #2369.

## PR Checklist:
- [X] I have tested this extensively and it does not break any existing behavior.
Modified the code as described in Issue #2369 to see, that the issue still exists.
Checked against different positions of Legend (TOP, BOTTOM).
- [ ] I have added/updated examples and tests for any new behavior.
No need for that, I think.
- [x] If this is a significant change, an issue has already been created where the problem / solution was suggested
Issue #2369


## PR Description
Removed statements described in ticket as they were completely not needed. Calculating offsets is already done in `BarLineCharBase#calculateOffsets(...)` (`calculateLegendOffsets(...)` is called inside it).
The code, where calculating legend offset is done in [`BarChartLineBase#473`](https://github.com/PhilJay/MPAndroidChart/compare/master...RobertZagorski:bugfix/%232369-legend-offset-is-not-calculated-twice-for-line-chart?expand=1#diff-c2688ad7111a70de6e0354d19bbff337R473)
Modified temporarily `LineChartActivity1` code to reproduce the issue and tested against various legend positions.
Additionally I changed one inner variable name to be more of Java style.