### PR TITLE
fix disable hightlight on piechart (#2755)

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/charts/Chart.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/charts/Chart.java
@@ -637,7 +637,7 @@ public abstract class Chart<T extends ChartData<? extends IDataSet<? extends Ent
             if (e == null) {
                 mIndicesToHighlight = null;
                 high = null;
-            } else {
+            } else if (mData.isHighlightEnabled()) {
 
                 // set the indices to highlight
                 mIndicesToHighlight = new Highlight[]{
@@ -650,7 +650,7 @@ public abstract class Chart<T extends ChartData<? extends IDataSet<? extends Ent
 
         if (callListener && mSelectionListener != null) {
 
-            if (!valuesToHighlight())
+            if (e == null)
                 mSelectionListener.onNothingSelected();
             else {
                 // notify the listener


### PR DESCRIPTION
I have a issue when I disable hightlight on my piechart, color of selected entry is still changed, I found a logic bug in Chart class.
Issue : https://github.com/PhilJay/MPAndroidChart/issues/2755