### PR TITLE
Removed G+ Button

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,12 +125,13 @@ Please read the [**documentation**](https://weeklycoding.com/mpandroidchart/) fi
 
 <br/>
 
-<h2 id="social">Social Media :fire:</h2>
+<h2 id="
+
+">Social Media :fire:</h2>
 
 If you like this library, please tell others about it :two_hearts: :two_hearts:
 
 [![Share on Twitter](https://github.com/PhilJay/MPAndroidChart/blob/master/design/twitter_icon.png)](https://twitter.com/intent/tweet?text=Check%20out%20the%20awesome%20MPAndroidChart%20library%20on%20Github:%20https://github.com/PhilJay/MPAndroidChart)
-[![Share on Google+](https://github.com/PhilJay/MPAndroidChart/blob/master/design/googleplus_icon.png)](https://plus.google.com/share?url=https://github.com/PhilJay/MPAndroidChart)
 [![Share on Facebook](https://github.com/PhilJay/MPAndroidChart/blob/master/design/facebook_icon.png)](https://www.facebook.com/sharer/sharer.php?u=https://github.com/PhilJay/MPAndroidChart)
 
 You can follow me on Twitter [**@PhilippJahoda**](https://twitter.com/PhilippJahoda) or sign up for my [**coding newsletter**](https://weeklycoding.com).


### PR DESCRIPTION
G+ is no more. Just removed the G+ Share-Button / Link

## PR Checklist:
- [x] I have tested this extensively and it does not break any existing behavior.
- [x] I have added/updated examples and tests for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description
Removed the G+ Button as GogglePlus is shut down
