### PR TITLE
Move to Jetpack libraries (androidx)

### DIFF
--- a/MPChartExample/AndroidManifest.xml
+++ b/MPChartExample/AndroidManifest.xml
@@ -1,12 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.xxmassdeveloper.mpchartexample"
-    android:versionCode="55"
-    android:versionName="3.0.2" >
+    package="com.xxmassdeveloper.mpchartexample">
 
-    <uses-sdk
-        android:minSdkVersion="16"
-        android:targetSdkVersion="25" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 
     <application

--- a/MPChartExample/build.gradle
+++ b/MPChartExample/build.gradle
@@ -39,7 +39,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:3.2.0'
         //classpath 'io.realm:realm-gradle-plugin:0.88.2'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/MPChartExample/build.gradle
+++ b/MPChartExample/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     implementation 'com.github.PhilJay:MPAndroidChart-Realm:v2.0.2@aar'
 
     implementation project(':MPChartLib')
-    implementation 'com.android.support:appcompat-v7:27.1.1'
+    implementation 'androidx.appcompat:appcompat:1.0.0'
     //compile 'io.realm:realm-android:0.87.5' // dependency for realm-database API (http://realm.io)
     //compile 'com.github.PhilJay:MPAndroidChart:v2.2.5'
 }

--- a/MPChartExample/build.gradle
+++ b/MPChartExample/build.gradle
@@ -2,11 +2,11 @@ apply plugin: 'com.android.application'
 apply plugin: 'realm-android'
 
 android {
-    compileSdkVersion 27
-    buildToolsVersion '27.0.3'
+    compileSdkVersion 28
+    buildToolsVersion '28.0.2'
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 56
         versionName '3.0.3'
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/BarChartActivity.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/BarChartActivity.java
@@ -4,7 +4,6 @@ package com.xxmassdeveloper.mpchartexample;
 import android.annotation.SuppressLint;
 import android.graphics.RectF;
 import android.os.Bundle;
-import android.support.v4.content.ContextCompat;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -41,6 +40,8 @@ import com.xxmassdeveloper.mpchartexample.notimportant.DemoBase;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import androidx.core.content.ContextCompat;
 
 public class BarChartActivity extends DemoBase implements OnSeekBarChangeListener,
         OnChartValueSelectedListener {

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/LineChartActivity1.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/LineChartActivity1.java
@@ -6,7 +6,6 @@ import android.graphics.DashPathEffect;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
-import android.support.v4.content.ContextCompat;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -39,6 +38,8 @@ import com.xxmassdeveloper.mpchartexample.notimportant.DemoBase;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import androidx.core.content.ContextCompat;
 
 public class LineChartActivity1 extends DemoBase implements OnSeekBarChangeListener,
         OnChartGestureListener, OnChartValueSelectedListener {

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/fragments/BarChartFrag.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/fragments/BarChartFrag.java
@@ -1,7 +1,6 @@
 package com.xxmassdeveloper.mpchartexample.fragments;
 import android.graphics.Typeface;
 import android.os.Bundle;
-import android.support.v4.app.Fragment;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
@@ -17,6 +16,8 @@ import com.github.mikephil.charting.listener.ChartTouchListener;
 import com.github.mikephil.charting.listener.OnChartGestureListener;
 import com.xxmassdeveloper.mpchartexample.R;
 import com.xxmassdeveloper.mpchartexample.custom.MyMarkerView;
+
+import androidx.fragment.app.Fragment;
 
 
 public class BarChartFrag extends SimpleFragment implements OnChartGestureListener {

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/fragments/ComplexityFragment.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/fragments/ComplexityFragment.java
@@ -1,7 +1,6 @@
 package com.xxmassdeveloper.mpchartexample.fragments;
 import android.graphics.Typeface;
 import android.os.Bundle;
-import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -11,6 +10,8 @@ import com.github.mikephil.charting.components.Legend;
 import com.github.mikephil.charting.components.XAxis;
 import com.github.mikephil.charting.components.YAxis;
 import com.xxmassdeveloper.mpchartexample.R;
+
+import androidx.fragment.app.Fragment;
 
 
 public class ComplexityFragment extends SimpleFragment {

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/fragments/PieChartFrag.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/fragments/PieChartFrag.java
@@ -2,7 +2,6 @@ package com.xxmassdeveloper.mpchartexample.fragments;
 import android.graphics.Color;
 import android.graphics.Typeface;
 import android.os.Bundle;
-import android.support.v4.app.Fragment;
 import android.text.SpannableString;
 import android.text.style.ForegroundColorSpan;
 import android.text.style.RelativeSizeSpan;
@@ -12,8 +11,9 @@ import android.view.ViewGroup;
 
 import com.github.mikephil.charting.charts.PieChart;
 import com.github.mikephil.charting.components.Legend;
-import com.github.mikephil.charting.components.Legend.LegendPosition;
 import com.xxmassdeveloper.mpchartexample.R;
+
+import androidx.fragment.app.Fragment;
 
 
 public class PieChartFrag extends SimpleFragment {

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/fragments/ScatterChartFrag.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/fragments/ScatterChartFrag.java
@@ -2,7 +2,6 @@ package com.xxmassdeveloper.mpchartexample.fragments;
 
 import android.graphics.Typeface;
 import android.os.Bundle;
-import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -14,6 +13,8 @@ import com.github.mikephil.charting.components.XAxis.XAxisPosition;
 import com.github.mikephil.charting.components.YAxis;
 import com.xxmassdeveloper.mpchartexample.R;
 import com.xxmassdeveloper.mpchartexample.custom.MyMarkerView;
+
+import androidx.fragment.app.Fragment;
 
 
 public class ScatterChartFrag extends SimpleFragment {

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/fragments/SimpleChartDemo.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/fragments/SimpleChartDemo.java
@@ -5,14 +5,15 @@ import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnClickListener;
 import android.os.Bundle;
-import android.support.v4.app.Fragment;
-import android.support.v4.app.FragmentManager;
-import android.support.v4.app.FragmentPagerAdapter;
-import android.support.v4.view.ViewPager;
 import android.view.WindowManager;
 
 import com.xxmassdeveloper.mpchartexample.R;
 import com.xxmassdeveloper.mpchartexample.notimportant.DemoBase;
+
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
+import androidx.fragment.app.FragmentPagerAdapter;
+import androidx.viewpager.widget.ViewPager;
 
 /**
  * Demonstrates how to keep your charts straight forward, simple and beautiful with the MPAndroidChart library.
@@ -56,7 +57,7 @@ public class SimpleChartDemo extends DemoBase {
         }
 
         @Override
-        public Fragment getItem(int pos) {  
+        public Fragment getItem(int pos) {
             Fragment f = null;
             
             switch(pos) {

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/fragments/SimpleFragment.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/fragments/SimpleFragment.java
@@ -3,7 +3,6 @@ package com.xxmassdeveloper.mpchartexample.fragments;
 import android.graphics.Color;
 import android.graphics.Typeface;
 import android.os.Bundle;
-import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -27,6 +26,8 @@ import com.github.mikephil.charting.utils.ColorTemplate;
 import com.github.mikephil.charting.utils.FileUtils;
 
 import java.util.ArrayList;
+
+import androidx.fragment.app.Fragment;
 
 public abstract class SimpleFragment extends Fragment {
     

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/fragments/SineCosineFragment.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/fragments/SineCosineFragment.java
@@ -1,7 +1,6 @@
 package com.xxmassdeveloper.mpchartexample.fragments;
 import android.graphics.Typeface;
 import android.os.Bundle;
-import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -11,6 +10,8 @@ import com.github.mikephil.charting.components.Legend;
 import com.github.mikephil.charting.components.XAxis;
 import com.github.mikephil.charting.components.YAxis;
 import com.xxmassdeveloper.mpchartexample.R;
+
+import androidx.fragment.app.Fragment;
 
 
 public class SineCosineFragment extends SimpleFragment {

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/notimportant/DemoBase.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/notimportant/DemoBase.java
@@ -3,11 +3,11 @@ package com.xxmassdeveloper.mpchartexample.notimportant;
 
 import android.graphics.Typeface;
 import android.os.Bundle;
-import android.renderscript.Type;
-import android.support.annotation.Nullable;
-import android.support.v4.app.FragmentActivity;
 
 import com.xxmassdeveloper.mpchartexample.R;
+
+import androidx.annotation.Nullable;
+import androidx.fragment.app.FragmentActivity;
 
 /**
  * Baseclass of all Activities of the Demo Application.

--- a/MPChartLib/build.gradle
+++ b/MPChartLib/build.gradle
@@ -4,13 +4,13 @@ apply plugin: 'maven'
 //apply plugin: 'realm-android'
 
 android {
-    compileSdkVersion 27
-    buildToolsVersion '27.0.3'
+    compileSdkVersion 28
+    buildToolsVersion '28.0.2'
     // resourcePrefix 'mpcht'
     defaultConfig {
         //noinspection MinSdkTooLow
         minSdkVersion 9
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 3
         versionName '3.0.3'
     }

--- a/MPChartLib/build.gradle
+++ b/MPChartLib/build.gradle
@@ -36,7 +36,7 @@ repositories {
 
 dependencies {
     //provided 'io.realm:realm-android:0.87.5' // "optional" dependency to realm-database API
-    implementation 'com.android.support:support-annotations:27.1.1'
+    implementation 'androidx.annotation:annotation:1.0.0'
     testImplementation 'junit:junit:4.12'
     testImplementation "org.mockito:mockito-core:1.10.19"
 }

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/animation/ChartAnimator.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/animation/ChartAnimator.java
@@ -3,9 +3,10 @@ package com.github.mikephil.charting.animation;
 
 import android.animation.ObjectAnimator;
 import android.animation.ValueAnimator.AnimatorUpdateListener;
-import android.support.annotation.RequiresApi;
 
 import com.github.mikephil.charting.animation.Easing.EasingFunction;
+
+import androidx.annotation.RequiresApi;
 
 /**
  * Object responsible for all animations in the Chart. Animations require API level 11.

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/animation/Easing.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/animation/Easing.java
@@ -2,7 +2,8 @@
 package com.github.mikephil.charting.animation;
 
 import android.animation.TimeInterpolator;
-import android.support.annotation.RequiresApi;
+
+import androidx.annotation.RequiresApi;
 
 /**
  * Easing options.

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/charts/Chart.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/charts/Chart.java
@@ -17,7 +17,6 @@ import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.os.Environment;
 import android.provider.MediaStore.Images;
-import android.support.annotation.RequiresApi;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.util.Log;
@@ -55,6 +54,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
+
+import androidx.annotation.RequiresApi;
 
 /**
  * Baseclass of all Chart-Views.

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
     dependencies {
         classpath "io.realm:realm-gradle-plugin:4.2.0"
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:3.2.0'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 25 08:04:33 CEST 2018
+#Tue Sep 25 11:58:06 WEST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip


### PR DESCRIPTION
## PR Description
Jetpack (androidx 1.0.0) was finally released as stable and libraries should start moving to it.

No behavior changes. In fact, the use of support library is restricted to annotations in the chart library, most of the changes are actually to the example app.

It ensures that we can continue using Jetpack as it gets developed instead of using the soon-to-be stagnant support library.
