### PR TITLE
 Fix XAxisRenderer typeface

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/XAxisRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/XAxisRenderer.java
@@ -31,6 +31,7 @@ public class XAxisRenderer extends AxisRenderer {
         mAxisLabelPaint.setColor(Color.BLACK);
         mAxisLabelPaint.setTextAlign(Align.CENTER);
         mAxisLabelPaint.setTextSize(Utils.convertDpToPixel(10f));
+        mAxisLabelPaint.setTypeface(mXAxis.getTypeface());
     }
 
     protected void setupGridPaint() {
@@ -77,7 +78,6 @@ public class XAxisRenderer extends AxisRenderer {
 
         String longest = mXAxis.getLongestLabel();
 
-        mAxisLabelPaint.setTypeface(mXAxis.getTypeface());
         mAxisLabelPaint.setTextSize(mXAxis.getTextSize());
 
         final FSize labelSize = Utils.calcTextSize(mAxisLabelPaint, longest);
@@ -108,7 +108,6 @@ public class XAxisRenderer extends AxisRenderer {
 
         float yoffset = mXAxis.getYOffset();
 
-        mAxisLabelPaint.setTypeface(mXAxis.getTypeface());
         mAxisLabelPaint.setTextSize(mXAxis.getTextSize());
         mAxisLabelPaint.setColor(mXAxis.getTextColor());
 


### PR DESCRIPTION
Typeface of Paint must be set at the first because some calculations with use of Paint may done earlier