### PR TITLE
Fix LargeValueFormatter

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/formatter/LargeValueFormatter.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/formatter/LargeValueFormatter.java
@@ -88,7 +88,7 @@ public class LargeValueFormatter implements IValueFormatter, IAxisValueFormatter
         int numericValue2 = Character.getNumericValue(r.charAt(r.length() - 2));
         int combined = Integer.valueOf(numericValue2 + "" + numericValue1);
 
-        r = r.replaceAll("E[0-9][0-9]", mSuffix[combined / 3]);
+        r = r.replaceAll("[Ee][0-9]*", SUFFIX[combined / 3]);
 
         while (r.length() > mMaxLength || r.matches("[0-9]+\\.[a-z]")) {
             r = r.substring(0, r.length() - 2) + r.substring(r.length() - 1);


### PR DESCRIPTION
On Android 8+ is format: 1e1, 1e2 1e22 for Slovak language although that in constructor is set: `###E00`

When you will have more than 2 numbers after `E` original regex will not work, because take just first 2 numbers.

## PR Checklist:
- [ ] I have tested this extensively and it does not break any existing behavior.
- [ ] I have added/updated examples and tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change, please
            create an issue to discuss those changes and gather
            feedback BEFORE submitting your PR. -->


## PR Description
<!-- Describe Your PR Here! -->

<!-- What does this add/ remove/ fix/ change? -->

<!-- WHY should this PR be merged into the main library? -->
