### PR TITLE
fix drawable border in Utilities#drawImage

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/utils/Utils.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/utils/Utils.java
@@ -537,7 +537,7 @@ public abstract class Utils {
                 mDrawableBoundsCache.left,
                 mDrawableBoundsCache.top,
                 mDrawableBoundsCache.left + width,
-                mDrawableBoundsCache.top + width);
+                mDrawableBoundsCache.top + height);
 
         int saveId = canvas.save();
         // translate to the correct position and draw


### PR DESCRIPTION
## PR Checklist:
- [ N/A] I have tested this extensively and it does not break any existing behavior.
- [ N/A] I have added/updated examples and tests for any new behavior.
- [ N/A] If this is a significant change, an issue has already been created where the problem / solution was discussed.

## PR Description
The border of the drawable is not set properly in Utils#drawImage. 
The height and width were both set to the width. This is not visible 
for square icons, but is for rectangular ones.

This PR sets the drawable bounds height to match the icon height. 

There are no formal tests included, but the behavior can easily be seen
by using the attached (hand drawn) rectangular png's as icons in any
of the existing examples.


![arrow_right](https://user-images.githubusercontent.com/10750221/51277934-eb48a300-198d-11e9-948c-3272034d1a30.png)
![arrow_up](https://user-images.githubusercontent.com/10750221/51277941-f26fb100-198d-11e9-8d6f-9bfb7b4ec46b.png)


