### PR TITLE
PercentFormatter: make space between number and percent sign optional

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/formatter/PercentFormatter.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/formatter/PercentFormatter.java
@@ -7,7 +7,7 @@ import java.text.DecimalFormat;
 
 /**
  * This IValueFormatter is just for convenience and simply puts a "%" sign after
- * each value. (Recommeded for PieChart)
+ * each value. (Recommended for PieChart)
  *
  * @author Philipp Jahoda
  */

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/formatter/PercentFormatter.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/formatter/PercentFormatter.java
@@ -16,9 +16,11 @@ public class PercentFormatter extends ValueFormatter
 
     public DecimalFormat mFormat;
     private PieChart pieChart;
+    private boolean percentSignSeparated;
 
     public PercentFormatter() {
         mFormat = new DecimalFormat("###,###,##0.0");
+        percentSignSeparated = true;
     }
 
     // Can be used to remove percent signs if the chart isn't in percent mode
@@ -27,9 +29,15 @@ public class PercentFormatter extends ValueFormatter
         this.pieChart = pieChart;
     }
 
+    // Can be used to remove percent signs if the chart isn't in percent mode
+    public PercentFormatter(PieChart pieChart, boolean percentSignSeparated) {
+        this(pieChart);
+        this.percentSignSeparated = percentSignSeparated;
+    }
+
     @Override
     public String getFormattedValue(float value) {
-        return mFormat.format(value) + " %";
+        return mFormat.format(value) + (percentSignSeparated ? " %" : "%");
     }
 
     @Override


### PR DESCRIPTION
## PR Checklist:
- [x] I have tested this extensively and it does not break any existing behavior.
- [-] I have added/updated examples and tests for any new behavior.


## PR Description
This PR makes the space between the number and the percent sign in PercentFormatter optional.
It preserves the current behaviour (insert space) as default but allows for not inserting the space.
As there is no definite convention on wether to insert a space or not, the user should imho have the opportunity to choose.