### PR TITLE
Fix issue #4214

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/AxisRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/AxisRenderer.java
@@ -187,10 +187,8 @@ public abstract class AxisRenderer extends Renderer {
             interval = (float) range / (float) (labelCount - 1);
             mAxis.mEntryCount = labelCount;
 
-            if (mAxis.mEntries.length < labelCount) {
-                // Ensure stops contains at least numStops elements.
-                mAxis.mEntries = new float[labelCount];
-            }
+            // Ensure stops contains at least numStops elements.
+            mAxis.mEntries = new float[labelCount];
 
             float v = min;
 
@@ -222,10 +220,7 @@ public abstract class AxisRenderer extends Renderer {
 
             mAxis.mEntryCount = n;
 
-            if (mAxis.mEntries.length < n) {
-                // Ensure stops contains at least numStops elements.
-                mAxis.mEntries = new float[n];
-            }
+            mAxis.mEntries = new float[n];
 
             for (f = first, i = 0; i < n; f += interval, ++i) {
 


### PR DESCRIPTION
setting xAxis label count with data set changes results in old dataset values passed to formatter

## PR Checklist:
- [ x] I have tested this extensively and it does not break any existing behavior.
- [ ] I have added/updated examples and tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change, please
            create an issue to discuss those changes and gather
            feedback BEFORE submitting your PR. -->


## PR Description
<!-- Describe Your PR Here! -->
Not always recreating entries array caused this bug.

<!-- What does this add/ remove/ fix/ change? -->
It only removes `if (mAxis.mEntries.length < n) {` check, always recreates the array 

<!-- WHY should this PR be merged into the main library? -->
Because it fixes the unwanted behavior.