### PR TITLE
Fix YAxisRenderer typeface

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/YAxisRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/YAxisRenderer.java
@@ -39,6 +39,8 @@ public class YAxisRenderer extends AxisRenderer {
             mZeroLinePaint.setStrokeWidth(1f);
             mZeroLinePaint.setStyle(Paint.Style.STROKE);
         }
+
+        mAxisLabelPaint.setTypeface(mYAxis.getTypeface());
     }
 
     /**
@@ -52,7 +54,6 @@ public class YAxisRenderer extends AxisRenderer {
 
         float[] positions = getTransformedPositions();
 
-        mAxisLabelPaint.setTypeface(mYAxis.getTypeface());
         mAxisLabelPaint.setTextSize(mYAxis.getTextSize());
         mAxisLabelPaint.setColor(mYAxis.getTextColor());
 


### PR DESCRIPTION
Typeface of Paint must be set at the first because horizontal offsets are calculated before renderAxisLabels by calling calcTextWidth(Paint paint, String demoText)