### PR TITLE
Added "Circle Stroke" legend form.

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/components/Legend.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/components/Legend.java
@@ -47,6 +47,11 @@ public class Legend extends ComponentBase {
         CIRCLE,
 
         /**
+         * Draw a circle stroke
+         */
+        CIRCLE_STROKE,
+
+        /**
          * Draw a horizontal line
          */
         LINE

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LegendRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LegendRenderer.java
@@ -516,6 +516,15 @@ public class LegendRenderer extends Renderer {
                 mLegendFormPaint.setStyle(Paint.Style.FILL);
                 c.drawCircle(x + half, y, half, mLegendFormPaint);
                 break;
+            case CIRCLE_STROKE:
+                mLegendFormPaint.setStyle(Paint.Style.STROKE);
+                final float strokeWidth = Utils.convertDpToPixel(
+                      Float.isNaN(entry.formLineWidth)
+                            ? legend.getFormLineWidth()
+                            : entry.formLineWidth);
+                mLegendFormPaint.setStrokeWidth(strokeWidth);
+                c.drawCircle(x + half, y, half, mLegendFormPaint);
+                break;
 
             case SQUARE:
                 mLegendFormPaint.setStyle(Paint.Style.FILL);


### PR DESCRIPTION
## PR Checklist:
- [ ] I have tested this extensively and it does not break any existing behavior.
- [ ] I have added/updated examples and tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change, please
            create an issue to discuss those changes and gather
            feedback BEFORE submitting your PR. -->


## PR Description
<!-- Describe Your PR Here! -->
This small styling change will add new legend entry form. It is transparent circle with colored stroke.
It is the same circle form, just with changed Paint.Style to Paint.Style.STROKE. Stroke width is calculated same as LINE form width.
<!-- What does this add/ remove/ fix/ change? -->

<!-- WHY should this PR be merged into the main library? -->
It is small styling change, but could be really useful in some designs.