### PR TITLE
[Enhancement] Remove redundant findViewById casts in example application

### DIFF
--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/AnotherBarActivity.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/AnotherBarActivity.java
@@ -36,16 +36,16 @@ public class AnotherBarActivity extends DemoBase implements OnSeekBarChangeListe
                 WindowManager.LayoutParams.FLAG_FULLSCREEN);
         setContentView(R.layout.activity_barchart);
 
-        tvX = (TextView) findViewById(R.id.tvXMax);
-        tvY = (TextView) findViewById(R.id.tvYMax);
+        tvX = findViewById(R.id.tvXMax);
+        tvY = findViewById(R.id.tvYMax);
 
-        mSeekBarX = (SeekBar) findViewById(R.id.seekBar1);
+        mSeekBarX = findViewById(R.id.seekBar1);
         mSeekBarX.setOnSeekBarChangeListener(this);
 
-        mSeekBarY = (SeekBar) findViewById(R.id.seekBar2);
+        mSeekBarY = findViewById(R.id.seekBar2);
         mSeekBarY.setOnSeekBarChangeListener(this);
 
-        mChart = (BarChart) findViewById(R.id.chart1);
+        mChart = findViewById(R.id.chart1);
 
         mChart.getDescription().setEnabled(false);
 

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/BarChartActivity.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/BarChartActivity.java
@@ -56,13 +56,13 @@ public class BarChartActivity extends DemoBase implements OnSeekBarChangeListene
                 WindowManager.LayoutParams.FLAG_FULLSCREEN);
         setContentView(R.layout.activity_barchart);
 
-        tvX = (TextView) findViewById(R.id.tvXMax);
-        tvY = (TextView) findViewById(R.id.tvYMax);
+        tvX = findViewById(R.id.tvXMax);
+        tvY = findViewById(R.id.tvYMax);
 
-        mSeekBarX = (SeekBar) findViewById(R.id.seekBar1);
-        mSeekBarY = (SeekBar) findViewById(R.id.seekBar2);
+        mSeekBarX = findViewById(R.id.seekBar1);
+        mSeekBarY = findViewById(R.id.seekBar2);
 
-        mChart = (BarChart) findViewById(R.id.chart1);
+        mChart = findViewById(R.id.chart1);
         mChart.setOnChartValueSelectedListener(this);
 
         mChart.setDrawBarShadow(false);

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/BarChartActivityMultiDataset.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/BarChartActivityMultiDataset.java
@@ -44,17 +44,17 @@ public class BarChartActivityMultiDataset extends DemoBase implements OnSeekBarC
                 WindowManager.LayoutParams.FLAG_FULLSCREEN);
         setContentView(R.layout.activity_barchart);
 
-        tvX = (TextView) findViewById(R.id.tvXMax);
+        tvX = findViewById(R.id.tvXMax);
         tvX.setTextSize(10);
-        tvY = (TextView) findViewById(R.id.tvYMax);
+        tvY = findViewById(R.id.tvYMax);
 
-        mSeekBarX = (SeekBar) findViewById(R.id.seekBar1);
+        mSeekBarX = findViewById(R.id.seekBar1);
         mSeekBarX.setOnSeekBarChangeListener(this);
 
-        mSeekBarY = (SeekBar) findViewById(R.id.seekBar2);
+        mSeekBarY = findViewById(R.id.seekBar2);
         mSeekBarY.setOnSeekBarChangeListener(this);
 
-        mChart = (BarChart) findViewById(R.id.chart1);
+        mChart = findViewById(R.id.chart1);
         mChart.setOnChartValueSelectedListener(this);
         mChart.getDescription().setEnabled(false);
 

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/BarChartActivitySinus.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/BarChartActivitySinus.java
@@ -44,11 +44,11 @@ public class BarChartActivitySinus extends DemoBase implements OnSeekBarChangeLi
 
         mSinusData = FileUtils.loadBarEntriesFromAssets(getAssets(), "othersine.txt");
 
-        tvX = (TextView) findViewById(R.id.tvValueCount);
+        tvX = findViewById(R.id.tvValueCount);
 
-        mSeekBarX = (SeekBar) findViewById(R.id.seekbarValues);
+        mSeekBarX = findViewById(R.id.seekbarValues);
 
-        mChart = (BarChart) findViewById(R.id.chart1);
+        mChart = findViewById(R.id.chart1);
 
         mChart.setDrawBarShadow(false);
         mChart.setDrawValueAboveBar(true);

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/BarChartPositiveNegative.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/BarChartPositiveNegative.java
@@ -37,7 +37,7 @@ public class BarChartPositiveNegative extends DemoBase {
         setContentView(R.layout.activity_barchart_noseekbar);
 
         mTf = Typeface.createFromAsset(getAssets(), "OpenSans-Regular.ttf");
-        mChart = (BarChart) findViewById(R.id.chart1);
+        mChart = findViewById(R.id.chart1);
         mChart.setBackgroundColor(Color.WHITE);
         mChart.setExtraTopOffset(-30f);
         mChart.setExtraBottomOffset(10f);

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/BubbleChartActivity.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/BubbleChartActivity.java
@@ -44,16 +44,16 @@ public class BubbleChartActivity extends DemoBase implements OnSeekBarChangeList
                 WindowManager.LayoutParams.FLAG_FULLSCREEN);
         setContentView(R.layout.activity_bubblechart);
 
-        tvX = (TextView) findViewById(R.id.tvXMax);
-        tvY = (TextView) findViewById(R.id.tvYMax);
+        tvX = findViewById(R.id.tvXMax);
+        tvY = findViewById(R.id.tvYMax);
 
-        mSeekBarX = (SeekBar) findViewById(R.id.seekBar1);
+        mSeekBarX = findViewById(R.id.seekBar1);
         mSeekBarX.setOnSeekBarChangeListener(this);
 
-        mSeekBarY = (SeekBar) findViewById(R.id.seekBar2);
+        mSeekBarY = findViewById(R.id.seekBar2);
         mSeekBarY.setOnSeekBarChangeListener(this);
 
-        mChart = (BubbleChart) findViewById(R.id.chart1);
+        mChart = findViewById(R.id.chart1);
         mChart.getDescription().setEnabled(false);
 
         mChart.setOnChartValueSelectedListener(this);

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/CandleStickChartActivity.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/CandleStickChartActivity.java
@@ -39,16 +39,16 @@ public class CandleStickChartActivity extends DemoBase implements OnSeekBarChang
                 WindowManager.LayoutParams.FLAG_FULLSCREEN);
         setContentView(R.layout.activity_candlechart);
 
-        tvX = (TextView) findViewById(R.id.tvXMax);
-        tvY = (TextView) findViewById(R.id.tvYMax);
+        tvX = findViewById(R.id.tvXMax);
+        tvY = findViewById(R.id.tvYMax);
 
-        mSeekBarX = (SeekBar) findViewById(R.id.seekBar1);
+        mSeekBarX = findViewById(R.id.seekBar1);
         mSeekBarX.setOnSeekBarChangeListener(this);
 
-        mSeekBarY = (SeekBar) findViewById(R.id.seekBar2);
+        mSeekBarY = findViewById(R.id.seekBar2);
         mSeekBarY.setOnSeekBarChangeListener(this);
 
-        mChart = (CandleStickChart) findViewById(R.id.chart1);
+        mChart = findViewById(R.id.chart1);
         mChart.setBackgroundColor(Color.WHITE);
 
         mChart.getDescription().setEnabled(false);

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/CombinedChartActivity.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/CombinedChartActivity.java
@@ -48,7 +48,7 @@ public class CombinedChartActivity extends DemoBase {
                 WindowManager.LayoutParams.FLAG_FULLSCREEN);
         setContentView(R.layout.activity_combined);
 
-        mChart = (CombinedChart) findViewById(R.id.chart1);
+        mChart = findViewById(R.id.chart1);
         mChart.getDescription().setEnabled(false);
         mChart.setBackgroundColor(Color.WHITE);
         mChart.setDrawGridBackground(false);

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/CubicLineChartActivity.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/CubicLineChartActivity.java
@@ -39,11 +39,11 @@ public class CubicLineChartActivity extends DemoBase implements OnSeekBarChangeL
                 WindowManager.LayoutParams.FLAG_FULLSCREEN);
         setContentView(R.layout.activity_linechart);
 
-        tvX = (TextView) findViewById(R.id.tvXMax);
-        tvY = (TextView) findViewById(R.id.tvYMax);
+        tvX = findViewById(R.id.tvXMax);
+        tvY = findViewById(R.id.tvYMax);
 
-        mSeekBarX = (SeekBar) findViewById(R.id.seekBar1);
-        mSeekBarY = (SeekBar) findViewById(R.id.seekBar2);
+        mSeekBarX = findViewById(R.id.seekBar1);
+        mSeekBarY = findViewById(R.id.seekBar2);
 
         mSeekBarX.setProgress(45);
         mSeekBarY.setProgress(100);
@@ -51,7 +51,7 @@ public class CubicLineChartActivity extends DemoBase implements OnSeekBarChangeL
         mSeekBarY.setOnSeekBarChangeListener(this);
         mSeekBarX.setOnSeekBarChangeListener(this);
 
-        mChart = (LineChart) findViewById(R.id.chart1);
+        mChart = findViewById(R.id.chart1);
         mChart.setViewPortOffsets(0, 0, 0, 0);
         mChart.setBackgroundColor(Color.rgb(104, 241, 175));
 

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/DrawChartActivity.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/DrawChartActivity.java
@@ -43,7 +43,7 @@ public class DrawChartActivity extends DemoBase implements OnChartValueSelectedL
                 WindowManager.LayoutParams.FLAG_FULLSCREEN);
         setContentView(R.layout.activity_draw_chart);
 
-        mChart = (LineChart) findViewById(R.id.chart1);
+        mChart = findViewById(R.id.chart1);
 
         // listener for selecting and drawing
         mChart.setOnChartValueSelectedListener(this);

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/DynamicalAddingActivity.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/DynamicalAddingActivity.java
@@ -32,7 +32,7 @@ public class DynamicalAddingActivity extends DemoBase implements OnChartValueSel
                 WindowManager.LayoutParams.FLAG_FULLSCREEN);
         setContentView(R.layout.activity_linechart_noseekbar);
 
-        mChart = (LineChart) findViewById(R.id.chart1);
+        mChart = findViewById(R.id.chart1);
         mChart.setOnChartValueSelectedListener(this);
         mChart.setDrawGridBackground(false);
         mChart.getDescription().setEnabled(false);

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/FilledLineActivity.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/FilledLineActivity.java
@@ -31,7 +31,7 @@ public class FilledLineActivity extends DemoBase {
                 WindowManager.LayoutParams.FLAG_FULLSCREEN);
         setContentView(R.layout.activity_linechart_noseekbar);
 
-        mChart = (LineChart) findViewById(R.id.chart1);
+        mChart = findViewById(R.id.chart1);
         mChart.setBackgroundColor(Color.WHITE);
         mChart.setGridBackgroundColor(mFillColor);
         mChart.setDrawGridBackground(true);

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/HalfPieChartActivity.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/HalfPieChartActivity.java
@@ -37,7 +37,7 @@ public class HalfPieChartActivity extends DemoBase {
                 WindowManager.LayoutParams.FLAG_FULLSCREEN);
         setContentView(R.layout.activity_piechart_half);
 
-        mChart = (PieChart) findViewById(R.id.chart1);
+        mChart = findViewById(R.id.chart1);
         mChart.setBackgroundColor(Color.WHITE);
 
         moveOffScreen();

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/HorizontalBarChartActivity.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/HorizontalBarChartActivity.java
@@ -46,13 +46,13 @@ public class HorizontalBarChartActivity extends DemoBase implements OnSeekBarCha
                 WindowManager.LayoutParams.FLAG_FULLSCREEN);
         setContentView(R.layout.activity_horizontalbarchart);
 
-        tvX = (TextView) findViewById(R.id.tvXMax);
-        tvY = (TextView) findViewById(R.id.tvYMax);
+        tvX = findViewById(R.id.tvXMax);
+        tvY = findViewById(R.id.tvYMax);
 
-        mSeekBarX = (SeekBar) findViewById(R.id.seekBar1);
-        mSeekBarY = (SeekBar) findViewById(R.id.seekBar2);
+        mSeekBarX = findViewById(R.id.seekBar1);
+        mSeekBarY = findViewById(R.id.seekBar2);
 
-        mChart = (HorizontalBarChart) findViewById(R.id.chart1);
+        mChart = findViewById(R.id.chart1);
         mChart.setOnChartValueSelectedListener(this);
         // mChart.setHighlightEnabled(false);
 

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/InvertedLineChartActivity.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/InvertedLineChartActivity.java
@@ -44,11 +44,11 @@ public class InvertedLineChartActivity extends DemoBase implements OnSeekBarChan
                 WindowManager.LayoutParams.FLAG_FULLSCREEN);
         setContentView(R.layout.activity_linechart);
 
-        tvX = (TextView) findViewById(R.id.tvXMax);
-        tvY = (TextView) findViewById(R.id.tvYMax);
+        tvX = findViewById(R.id.tvXMax);
+        tvY = findViewById(R.id.tvYMax);
 
-        mSeekBarX = (SeekBar) findViewById(R.id.seekBar1);
-        mSeekBarY = (SeekBar) findViewById(R.id.seekBar2);
+        mSeekBarX = findViewById(R.id.seekBar1);
+        mSeekBarY = findViewById(R.id.seekBar2);
 
         mSeekBarX.setProgress(45);
         mSeekBarY.setProgress(100);
@@ -56,7 +56,7 @@ public class InvertedLineChartActivity extends DemoBase implements OnSeekBarChan
         mSeekBarY.setOnSeekBarChangeListener(this);
         mSeekBarX.setOnSeekBarChangeListener(this);
 
-        mChart = (LineChart) findViewById(R.id.chart1);
+        mChart = findViewById(R.id.chart1);
         mChart.setOnChartValueSelectedListener(this);
         mChart.setDrawGridBackground(false);
         

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/LineChartActivity1.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/LineChartActivity1.java
@@ -54,11 +54,11 @@ public class LineChartActivity1 extends DemoBase implements OnSeekBarChangeListe
                 WindowManager.LayoutParams.FLAG_FULLSCREEN);
         setContentView(R.layout.activity_linechart);
 
-        tvX = (TextView) findViewById(R.id.tvXMax);
-        tvY = (TextView) findViewById(R.id.tvYMax);
+        tvX = findViewById(R.id.tvXMax);
+        tvY = findViewById(R.id.tvYMax);
 
-        mSeekBarX = (SeekBar) findViewById(R.id.seekBar1);
-        mSeekBarY = (SeekBar) findViewById(R.id.seekBar2);
+        mSeekBarX = findViewById(R.id.seekBar1);
+        mSeekBarY = findViewById(R.id.seekBar2);
 
         mSeekBarX.setProgress(45);
         mSeekBarY.setProgress(100);
@@ -66,7 +66,7 @@ public class LineChartActivity1 extends DemoBase implements OnSeekBarChangeListe
         mSeekBarY.setOnSeekBarChangeListener(this);
         mSeekBarX.setOnSeekBarChangeListener(this);
 
-        mChart = (LineChart) findViewById(R.id.chart1);
+        mChart = findViewById(R.id.chart1);
         mChart.setOnChartGestureListener(this);
         mChart.setOnChartValueSelectedListener(this);
         mChart.setDrawGridBackground(false);

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/LineChartActivity2.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/LineChartActivity2.java
@@ -44,10 +44,10 @@ public class LineChartActivity2 extends DemoBase implements OnSeekBarChangeListe
                 WindowManager.LayoutParams.FLAG_FULLSCREEN);
         setContentView(R.layout.activity_linechart);
 
-        tvX = (TextView) findViewById(R.id.tvXMax);
-        tvY = (TextView) findViewById(R.id.tvYMax);
-        mSeekBarX = (SeekBar) findViewById(R.id.seekBar1);
-        mSeekBarY = (SeekBar) findViewById(R.id.seekBar2);
+        tvX = findViewById(R.id.tvXMax);
+        tvY = findViewById(R.id.tvYMax);
+        mSeekBarX = findViewById(R.id.seekBar1);
+        mSeekBarY = findViewById(R.id.seekBar2);
 
         mSeekBarX.setProgress(45);
         mSeekBarY.setProgress(100);
@@ -55,7 +55,7 @@ public class LineChartActivity2 extends DemoBase implements OnSeekBarChangeListe
         mSeekBarY.setOnSeekBarChangeListener(this);
         mSeekBarX.setOnSeekBarChangeListener(this);
 
-        mChart = (LineChart) findViewById(R.id.chart1);
+        mChart = findViewById(R.id.chart1);
         mChart.setOnChartValueSelectedListener(this);
 
         // no description text

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/LineChartActivityColored.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/LineChartActivityColored.java
@@ -27,10 +27,10 @@ public class LineChartActivityColored extends DemoBase {
                 WindowManager.LayoutParams.FLAG_FULLSCREEN);
         setContentView(R.layout.activity_colored_lines);
 
-        mCharts[0] = (LineChart) findViewById(R.id.chart1);
-        mCharts[1] = (LineChart) findViewById(R.id.chart2);
-        mCharts[2] = (LineChart) findViewById(R.id.chart3);
-        mCharts[3] = (LineChart) findViewById(R.id.chart4);
+        mCharts[0] = findViewById(R.id.chart1);
+        mCharts[1] = findViewById(R.id.chart2);
+        mCharts[2] = findViewById(R.id.chart3);
+        mCharts[3] = findViewById(R.id.chart4);
 
         mTf = Typeface.createFromAsset(getAssets(), "OpenSans-Bold.ttf");
 

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/LineChartTime.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/LineChartTime.java
@@ -45,14 +45,14 @@ public class LineChartTime extends DemoBase implements OnSeekBarChangeListener {
                 WindowManager.LayoutParams.FLAG_FULLSCREEN);
         setContentView(R.layout.activity_linechart_time);
 
-        tvX = (TextView) findViewById(R.id.tvXMax);
-        mSeekBarX = (SeekBar) findViewById(R.id.seekBar1);
+        tvX = findViewById(R.id.tvXMax);
+        mSeekBarX = findViewById(R.id.seekBar1);
         mSeekBarX.setProgress(100);
         tvX.setText("100");
 
         mSeekBarX.setOnSeekBarChangeListener(this);
 
-        mChart = (LineChart) findViewById(R.id.chart1);
+        mChart = findViewById(R.id.chart1);
 
         // no description text
         mChart.getDescription().setEnabled(false);

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/ListViewBarChartActivity.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/ListViewBarChartActivity.java
@@ -41,7 +41,7 @@ public class ListViewBarChartActivity extends DemoBase {
                 WindowManager.LayoutParams.FLAG_FULLSCREEN);
         setContentView(R.layout.activity_listview_chart);
         
-        ListView lv = (ListView) findViewById(R.id.listView1);
+        ListView lv = findViewById(R.id.listView1);
 
         ArrayList<BarData> list = new ArrayList<BarData>();
 
@@ -73,7 +73,7 @@ public class ListViewBarChartActivity extends DemoBase {
 
                 convertView = LayoutInflater.from(getContext()).inflate(
                         R.layout.list_item_barchart, null);
-                holder.chart = (BarChart) convertView.findViewById(R.id.chart);
+                holder.chart = convertView.findViewById(R.id.chart);
 
                 convertView.setTag(holder);
 

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/ListViewMultiChartActivity.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/ListViewMultiChartActivity.java
@@ -45,7 +45,7 @@ public class ListViewMultiChartActivity extends DemoBase {
                 WindowManager.LayoutParams.FLAG_FULLSCREEN);
         setContentView(R.layout.activity_listview_chart);
         
-        ListView lv = (ListView) findViewById(R.id.listView1);
+        ListView lv = findViewById(R.id.listView1);
 
         ArrayList<ChartItem> list = new ArrayList<ChartItem>();
 

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/MultiLineChartActivity.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/MultiLineChartActivity.java
@@ -39,16 +39,16 @@ public class MultiLineChartActivity extends DemoBase implements OnSeekBarChangeL
                 WindowManager.LayoutParams.FLAG_FULLSCREEN);
         setContentView(R.layout.activity_linechart);
 
-        tvX = (TextView) findViewById(R.id.tvXMax);
-        tvY = (TextView) findViewById(R.id.tvYMax);
+        tvX = findViewById(R.id.tvXMax);
+        tvY = findViewById(R.id.tvYMax);
 
-        mSeekBarX = (SeekBar) findViewById(R.id.seekBar1);
+        mSeekBarX = findViewById(R.id.seekBar1);
         mSeekBarX.setOnSeekBarChangeListener(this);
 
-        mSeekBarY = (SeekBar) findViewById(R.id.seekBar2);
+        mSeekBarY = findViewById(R.id.seekBar2);
         mSeekBarY.setOnSeekBarChangeListener(this);
 
-        mChart = (LineChart) findViewById(R.id.chart1);
+        mChart = findViewById(R.id.chart1);
         mChart.setOnChartValueSelectedListener(this);
         
         mChart.setDrawGridBackground(false);

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/PerformanceLineChart.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/PerformanceLineChart.java
@@ -30,15 +30,15 @@ public class PerformanceLineChart extends DemoBase implements OnSeekBarChangeLis
                 WindowManager.LayoutParams.FLAG_FULLSCREEN);
         setContentView(R.layout.activity_performance_linechart);
 
-        mTvCount = (TextView) findViewById(R.id.tvValueCount);
-        mSeekBarValues = (SeekBar) findViewById(R.id.seekbarValues);
+        mTvCount = findViewById(R.id.tvValueCount);
+        mSeekBarValues = findViewById(R.id.seekbarValues);
         mTvCount.setText("500");
 
         mSeekBarValues.setProgress(500);
         
         mSeekBarValues.setOnSeekBarChangeListener(this);
 
-        mChart = (LineChart) findViewById(R.id.chart1);
+        mChart = findViewById(R.id.chart1);
         mChart.setDrawGridBackground(false);
 
         // no description text

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/PieChartActivity.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/PieChartActivity.java
@@ -48,15 +48,15 @@ public class PieChartActivity extends DemoBase implements OnSeekBarChangeListene
                 WindowManager.LayoutParams.FLAG_FULLSCREEN);
         setContentView(R.layout.activity_piechart);
 
-        tvX = (TextView) findViewById(R.id.tvXMax);
-        tvY = (TextView) findViewById(R.id.tvYMax);
+        tvX = findViewById(R.id.tvXMax);
+        tvY = findViewById(R.id.tvYMax);
 
-        mSeekBarX = (SeekBar) findViewById(R.id.seekBar1);
-        mSeekBarY = (SeekBar) findViewById(R.id.seekBar2);
+        mSeekBarX = findViewById(R.id.seekBar1);
+        mSeekBarY = findViewById(R.id.seekBar2);
         mSeekBarX.setProgress(4);
         mSeekBarY.setProgress(10);
 
-        mChart = (PieChart) findViewById(R.id.chart1);
+        mChart = findViewById(R.id.chart1);
         mChart.setUsePercentValues(true);
         mChart.getDescription().setEnabled(false);
         mChart.setExtraOffsets(5, 10, 5, 5);

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/PiePolylineChartActivity.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/PiePolylineChartActivity.java
@@ -48,18 +48,18 @@ public class PiePolylineChartActivity extends DemoBase implements OnSeekBarChang
                 WindowManager.LayoutParams.FLAG_FULLSCREEN);
         setContentView(R.layout.activity_piechart);
 
-        tvX = (TextView) findViewById(R.id.tvXMax);
-        tvY = (TextView) findViewById(R.id.tvYMax);
+        tvX = findViewById(R.id.tvXMax);
+        tvY = findViewById(R.id.tvYMax);
 
-        mSeekBarX = (SeekBar) findViewById(R.id.seekBar1);
-        mSeekBarY = (SeekBar) findViewById(R.id.seekBar2);
+        mSeekBarX = findViewById(R.id.seekBar1);
+        mSeekBarY = findViewById(R.id.seekBar2);
 
         mSeekBarY.setProgress(10);
 
         mSeekBarX.setOnSeekBarChangeListener(this);
         mSeekBarY.setOnSeekBarChangeListener(this);
 
-        mChart = (PieChart) findViewById(R.id.chart1);
+        mChart = findViewById(R.id.chart1);
         mChart.setUsePercentValues(true);
         mChart.getDescription().setEnabled(false);
         mChart.setExtraOffsets(5, 10, 5, 5);

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/RadarChartActivity.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/RadarChartActivity.java
@@ -38,12 +38,12 @@ public class RadarChartActivity extends DemoBase {
                 WindowManager.LayoutParams.FLAG_FULLSCREEN);
         setContentView(R.layout.activity_radarchart_noseekbar);
 
-        TextView tv = (TextView) findViewById(R.id.textView);
+        TextView tv = findViewById(R.id.textView);
         tv.setTypeface(mTfLight);
         tv.setTextColor(Color.WHITE);
         tv.setBackgroundColor(Color.rgb(60, 65, 82));
 
-        mChart = (RadarChart) findViewById(R.id.chart1);
+        mChart = findViewById(R.id.chart1);
         mChart.setBackgroundColor(Color.rgb(60, 65, 82));
 
         mChart.getDescription().setEnabled(false);

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/RealtimeLineChartActivity.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/RealtimeLineChartActivity.java
@@ -36,7 +36,7 @@ public class RealtimeLineChartActivity extends DemoBase implements
                 WindowManager.LayoutParams.FLAG_FULLSCREEN);
         setContentView(R.layout.activity_realtime_linechart);
 
-        mChart = (LineChart) findViewById(R.id.chart1);
+        mChart = findViewById(R.id.chart1);
         mChart.setOnChartValueSelectedListener(this);
 
         // enable description text

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/ScatterChartActivity.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/ScatterChartActivity.java
@@ -42,16 +42,16 @@ public class ScatterChartActivity extends DemoBase implements OnSeekBarChangeLis
                 WindowManager.LayoutParams.FLAG_FULLSCREEN);
         setContentView(R.layout.activity_scatterchart);
 
-        tvX = (TextView) findViewById(R.id.tvXMax);
-        tvY = (TextView) findViewById(R.id.tvYMax);
+        tvX = findViewById(R.id.tvXMax);
+        tvY = findViewById(R.id.tvYMax);
 
-        mSeekBarX = (SeekBar) findViewById(R.id.seekBar1);
+        mSeekBarX = findViewById(R.id.seekBar1);
         mSeekBarX.setOnSeekBarChangeListener(this);
 
-        mSeekBarY = (SeekBar) findViewById(R.id.seekBar2);
+        mSeekBarY = findViewById(R.id.seekBar2);
         mSeekBarY.setOnSeekBarChangeListener(this);
 
-        mChart = (ScatterChart) findViewById(R.id.chart1);
+        mChart = findViewById(R.id.chart1);
         mChart.getDescription().setEnabled(false);
         mChart.setOnChartValueSelectedListener(this);
 

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/ScrollViewActivity.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/ScrollViewActivity.java
@@ -26,7 +26,7 @@ public class ScrollViewActivity extends DemoBase {
                 WindowManager.LayoutParams.FLAG_FULLSCREEN);
         setContentView(R.layout.activity_scrollview);
 
-        mChart = (BarChart) findViewById(R.id.chart1);
+        mChart = findViewById(R.id.chart1);
 
         mChart.getDescription().setEnabled(false);
 

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/StackedBarActivity.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/StackedBarActivity.java
@@ -44,16 +44,16 @@ public class StackedBarActivity extends DemoBase implements OnSeekBarChangeListe
         getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN, WindowManager.LayoutParams.FLAG_FULLSCREEN);
         setContentView(R.layout.activity_barchart);
 
-        tvX = (TextView) findViewById(R.id.tvXMax);
-        tvY = (TextView) findViewById(R.id.tvYMax);
+        tvX = findViewById(R.id.tvXMax);
+        tvY = findViewById(R.id.tvYMax);
 
-        mSeekBarX = (SeekBar) findViewById(R.id.seekBar1);
+        mSeekBarX = findViewById(R.id.seekBar1);
         mSeekBarX.setOnSeekBarChangeListener(this);
 
-        mSeekBarY = (SeekBar) findViewById(R.id.seekBar2);
+        mSeekBarY = findViewById(R.id.seekBar2);
         mSeekBarY.setOnSeekBarChangeListener(this);
 
-        mChart = (BarChart) findViewById(R.id.chart1);
+        mChart = findViewById(R.id.chart1);
         mChart.setOnChartValueSelectedListener(this);
 
         mChart.getDescription().setEnabled(false);

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/StackedBarActivityNegative.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/StackedBarActivityNegative.java
@@ -46,7 +46,7 @@ public class StackedBarActivityNegative extends DemoBase implements
 
         setTitle("Age Distribution Austria");
 
-        mChart = (HorizontalBarChart) findViewById(R.id.chart1);
+        mChart = findViewById(R.id.chart1);
         mChart.setOnChartValueSelectedListener(this);
         mChart.setDrawGridBackground(false);
         mChart.getDescription().setEnabled(false);

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/custom/MyMarkerView.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/custom/MyMarkerView.java
@@ -24,7 +24,7 @@ public class MyMarkerView extends MarkerView {
     public MyMarkerView(Context context, int layoutResource) {
         super(context, layoutResource);
 
-        tvContent = (TextView) findViewById(R.id.tvContent);
+        tvContent = findViewById(R.id.tvContent);
     }
 
     // callbacks everytime the MarkerView is redrawn, can be used to update the

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/custom/RadarMarkerView.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/custom/RadarMarkerView.java
@@ -28,7 +28,7 @@ public class RadarMarkerView extends MarkerView {
     public RadarMarkerView(Context context, int layoutResource) {
         super(context, layoutResource);
 
-        tvContent = (TextView) findViewById(R.id.tvContent);
+        tvContent = findViewById(R.id.tvContent);
         tvContent.setTypeface(Typeface.createFromAsset(context.getAssets(), "OpenSans-Light.ttf"));
     }
 

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/custom/StackedBarsMarkerView.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/custom/StackedBarsMarkerView.java
@@ -24,7 +24,7 @@ public class StackedBarsMarkerView extends MarkerView {
     public StackedBarsMarkerView(Context context, int layoutResource) {
         super(context, layoutResource);
 
-        tvContent = (TextView) findViewById(R.id.tvContent);
+        tvContent = findViewById(R.id.tvContent);
     }
 
     // callbacks everytime the MarkerView is redrawn, can be used to update the

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/custom/XYMarkerView.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/custom/XYMarkerView.java
@@ -29,7 +29,7 @@ public class XYMarkerView extends MarkerView {
         super(context, R.layout.custom_marker_view);
 
         this.xAxisValueFormatter = xAxisValueFormatter;
-        tvContent = (TextView) findViewById(R.id.tvContent);
+        tvContent = findViewById(R.id.tvContent);
         format = new DecimalFormat("###.0");
     }
 

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/fragments/BarChartFrag.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/fragments/BarChartFrag.java
@@ -60,7 +60,7 @@ public class BarChartFrag extends SimpleFragment implements OnChartGestureListen
         xAxis.setEnabled(false);
         
         // programatically add the chart
-        FrameLayout parent = (FrameLayout) v.findViewById(R.id.parentLayout);
+        FrameLayout parent = v.findViewById(R.id.parentLayout);
         parent.addView(mChart);
         
         return v;

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/fragments/ComplexityFragment.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/fragments/ComplexityFragment.java
@@ -25,7 +25,7 @@ public class ComplexityFragment extends SimpleFragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View v = inflater.inflate(R.layout.frag_simple_line, container, false);
         
-        mChart = (LineChart) v.findViewById(R.id.lineChart1);
+        mChart = v.findViewById(R.id.lineChart1);
 
         mChart.getDescription().setEnabled(false);
 

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/fragments/PieChartFrag.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/fragments/PieChartFrag.java
@@ -28,7 +28,7 @@ public class PieChartFrag extends SimpleFragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View v = inflater.inflate(R.layout.frag_simple_pie, container, false);
         
-        mChart = (PieChart) v.findViewById(R.id.pieChart1);
+        mChart = v.findViewById(R.id.pieChart1);
         mChart.getDescription().setEnabled(false);
         
         Typeface tf = Typeface.createFromAsset(getActivity().getAssets(), "OpenSans-Light.ttf");

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/fragments/ScatterChartFrag.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/fragments/ScatterChartFrag.java
@@ -28,7 +28,7 @@ public class ScatterChartFrag extends SimpleFragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View v = inflater.inflate(R.layout.frag_simple_scatter, container, false);
         
-        mChart = (ScatterChart) v.findViewById(R.id.scatterChart1);
+        mChart = v.findViewById(R.id.scatterChart1);
         mChart.getDescription().setEnabled(false);
         
         Typeface tf = Typeface.createFromAsset(getActivity().getAssets(),"OpenSans-Light.ttf");

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/fragments/SimpleChartDemo.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/fragments/SimpleChartDemo.java
@@ -29,7 +29,7 @@ public class SimpleChartDemo extends DemoBase {
         
         setContentView(R.layout.activity_awesomedesign);
 
-        ViewPager pager = (ViewPager) findViewById(R.id.pager);
+        ViewPager pager = findViewById(R.id.pager);
         pager.setOffscreenPageLimit(3);
         
         PageAdapter a = new PageAdapter(getSupportFragmentManager());

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/fragments/SineCosineFragment.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/fragments/SineCosineFragment.java
@@ -25,7 +25,7 @@ public class SineCosineFragment extends SimpleFragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View v = inflater.inflate(R.layout.frag_simple_line, container, false);
         
-        mChart = (LineChart) v.findViewById(R.id.lineChart1);
+        mChart = v.findViewById(R.id.lineChart1);
 
         mChart.getDescription().setEnabled(false);
 

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/listviewitems/BarChartItem.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/listviewitems/BarChartItem.java
@@ -39,7 +39,7 @@ public class BarChartItem extends ChartItem {
 
             convertView = LayoutInflater.from(c).inflate(
                     R.layout.list_item_barchart, null);
-            holder.chart = (BarChart) convertView.findViewById(R.id.chart);
+            holder.chart = convertView.findViewById(R.id.chart);
 
             convertView.setTag(holder);
 

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/listviewitems/LineChartItem.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/listviewitems/LineChartItem.java
@@ -40,7 +40,7 @@ public class LineChartItem extends ChartItem {
 
             convertView = LayoutInflater.from(c).inflate(
                     R.layout.list_item_linechart, null);
-            holder.chart = (LineChart) convertView.findViewById(R.id.chart);
+            holder.chart = convertView.findViewById(R.id.chart);
 
             convertView.setTag(holder);
 

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/listviewitems/PieChartItem.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/listviewitems/PieChartItem.java
@@ -47,7 +47,7 @@ public class PieChartItem extends ChartItem {
 
             convertView = LayoutInflater.from(c).inflate(
                     R.layout.list_item_piechart, null);
-            holder.chart = (PieChart) convertView.findViewById(R.id.chart);
+            holder.chart = convertView.findViewById(R.id.chart);
 
             convertView.setTag(holder);
 

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/notimportant/MainActivity.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/notimportant/MainActivity.java
@@ -149,7 +149,7 @@ public class MainActivity extends Activity implements OnItemClickListener {
 
         MyAdapter adapter = new MyAdapter(this, objects);
 
-        ListView lv = (ListView) findViewById(R.id.listView1);
+        ListView lv = findViewById(R.id.listView1);
         lv.setAdapter(adapter);
 
         lv.setOnItemClickListener(this);

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/notimportant/MyAdapter.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/notimportant/MyAdapter.java
@@ -39,9 +39,9 @@ public class MyAdapter extends ArrayAdapter<ContentItem> {
             holder = new ViewHolder();
 
             convertView = LayoutInflater.from(getContext()).inflate(R.layout.list_item, null);
-            holder.tvName = (TextView) convertView.findViewById(R.id.tvName);
-            holder.tvDesc = (TextView) convertView.findViewById(R.id.tvDesc);
-            holder.tvNew = (TextView) convertView.findViewById(R.id.tvNew);
+            holder.tvName = convertView.findViewById(R.id.tvName);
+            holder.tvDesc = convertView.findViewById(R.id.tvDesc);
+            holder.tvNew = convertView.findViewById(R.id.tvNew);
 
             convertView.setTag(holder);
 

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/realm/RealmDatabaseActivityBar.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/realm/RealmDatabaseActivityBar.java
@@ -30,7 +30,7 @@ public class RealmDatabaseActivityBar extends RealmBaseActivity {
                 WindowManager.LayoutParams.FLAG_FULLSCREEN);
         setContentView(R.layout.activity_barchart_noseekbar);
 
-        mChart = (BarChart) findViewById(R.id.chart1);
+        mChart = findViewById(R.id.chart1);
         setup(mChart);
     }
 

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/realm/RealmDatabaseActivityBubble.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/realm/RealmDatabaseActivityBubble.java
@@ -30,7 +30,7 @@ public class RealmDatabaseActivityBubble extends RealmBaseActivity {
                 WindowManager.LayoutParams.FLAG_FULLSCREEN);
         setContentView(R.layout.activity_bubblechart_noseekbar);
 
-        mChart = (BubbleChart) findViewById(R.id.chart1);
+        mChart = findViewById(R.id.chart1);
         setup(mChart);
 
         mChart.getXAxis().setDrawGridLines(false);

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/realm/RealmDatabaseActivityCandle.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/realm/RealmDatabaseActivityCandle.java
@@ -31,7 +31,7 @@ public class RealmDatabaseActivityCandle extends RealmBaseActivity {
                 WindowManager.LayoutParams.FLAG_FULLSCREEN);
         setContentView(R.layout.activity_candlechart_noseekbar);
 
-        mChart = (CandleStickChart) findViewById(R.id.chart1);
+        mChart = findViewById(R.id.chart1);
         setup(mChart);
 
         mChart.getAxisLeft().setDrawGridLines(false);

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/realm/RealmDatabaseActivityHorizontalBar.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/realm/RealmDatabaseActivityHorizontalBar.java
@@ -31,7 +31,7 @@ public class RealmDatabaseActivityHorizontalBar extends RealmBaseActivity {
                 WindowManager.LayoutParams.FLAG_FULLSCREEN);
         setContentView(R.layout.activity_horizontalbarchart_noseekbar);
 
-        mChart = (HorizontalBarChart) findViewById(R.id.chart1);
+        mChart = findViewById(R.id.chart1);
         setup(mChart);
 
         mChart.getAxisLeft().setAxisMinimum(0f);

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/realm/RealmDatabaseActivityLine.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/realm/RealmDatabaseActivityLine.java
@@ -31,7 +31,7 @@ public class RealmDatabaseActivityLine extends RealmBaseActivity {
                 WindowManager.LayoutParams.FLAG_FULLSCREEN);
         setContentView(R.layout.activity_linechart_noseekbar);
 
-        mChart = (LineChart) findViewById(R.id.chart1);
+        mChart = findViewById(R.id.chart1);
         setup(mChart);
 
         mChart.getAxisLeft().setAxisMaximum(150f);

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/realm/RealmDatabaseActivityPie.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/realm/RealmDatabaseActivityPie.java
@@ -32,7 +32,7 @@ public class RealmDatabaseActivityPie extends RealmBaseActivity {
                 WindowManager.LayoutParams.FLAG_FULLSCREEN);
         setContentView(R.layout.activity_piechart_noseekbar);
 
-        mChart = (PieChart) findViewById(R.id.chart1);
+        mChart = findViewById(R.id.chart1);
         setup(mChart);
 
         mChart.setCenterText(generateCenterSpannableText());

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/realm/RealmDatabaseActivityRadar.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/realm/RealmDatabaseActivityRadar.java
@@ -30,7 +30,7 @@ public class RealmDatabaseActivityRadar extends RealmBaseActivity {
                 WindowManager.LayoutParams.FLAG_FULLSCREEN);
         setContentView(R.layout.activity_radarchart_noseekbar);
 
-        mChart = (RadarChart) findViewById(R.id.chart1);
+        mChart = findViewById(R.id.chart1);
         setup(mChart);
 
         mChart.getYAxis().setEnabled(false);

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/realm/RealmDatabaseActivityScatter.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/realm/RealmDatabaseActivityScatter.java
@@ -30,7 +30,7 @@ public class RealmDatabaseActivityScatter extends RealmBaseActivity {
                 WindowManager.LayoutParams.FLAG_FULLSCREEN);
         setContentView(R.layout.activity_scatterchart_noseekbar);
 
-        mChart = (ScatterChart) findViewById(R.id.chart1);
+        mChart = findViewById(R.id.chart1);
         setup(mChart);
 
         mChart.getAxisLeft().setDrawGridLines(false);

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/realm/RealmMainActivity.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/realm/RealmMainActivity.java
@@ -51,7 +51,7 @@ public class RealmMainActivity extends DemoBase implements AdapterView.OnItemCli
 
         MyAdapter adapter = new MyAdapter(this, objects);
 
-        ListView lv = (ListView) findViewById(R.id.listView1);
+        ListView lv = findViewById(R.id.listView1);
         lv.setAdapter(adapter);
 
         lv.setOnItemClickListener(this);

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/realm/RealmWikiExample.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/realm/RealmWikiExample.java
@@ -37,8 +37,8 @@ public class RealmWikiExample extends RealmBaseActivity {
                 WindowManager.LayoutParams.FLAG_FULLSCREEN);
         setContentView(R.layout.activity_realm_wiki);
 
-        lineChart = (LineChart) findViewById(R.id.lineChart);
-        barChart = (BarChart) findViewById(R.id.barChart);
+        lineChart = findViewById(R.id.lineChart);
+        barChart = findViewById(R.id.barChart);
         setup(lineChart);
         setup(barChart);
 


### PR DESCRIPTION
## PR Checklist:
- [X] I have tested this extensively and it does not break any existing behavior.
Yep, opened the example app, clicked through it to see, if views initialise properly.
- [X] I have added/updated examples and tests for any new behavior.
Modified existing ones.
- [X] If this is a significant change, an issue has already been created where the problem / solution was discussed
This was suggested in [PR 3975](https://github.com/PhilJay/MPAndroidChart/pull/3975) that migrated the project to newest Gradle version and Gradle version plugin.


## PR Description
After migration to API 26, new version of `findViewById` method was added that caused, that casts to specific view instance is unnecessary. This PR removes those unnecessary casts.

