### PR TITLE
HorizontalBarChart: fix value text colors which were set via barData.setValueTextColors(list)

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/HorizontalBarChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/HorizontalBarChartRenderer.java
@@ -212,7 +212,7 @@ public class HorizontalBarChartRenderer extends BarChartRenderer {
                                     formattedValue,
                                     buffer.buffer[j + 2] + (val >= 0 ? posOffset : negOffset),
                                     y + halfTextHeight,
-                                    dataSet.getValueTextColor(j / 2));
+                                    dataSet.getValueTextColor(j / 4));
                         }
 
                         if (entry.getIcon() != null && dataSet.isDrawIconsEnabled()) {


### PR DESCRIPTION
## PR Checklist:
- [x] I have tested this extensively and it does not break any existing behavior.
- [ ] I have added/updated examples and tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description
PR fixes horizontalBar value text colors which were set via barData.setValueTextColors(list).

in line 215 j should be divided by 4 to get correct color index.

line 183: for (int j = 0; j < ...; j += **4**) {
    ...
    line 215: dataSet.getValueTextColor(j / **4**));
}