### PR TITLE
YAxis: add missing setDrawBottomYLabelEntry method

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/components/YAxis.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/components/YAxis.java
@@ -202,6 +202,17 @@ public class YAxis extends AxisBase {
     public void setDrawTopYLabelEntry(boolean enabled) {
         mDrawTopYLabelEntry = enabled;
     }
+    
+    /**
+     * set this to true to enable drawing the bottom y-label entry. Disabling this can be helpful
+     * when the bottom y-label and
+     * left x-label interfere with each other. default: true
+     *
+     * @param enabled
+     */
+    public void setDrawBottomYLabelEntry(boolean enabled) {
+        mDrawBottomYLabelEntry = enabled;
+    }
 
     /**
      * If this is set to true, the y-axis is inverted which means that low values are on top of


### PR DESCRIPTION
## PR Checklist:
- [-] I have tested this extensively and it does not break any existing behavior.

## PR Description
<!-- Describe Your PR Here! -->
add missing setDrawBottomYLabelEntry method in YAxis

<!-- What does this add/ remove/ fix/ change? -->
this prevent can prevent bottom y axis value from overlapping with left x axis value
<!-- WHY should this PR be merged into the main library? -->
It is an important and useful method