### PR TITLE
Fix IndexOutOfBoundsException thrown when drawing data set values (#2450)

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/BarChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/BarChartRenderer.java
@@ -229,9 +229,12 @@ public class BarChartRenderer extends BarLineScatterCandleBubbleRenderer {
             for (int i = 0; i < mChart.getBarData().getDataSetCount(); i++) {
 
                 IBarDataSet dataSet = dataSets.get(i);
-
-                if (!shouldDrawValues(dataSet))
+                if (dataSet.getEntryCount() == 0) {
                     continue;
+                }
+                if (!shouldDrawValues(dataSet)) {
+                    continue;
+                }
 
                 // apply the text-styling defined by the DataSet
                 applyValueTextStyle(dataSet);

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/BubbleChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/BubbleChartRenderer.java
@@ -130,9 +130,12 @@ public class BubbleChartRenderer extends BarLineScatterCandleBubbleRenderer {
             for (int i = 0; i < dataSets.size(); i++) {
 
                 IBubbleDataSet dataSet = dataSets.get(i);
-
-                if (!shouldDrawValues(dataSet))
+                if (dataSet.getEntryCount() == 0) {
                     continue;
+                }
+                if (!shouldDrawValues(dataSet)) {
+                    continue;
+                }
 
                 // apply the text-styling defined by the DataSet
                 applyValueTextStyle(dataSet);

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/CandleStickChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/CandleStickChartRenderer.java
@@ -263,9 +263,12 @@ public class CandleStickChartRenderer extends LineScatterCandleRadarRenderer {
             for (int i = 0; i < dataSets.size(); i++) {
 
                 ICandleDataSet dataSet = dataSets.get(i);
-
-                if (!shouldDrawValues(dataSet))
+                if (dataSet.getEntryCount() == 0) {
                     continue;
+                }
+                if (!shouldDrawValues(dataSet)) {
+                    continue;
+                }
 
                 // apply the text-styling defined by the DataSet
                 applyValueTextStyle(dataSet);

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/HorizontalBarChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/HorizontalBarChartRenderer.java
@@ -75,7 +75,7 @@ public class HorizontalBarChartRenderer extends BarChartRenderer {
             final float barWidthHalf = barWidth / 2.0f;
             float x;
 
-            for (int i = 0, count = Math.min((int)(Math.ceil((float)(dataSet.getEntryCount()) * phaseX)), dataSet.getEntryCount());
+            for (int i = 0, count = Math.min((int) (Math.ceil((float) (dataSet.getEntryCount()) * phaseX)), dataSet.getEntryCount());
                  i < count;
                  i++) {
 
@@ -157,9 +157,12 @@ public class HorizontalBarChartRenderer extends BarChartRenderer {
             for (int i = 0; i < mChart.getBarData().getDataSetCount(); i++) {
 
                 IBarDataSet dataSet = dataSets.get(i);
-
-                if (!shouldDrawValues(dataSet))
+                if (dataSet.getEntryCount() == 0) {
                     continue;
+                }
+                if (!shouldDrawValues(dataSet)) {
+                    continue;
+                }
 
                 boolean isInverted = mChart.isInverted(dataSet.getAxisDependency());
 
@@ -229,8 +232,8 @@ public class HorizontalBarChartRenderer extends BarChartRenderer {
                             Utils.drawImage(
                                     c,
                                     icon,
-                                    (int)px,
-                                    (int)py,
+                                    (int) px,
+                                    (int) py,
                                     icon.getIntrinsicWidth(),
                                     icon.getIntrinsicHeight());
                         }
@@ -300,8 +303,8 @@ public class HorizontalBarChartRenderer extends BarChartRenderer {
                                 Utils.drawImage(
                                         c,
                                         icon,
-                                        (int)px,
-                                        (int)py,
+                                        (int) px,
+                                        (int) py,
                                         icon.getIntrinsicWidth(),
                                         icon.getIntrinsicHeight());
                             }
@@ -378,8 +381,8 @@ public class HorizontalBarChartRenderer extends BarChartRenderer {
                                     Utils.drawImage(
                                             c,
                                             icon,
-                                            (int)(x + iconsOffset.x),
-                                            (int)(y + iconsOffset.y),
+                                            (int) (x + iconsOffset.x),
+                                            (int) (y + iconsOffset.y),
                                             icon.getIntrinsicWidth(),
                                             icon.getIntrinsicHeight());
                                 }

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineChartRenderer.java
@@ -529,9 +529,12 @@ public class LineChartRenderer extends LineRadarRenderer {
             for (int i = 0; i < dataSets.size(); i++) {
 
                 ILineDataSet dataSet = dataSets.get(i);
-
-                if (!shouldDrawValues(dataSet))
+                if (dataSet.getEntryCount() == 0) {
                     continue;
+                }
+                if (!shouldDrawValues(dataSet)) {
+                    continue;
+                }
 
                 // apply the text-styling defined by the DataSet
                 applyValueTextStyle(dataSet);

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/PieChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/PieChartRenderer.java
@@ -423,11 +423,13 @@ public class PieChartRenderer extends DataRenderer {
         for (int i = 0; i < dataSets.size(); i++) {
 
             IPieDataSet dataSet = dataSets.get(i);
-
-            final boolean drawValues = dataSet.isDrawValuesEnabled();
-
-            if (!drawValues && !drawEntryLabels)
+            if (dataSet.getEntryCount() == 0) {
                 continue;
+            }
+            final boolean drawValues = dataSet.isDrawValuesEnabled();
+            if (!drawValues && !drawEntryLabels) {
+                continue;
+            }
 
             final PieDataSet.ValuePosition xValuePosition = dataSet.getXValuePosition();
             final PieDataSet.ValuePosition yValuePosition = dataSet.getYValuePosition();
@@ -520,7 +522,7 @@ public class PieChartRenderer extends DataRenderer {
 
                         mValuePaint.setTextAlign(Align.RIGHT);
 
-                        if(drawXOutside)
+                        if (drawXOutside)
                             mEntryLabelsPaint.setTextAlign(Align.RIGHT);
 
                         labelPtx = pt2x - offset;
@@ -530,7 +532,7 @@ public class PieChartRenderer extends DataRenderer {
                         pt2y = pt1y;
                         mValuePaint.setTextAlign(Align.LEFT);
 
-                        if(drawXOutside)
+                        if (drawXOutside)
                             mEntryLabelsPaint.setTextAlign(Align.LEFT);
 
                         labelPtx = pt2x + offset;
@@ -611,8 +613,8 @@ public class PieChartRenderer extends DataRenderer {
                     Utils.drawImage(
                             c,
                             icon,
-                            (int)x,
-                            (int)y,
+                            (int) x,
+                            (int) y,
                             icon.getIntrinsicWidth(),
                             icon.getIntrinsicHeight());
                 }
@@ -690,6 +692,7 @@ public class PieChartRenderer extends DataRenderer {
     }
 
     protected Path mDrawCenterTextPathBuffer = new Path();
+
     /**
      * draws the description text in the center of the pie chart makes most
      * sense when center-hole is enabled
@@ -763,6 +766,7 @@ public class PieChartRenderer extends DataRenderer {
     }
 
     protected RectF mDrawHighlightedRectF = new RectF();
+
     @Override
     public void drawHighlighted(Canvas c, Highlight[] indices) {
 
@@ -782,7 +786,7 @@ public class PieChartRenderer extends DataRenderer {
                 : 0.f;
 
         final RectF highlightedCircleBox = mDrawHighlightedRectF;
-        highlightedCircleBox.set(0,0,0,0);
+        highlightedCircleBox.set(0, 0, 0, 0);
 
         for (int i = 0; i < indices.length; i++) {
 

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/RadarChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/RadarChartRenderer.java
@@ -70,6 +70,7 @@ public class RadarChartRenderer extends LineRadarRenderer {
     }
 
     protected Path mDrawDataSetSurfacePathBuffer = new Path();
+
     /**
      * Draws the RadarDataSet
      *
@@ -89,7 +90,7 @@ public class RadarChartRenderer extends LineRadarRenderer {
         float factor = mChart.getFactor();
 
         MPPointF center = mChart.getCenterOffsets();
-        MPPointF pOut = MPPointF.getInstance(0,0);
+        MPPointF pOut = MPPointF.getInstance(0, 0);
         Path surface = mDrawDataSetSurfacePathBuffer;
         surface.reset();
 
@@ -159,17 +160,20 @@ public class RadarChartRenderer extends LineRadarRenderer {
         float factor = mChart.getFactor();
 
         MPPointF center = mChart.getCenterOffsets();
-        MPPointF pOut = MPPointF.getInstance(0,0);
-        MPPointF pIcon = MPPointF.getInstance(0,0);
+        MPPointF pOut = MPPointF.getInstance(0, 0);
+        MPPointF pIcon = MPPointF.getInstance(0, 0);
 
         float yoffset = Utils.convertDpToPixel(5f);
 
         for (int i = 0; i < mChart.getData().getDataSetCount(); i++) {
 
             IRadarDataSet dataSet = mChart.getData().getDataSetByIndex(i);
-
-            if (!shouldDrawValues(dataSet))
+            if (dataSet.getEntryCount() == 0) {
                 continue;
+            }
+            if (!shouldDrawValues(dataSet)) {
+                continue;
+            }
 
             // apply the text-styling defined by the DataSet
             applyValueTextStyle(dataSet);
@@ -182,11 +186,11 @@ public class RadarChartRenderer extends LineRadarRenderer {
 
                 RadarEntry entry = dataSet.getEntryForIndex(j);
 
-                 Utils.getPosition(
-                         center,
-                         (entry.getY() - mChart.getYChartMin()) * factor * phaseY,
-                         sliceangle * j * phaseX + mChart.getRotationAngle(),
-                         pOut);
+                Utils.getPosition(
+                        center,
+                        (entry.getY() - mChart.getYChartMin()) * factor * phaseY,
+                        sliceangle * j * phaseX + mChart.getRotationAngle(),
+                        pOut);
 
                 if (dataSet.isDrawValuesEnabled()) {
                     drawValue(c,
@@ -216,8 +220,8 @@ public class RadarChartRenderer extends LineRadarRenderer {
                     Utils.drawImage(
                             c,
                             icon,
-                            (int)pIcon.x,
-                            (int)pIcon.y,
+                            (int) pIcon.x,
+                            (int) pIcon.y,
                             icon.getIntrinsicWidth(),
                             icon.getIntrinsicHeight());
                 }
@@ -255,7 +259,7 @@ public class RadarChartRenderer extends LineRadarRenderer {
         final int xIncrements = 1 + mChart.getSkipWebLineCount();
         int maxEntryCount = mChart.getData().getMaxEntryCountSet().getEntryCount();
 
-        MPPointF p = MPPointF.getInstance(0,0);
+        MPPointF p = MPPointF.getInstance(0, 0);
         for (int i = 0; i < maxEntryCount; i += xIncrements) {
 
             Utils.getPosition(
@@ -275,8 +279,8 @@ public class RadarChartRenderer extends LineRadarRenderer {
 
         int labelCount = mChart.getYAxis().mEntryCount;
 
-        MPPointF p1out = MPPointF.getInstance(0,0);
-        MPPointF p2out = MPPointF.getInstance(0,0);
+        MPPointF p1out = MPPointF.getInstance(0, 0);
+        MPPointF p2out = MPPointF.getInstance(0, 0);
         for (int j = 0; j < labelCount; j++) {
 
             for (int i = 0; i < mChart.getData().getEntryCount(); i++) {
@@ -305,7 +309,7 @@ public class RadarChartRenderer extends LineRadarRenderer {
         float factor = mChart.getFactor();
 
         MPPointF center = mChart.getCenterOffsets();
-        MPPointF pOut = MPPointF.getInstance(0,0);
+        MPPointF pOut = MPPointF.getInstance(0, 0);
 
         RadarData radarData = mChart.getData();
 
@@ -362,6 +366,7 @@ public class RadarChartRenderer extends LineRadarRenderer {
     }
 
     protected Path mDrawHighlightCirclePathBuffer = new Path();
+
     public void drawHighlightCircle(Canvas c,
                                     MPPointF point,
                                     float innerRadius,

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/ScatterChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/ScatterChartRenderer.java
@@ -101,8 +101,12 @@ public class ScatterChartRenderer extends LineScatterCandleRadarRenderer {
 
                 IScatterDataSet dataSet = dataSets.get(i);
 
-                if (!shouldDrawValues(dataSet))
+                if (dataSet.getEntryCount() == 0) {
                     continue;
+                }
+                if (!shouldDrawValues(dataSet)) {
+                    continue;
+                }
 
                 // apply the text-styling defined by the DataSet
                 applyValueTextStyle(dataSet);


### PR DESCRIPTION
## PR Checklist:
- [X] I have tested this extensively and it does not break any existing behavior.
Issue was easily reproduced in example app.
Steps to reproduce:
1. Open Line char (Dual axis) or Scatter Chart
2. Move upper progress bar to very left
- [X] I have added/updated examples and tests for any new behavior.
Example charts are fixed, crash does not happen anymore
- [X] If this is a significant change, an issue has already been created where the problem / solution was discussed:
Issues with the same stacktrace:
#2450
#2455
#2849
#2869
#2952
#3011
#3124
#3171
#3213
#3361
#3566
#3623
#3696
#3755
#4015
#4033

There were: [PR 3232](https://github.com/PhilJay/MPAndroidChart/pull/3232) and [PR 2958](https://github.com/PhilJay/MPAndroidChart/pull/2958) that tried to fix that. However, those fixes just suppressed the cause, and did not omitted root cause (Empty data set). In my opinion they can be closed.

## PR Description
Crash was thrown, when one of data set in charts' data sets was empty.
The fix is preventing from drawing anything on empty data set.
Fixed for all chart types.

<!-- What does this add/ remove/ fix/ change? -->
Adds a check, whether data set is empty before drawing values.

<!-- WHY should this PR be merged into the main library? -->
Adds greatly awaited bugfix, that was reported multiple times.
