### PR TITLE
[Enhancement] Removed mLabelRotatedWidth/Height variables from XAxis model.

### DIFF
--- a/MPChartExample/res/menu/bar.xml
+++ b/MPChartExample/res/menu/bar.xml
@@ -45,5 +45,10 @@
         android:id="@+id/actionToggleBarBorders"
         android:title="Show Bar Borders">
     </item>
+    <item
+        android:id="@+id/actionRotateXAxisLabelsBy45Deg"
+        android:title="rotate X Axis labels">
+
+    </item>
 
 </menu>

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/BarChartActivity.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/BarChartActivity.java
@@ -212,6 +212,11 @@ public class BarChartActivity extends DemoBase implements OnSeekBarChangeListene
                             .show();
                 break;
             }
+            case R.id.actionRotateXAxisLabelsBy45Deg: {
+                mChart.getXAxis().setLabelRotationAngle(45);
+                mChart.notifyDataSetChanged();
+                mChart.invalidate();
+            }
         }
         return true;
     }

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/charts/BarLineChartBase.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/charts/BarLineChartBase.java
@@ -486,7 +486,7 @@ public abstract class BarLineChartBase<T extends BarLineScatterCandleBubbleData<
 
             if (mXAxis.isEnabled() && mXAxis.isDrawLabelsEnabled()) {
 
-                float xLabelHeight = mXAxis.mLabelRotatedHeight + mXAxis.getYOffset();
+                float xLabelHeight = mXAxis.mLabelHeight + mXAxis.getYOffset();
 
                 // offsets for x-labels
                 if (mXAxis.getPosition() == XAxisPosition.BOTTOM) {

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/charts/HorizontalBarChart.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/charts/HorizontalBarChart.java
@@ -81,23 +81,23 @@ public class HorizontalBarChart extends BarChart {
             offsetBottom += mAxisRight.getRequiredHeightSpace(mAxisRendererRight.getPaintAxisLabels());
         }
 
-        float xlabelwidth = mXAxis.mLabelRotatedWidth;
+        float xLabelWidth = mXAxis.mLabelWidth;
 
         if (mXAxis.isEnabled()) {
 
             // offsets for x-labels
             if (mXAxis.getPosition() == XAxisPosition.BOTTOM) {
 
-                offsetLeft += xlabelwidth;
+                offsetLeft += xLabelWidth;
 
             } else if (mXAxis.getPosition() == XAxisPosition.TOP) {
 
-                offsetRight += xlabelwidth;
+                offsetRight += xLabelWidth;
 
             } else if (mXAxis.getPosition() == XAxisPosition.BOTH_SIDED) {
 
-                offsetLeft += xlabelwidth;
-                offsetRight += xlabelwidth;
+                offsetLeft += xLabelWidth;
+                offsetRight += xLabelWidth;
             }
         }
 

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/charts/PieRadarChartBase.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/charts/PieRadarChartBase.java
@@ -228,7 +228,7 @@ public abstract class PieRadarChartBase<T extends ChartData<? extends IDataSet<?
             XAxis x = this.getXAxis();
 
             if (x.isEnabled() && x.isDrawLabelsEnabled()) {
-                minOffset = Math.max(minOffset, x.mLabelRotatedWidth);
+                minOffset = Math.max(minOffset, x.mLabelWidth);
             }
         }
 

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/charts/RadarChart.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/charts/RadarChart.java
@@ -326,7 +326,7 @@ public class RadarChart extends PieRadarChartBase<RadarData> {
     @Override
     protected float getRequiredBaseOffset() {
         return mXAxis.isEnabled() && mXAxis.isDrawLabelsEnabled() ?
-                mXAxis.mLabelRotatedWidth :
+                mXAxis.mLabelWidth :
                 Utils.convertDpToPixel(10f);
     }
 

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/components/XAxis.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/components/XAxis.java
@@ -25,18 +25,6 @@ public class XAxis extends AxisBase {
     public int mLabelHeight = 1;
 
     /**
-     * width of the (rotated) x-axis labels in pixels - this is automatically
-     * calculated by the computeSize() methods in the renderers
-     */
-    public int mLabelRotatedWidth = 1;
-
-    /**
-     * height of the (rotated) x-axis labels in pixels - this is automatically
-     * calculated by the computeSize() methods in the renderers
-     */
-    public int mLabelRotatedHeight = 1;
-
-    /**
      * This is the angle for drawing the X axis labels (in degrees)
      */
     protected float mLabelRotationAngle = 0f;

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/XAxisRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/XAxisRenderer.java
@@ -92,10 +92,8 @@ public class XAxisRenderer extends AxisRenderer {
                 mXAxis.getLabelRotationAngle());
 
 
-        mXAxis.mLabelWidth = Math.round(labelWidth);
-        mXAxis.mLabelHeight = Math.round(labelHeight);
-        mXAxis.mLabelRotatedWidth = Math.round(labelRotatedSize.width);
-        mXAxis.mLabelRotatedHeight = Math.round(labelRotatedSize.height);
+        mXAxis.mLabelWidth = Math.round(labelRotatedSize.width);
+        mXAxis.mLabelHeight = Math.round(labelRotatedSize.height);
 
         FSize.recycleInstance(labelRotatedSize);
         FSize.recycleInstance(labelSize);
@@ -109,8 +107,6 @@ public class XAxisRenderer extends AxisRenderer {
 
         float yoffset = mXAxis.getYOffset();
 
-        mAxisLabelPaint.setTypeface(mXAxis.getTypeface());
-        mAxisLabelPaint.setTextSize(mXAxis.getTextSize());
         mAxisLabelPaint.setColor(mXAxis.getTextColor());
 
         MPPointF pointF = MPPointF.getInstance(0,0);
@@ -122,7 +118,7 @@ public class XAxisRenderer extends AxisRenderer {
         } else if (mXAxis.getPosition() == XAxisPosition.TOP_INSIDE) {
             pointF.x = 0.5f;
             pointF.y = 1.0f;
-            drawLabels(c, mViewPortHandler.contentTop() + yoffset + mXAxis.mLabelRotatedHeight, pointF);
+            drawLabels(c, mViewPortHandler.contentTop() + yoffset + mXAxis.mLabelHeight, pointF);
 
         } else if (mXAxis.getPosition() == XAxisPosition.BOTTOM) {
             pointF.x = 0.5f;
@@ -132,7 +128,7 @@ public class XAxisRenderer extends AxisRenderer {
         } else if (mXAxis.getPosition() == XAxisPosition.BOTTOM_INSIDE) {
             pointF.x = 0.5f;
             pointF.y = 0.0f;
-            drawLabels(c, mViewPortHandler.contentBottom() - yoffset - mXAxis.mLabelRotatedHeight, pointF);
+            drawLabels(c, mViewPortHandler.contentBottom() - yoffset - mXAxis.mLabelHeight, pointF);
 
         } else { // BOTH SIDED
             pointF.x = 0.5f;

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/XAxisRendererHorizontalBarChart.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/XAxisRendererHorizontalBarChart.java
@@ -72,14 +72,12 @@ public class XAxisRendererHorizontalBarChart extends XAxisRenderer {
         final float labelHeight = labelSize.height;
 
         final FSize labelRotatedSize = Utils.getSizeOfRotatedRectangleByDegrees(
-                labelSize.width,
+                labelWidth,
                 labelHeight,
                 mXAxis.getLabelRotationAngle());
 
-        mXAxis.mLabelWidth = Math.round(labelWidth);
-        mXAxis.mLabelHeight = Math.round(labelHeight);
-        mXAxis.mLabelRotatedWidth = (int)(labelRotatedSize.width + mXAxis.getXOffset() * 3.5f);
-        mXAxis.mLabelRotatedHeight = Math.round(labelRotatedSize.height);
+        mXAxis.mLabelWidth = Math.round(labelRotatedSize.width);
+        mXAxis.mLabelHeight = Math.round(labelRotatedSize.height);
 
         FSize.recycleInstance(labelRotatedSize);
     }

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/XAxisRendererRadarChart.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/XAxisRendererRadarChart.java
@@ -48,9 +48,9 @@ public class XAxisRendererRadarChart extends XAxisRenderer {
             float angle = (sliceangle * i + mChart.getRotationAngle()) % 360f;
 
             Utils.getPosition(center, mChart.getYRange() * factor
-                    + mXAxis.mLabelRotatedWidth / 2f, angle, pOut);
+                    + mXAxis.mLabelWidth / 2f, angle, pOut);
 
-            drawLabel(c, label, pOut.x, pOut.y - mXAxis.mLabelRotatedHeight / 2.f,
+            drawLabel(c, label, pOut.x, pOut.y - mXAxis.mLabelHeight / 2.f,
                     drawLabelAnchor, labelRotationAngleDegrees);
         }
 


### PR DESCRIPTION
## PR Checklist:
- [X] I have tested this extensively and it does not break any existing behavior.
- [X] I have added/updated examples and tests for any new behavior.
Added a case for one of example charts.

## PR Description
There are 2 variables in `XAxis` model:
* mLabelRotatedWidth
* mLabelRotatedHeight
Their existence is unjustified. Those 2 variables were used only if mLabelRotationAngle was different than 0. In such situation mLabelWidth/Height became unused. This PR was removes this unnecessary overhead - merges those two cases into one  - making use of mLabelWidth/Height variables in XAxis.