### PR TITLE
Fix issues related to Radar chart highlighting and icons

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/highlight/RadarHighlighter.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/highlight/RadarHighlighter.java
@@ -31,7 +31,7 @@ public class RadarHighlighter extends PieRadarHighlighter<RadarChart> {
 
             Highlight high = highlights.get(i);
 
-            float cdistance = Math.abs(high.getY() - distanceToCenter);
+            float cdistance = Math.abs(high.getY() - mChart.getYChartMin() - distanceToCenter);
             if (cdistance < distance) {
                 closest = high;
                 distance = cdistance;
@@ -63,15 +63,17 @@ public class RadarHighlighter extends PieRadarHighlighter<RadarChart> {
 
             IDataSet<?> dataSet = mChart.getData().getDataSetByIndex(i);
 
-            final Entry entry = dataSet.getEntryForIndex(index);
+            if (index < dataSet.getEntryCount()) {
+                final Entry entry = dataSet.getEntryForIndex(index);
 
-            float y = (entry.getY() - mChart.getYChartMin());
+                float y = (entry.getY() - mChart.getYChartMin());
 
-            Utils.getPosition(
-                    mChart.getCenterOffsets(), y * factor * phaseY,
-                    sliceangle * index * phaseX + mChart.getRotationAngle(), pOut);
+                Utils.getPosition(
+                        mChart.getCenterOffsets(), y * factor * phaseY,
+                        sliceangle * index * phaseX + mChart.getRotationAngle(), pOut);
 
-            mHighlightBuffer.add(new Highlight(index, entry.getY(), pOut.x, pOut.y, i, dataSet.getAxisDependency()));
+                mHighlightBuffer.add(new Highlight(index, entry.getY(), pOut.x, pOut.y, i, dataSet.getAxisDependency()));
+            }
         }
 
         return mHighlightBuffer;

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/RadarChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/RadarChartRenderer.java
@@ -200,7 +200,7 @@ public class RadarChartRenderer extends LineRadarRenderer {
 
                     Utils.getPosition(
                             center,
-                            (entry.getY()) * factor * phaseY + iconsOffset.y,
+                            (entry.getY() - mChart.getYChartMin()) * factor * phaseY + iconsOffset.y,
                             sliceangle * j * phaseX + mChart.getRotationAngle(),
                             pIcon);
 


### PR DESCRIPTION
## PR Checklist:
- [x] I have tested this extensively and it does not break any existing behavior.
     
## PR Description
I have done 3 bug fixes:
- Fix the formula for calculating the closest highlight entry by taking into account the YChartMin() distance
- Fix an IndexOutOfBound exception for DataSets with unequal entry count
- Fix the formula for calculating the icons position by taking into account the YChartMin() distance
