### PR TITLE
Add multiline support at Renderer.drawValue

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/BarChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/BarChartRenderer.java
@@ -6,6 +6,7 @@ import android.graphics.Paint;
 import android.graphics.RectF;
 import android.graphics.drawable.Drawable;
 import android.text.TextPaint;
+import android.view.Gravity;
 
 import com.github.mikephil.charting.animation.ChartAnimator;
 import com.github.mikephil.charting.buffer.BarBuffer;
@@ -430,7 +431,7 @@ public class BarChartRenderer extends BarLineScatterCandleBubbleRenderer {
         if (Utils.isMultilineText(valueText)) {
             Utils.drawMultilineText(c, valueText, x, y,
                     new TextPaint(mValuePaint),
-                    new FSize(c.getWidth(), c.getHeight()), new MPPointF(0f, 0f), 0);
+                    new FSize(c.getWidth(), c.getHeight()), new MPPointF(0f, 0f), 0, Gravity.TOP);
         } else {
             c.drawText(valueText, x, y, mValuePaint);
         }

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/BarChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/BarChartRenderer.java
@@ -5,6 +5,7 @@ import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.RectF;
 import android.graphics.drawable.Drawable;
+import android.text.TextPaint;
 
 import com.github.mikephil.charting.animation.ChartAnimator;
 import com.github.mikephil.charting.buffer.BarBuffer;
@@ -15,6 +16,7 @@ import com.github.mikephil.charting.highlight.Highlight;
 import com.github.mikephil.charting.highlight.Range;
 import com.github.mikephil.charting.interfaces.dataprovider.BarDataProvider;
 import com.github.mikephil.charting.interfaces.datasets.IBarDataSet;
+import com.github.mikephil.charting.utils.FSize;
 import com.github.mikephil.charting.utils.Fill;
 import com.github.mikephil.charting.utils.MPPointF;
 import com.github.mikephil.charting.utils.Transformer;
@@ -425,7 +427,13 @@ public class BarChartRenderer extends BarLineScatterCandleBubbleRenderer {
     @Override
     public void drawValue(Canvas c, String valueText, float x, float y, int color) {
         mValuePaint.setColor(color);
-        c.drawText(valueText, x, y, mValuePaint);
+        if (Utils.isMultilineText(valueText)) {
+            Utils.drawMultilineText(c, valueText, x, y,
+                    new TextPaint(mValuePaint),
+                    new FSize(c.getWidth(), c.getHeight()), new MPPointF(0f, 0f), 0);
+        } else {
+            c.drawText(valueText, x, y, mValuePaint);
+        }
     }
 
     @Override

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/BubbleChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/BubbleChartRenderer.java
@@ -5,6 +5,7 @@ import android.graphics.Color;
 import android.graphics.Paint.Style;
 import android.graphics.drawable.Drawable;
 import android.text.TextPaint;
+import android.view.Gravity;
 
 import com.github.mikephil.charting.animation.ChartAnimator;
 import com.github.mikephil.charting.data.BubbleData;
@@ -204,7 +205,7 @@ public class BubbleChartRenderer extends BarLineScatterCandleBubbleRenderer {
         if (Utils.isMultilineText(valueText)) {
             Utils.drawMultilineText(c, valueText, x, y,
                     new TextPaint(mValuePaint),
-                    new FSize(c.getWidth(), c.getHeight()), new MPPointF(0f, 0f), 0);
+                    new FSize(c.getWidth(), c.getHeight()), new MPPointF(0f, 0f), 0, Gravity.TOP);
         } else {
             c.drawText(valueText, x, y, mValuePaint);
         }

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/BubbleChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/BubbleChartRenderer.java
@@ -4,6 +4,7 @@ import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint.Style;
 import android.graphics.drawable.Drawable;
+import android.text.TextPaint;
 
 import com.github.mikephil.charting.animation.ChartAnimator;
 import com.github.mikephil.charting.data.BubbleData;
@@ -12,6 +13,7 @@ import com.github.mikephil.charting.formatter.ValueFormatter;
 import com.github.mikephil.charting.highlight.Highlight;
 import com.github.mikephil.charting.interfaces.dataprovider.BubbleDataProvider;
 import com.github.mikephil.charting.interfaces.datasets.IBubbleDataSet;
+import com.github.mikephil.charting.utils.FSize;
 import com.github.mikephil.charting.utils.MPPointF;
 import com.github.mikephil.charting.utils.Transformer;
 import com.github.mikephil.charting.utils.Utils;
@@ -199,7 +201,13 @@ public class BubbleChartRenderer extends BarLineScatterCandleBubbleRenderer {
     @Override
     public void drawValue(Canvas c, String valueText, float x, float y, int color) {
         mValuePaint.setColor(color);
-        c.drawText(valueText, x, y, mValuePaint);
+        if (Utils.isMultilineText(valueText)) {
+            Utils.drawMultilineText(c, valueText, x, y,
+                    new TextPaint(mValuePaint),
+                    new FSize(c.getWidth(), c.getHeight()), new MPPointF(0f, 0f), 0);
+        } else {
+            c.drawText(valueText, x, y, mValuePaint);
+        }
     }
 
     @Override

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/CandleStickChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/CandleStickChartRenderer.java
@@ -4,6 +4,7 @@ import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.drawable.Drawable;
 import android.text.TextPaint;
+import android.view.Gravity;
 
 import com.github.mikephil.charting.animation.ChartAnimator;
 import com.github.mikephil.charting.data.CandleData;
@@ -329,7 +330,7 @@ public class CandleStickChartRenderer extends LineScatterCandleRadarRenderer {
         if (Utils.isMultilineText(valueText)) {
             Utils.drawMultilineText(c, valueText, x, y,
                     new TextPaint(mValuePaint),
-                    new FSize(c.getWidth(), c.getHeight()), new MPPointF(0f, 0f), 0);
+                    new FSize(c.getWidth(), c.getHeight()), new MPPointF(0f, 0f), 0, Gravity.TOP);
         } else {
             c.drawText(valueText, x, y, mValuePaint);
         }

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/CandleStickChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/CandleStickChartRenderer.java
@@ -3,6 +3,7 @@ package com.github.mikephil.charting.renderer;
 import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.drawable.Drawable;
+import android.text.TextPaint;
 
 import com.github.mikephil.charting.animation.ChartAnimator;
 import com.github.mikephil.charting.data.CandleData;
@@ -12,6 +13,7 @@ import com.github.mikephil.charting.highlight.Highlight;
 import com.github.mikephil.charting.interfaces.dataprovider.CandleDataProvider;
 import com.github.mikephil.charting.interfaces.datasets.ICandleDataSet;
 import com.github.mikephil.charting.utils.ColorTemplate;
+import com.github.mikephil.charting.utils.FSize;
 import com.github.mikephil.charting.utils.MPPointD;
 import com.github.mikephil.charting.utils.MPPointF;
 import com.github.mikephil.charting.utils.Transformer;
@@ -324,7 +326,13 @@ public class CandleStickChartRenderer extends LineScatterCandleRadarRenderer {
     @Override
     public void drawValue(Canvas c, String valueText, float x, float y, int color) {
         mValuePaint.setColor(color);
-        c.drawText(valueText, x, y, mValuePaint);
+        if (Utils.isMultilineText(valueText)) {
+            Utils.drawMultilineText(c, valueText, x, y,
+                    new TextPaint(mValuePaint),
+                    new FSize(c.getWidth(), c.getHeight()), new MPPointF(0f, 0f), 0);
+        } else {
+            c.drawText(valueText, x, y, mValuePaint);
+        }
     }
 
     @Override

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/HorizontalBarChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/HorizontalBarChartRenderer.java
@@ -5,6 +5,7 @@ import android.graphics.Paint.Align;
 import android.graphics.RectF;
 import android.graphics.drawable.Drawable;
 import android.text.TextPaint;
+import android.view.Gravity;
 
 import com.github.mikephil.charting.animation.ChartAnimator;
 import com.github.mikephil.charting.buffer.BarBuffer;
@@ -416,7 +417,7 @@ public class HorizontalBarChartRenderer extends BarChartRenderer {
         if (Utils.isMultilineText(valueText)) {
             Utils.drawMultilineText(c, valueText, x, y,
                     new TextPaint(mValuePaint),
-                    new FSize(c.getWidth(), c.getHeight()), new MPPointF(0f, 0f), 0);
+                    new FSize(c.getWidth(), c.getHeight()), new MPPointF(0f, 0f), 0, Gravity.TOP);
         } else {
             c.drawText(valueText, x, y, mValuePaint);
         }

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/HorizontalBarChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/HorizontalBarChartRenderer.java
@@ -4,6 +4,7 @@ import android.graphics.Canvas;
 import android.graphics.Paint.Align;
 import android.graphics.RectF;
 import android.graphics.drawable.Drawable;
+import android.text.TextPaint;
 
 import com.github.mikephil.charting.animation.ChartAnimator;
 import com.github.mikephil.charting.buffer.BarBuffer;
@@ -15,6 +16,7 @@ import com.github.mikephil.charting.highlight.Highlight;
 import com.github.mikephil.charting.interfaces.dataprovider.BarDataProvider;
 import com.github.mikephil.charting.interfaces.dataprovider.ChartInterface;
 import com.github.mikephil.charting.interfaces.datasets.IBarDataSet;
+import com.github.mikephil.charting.utils.FSize;
 import com.github.mikephil.charting.utils.Fill;
 import com.github.mikephil.charting.utils.MPPointF;
 import com.github.mikephil.charting.utils.Transformer;
@@ -411,7 +413,13 @@ public class HorizontalBarChartRenderer extends BarChartRenderer {
     @Override
     public void drawValue(Canvas c, String valueText, float x, float y, int color) {
         mValuePaint.setColor(color);
-        c.drawText(valueText, x, y, mValuePaint);
+        if (Utils.isMultilineText(valueText)) {
+            Utils.drawMultilineText(c, valueText, x, y,
+                    new TextPaint(mValuePaint),
+                    new FSize(c.getWidth(), c.getHeight()), new MPPointF(0f, 0f), 0);
+        } else {
+            c.drawText(valueText, x, y, mValuePaint);
+        }
     }
 
     @Override

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineChartRenderer.java
@@ -7,6 +7,7 @@ import android.graphics.Paint;
 import android.graphics.Path;
 import android.graphics.drawable.Drawable;
 import android.text.TextPaint;
+import android.view.Gravity;
 
 import com.github.mikephil.charting.animation.ChartAnimator;
 import com.github.mikephil.charting.charts.LineChart;
@@ -612,7 +613,7 @@ public class LineChartRenderer extends LineRadarRenderer {
         if (Utils.isMultilineText(valueText)) {
             Utils.drawMultilineText(c, valueText, x, y,
                     new TextPaint(mValuePaint),
-                    new FSize(c.getWidth(), c.getHeight()), new MPPointF(0f, 0f), 0);
+                    new FSize(c.getWidth(), c.getHeight()), new MPPointF(0f, 0f), 0, Gravity.TOP);
         } else {
             c.drawText(valueText, x, y, mValuePaint);
         }

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineChartRenderer.java
@@ -6,6 +6,7 @@ import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.Path;
 import android.graphics.drawable.Drawable;
+import android.text.TextPaint;
 
 import com.github.mikephil.charting.animation.ChartAnimator;
 import com.github.mikephil.charting.charts.LineChart;
@@ -18,6 +19,7 @@ import com.github.mikephil.charting.interfaces.dataprovider.LineDataProvider;
 import com.github.mikephil.charting.interfaces.datasets.IDataSet;
 import com.github.mikephil.charting.interfaces.datasets.ILineDataSet;
 import com.github.mikephil.charting.utils.ColorTemplate;
+import com.github.mikephil.charting.utils.FSize;
 import com.github.mikephil.charting.utils.MPPointD;
 import com.github.mikephil.charting.utils.MPPointF;
 import com.github.mikephil.charting.utils.Transformer;
@@ -607,7 +609,13 @@ public class LineChartRenderer extends LineRadarRenderer {
     @Override
     public void drawValue(Canvas c, String valueText, float x, float y, int color) {
         mValuePaint.setColor(color);
-        c.drawText(valueText, x, y, mValuePaint);
+        if (Utils.isMultilineText(valueText)) {
+            Utils.drawMultilineText(c, valueText, x, y,
+                    new TextPaint(mValuePaint),
+                    new FSize(c.getWidth(), c.getHeight()), new MPPointF(0f, 0f), 0);
+        } else {
+            c.drawText(valueText, x, y, mValuePaint);
+        }
     }
 
     @Override

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/PieChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/PieChartRenderer.java
@@ -13,6 +13,7 @@ import android.os.Build;
 import android.text.Layout;
 import android.text.StaticLayout;
 import android.text.TextPaint;
+import android.view.Gravity;
 
 import com.github.mikephil.charting.animation.ChartAnimator;
 import com.github.mikephil.charting.charts.LineChart;
@@ -657,7 +658,7 @@ public class PieChartRenderer extends DataRenderer {
         if (Utils.isMultilineText(valueText)) {
             Utils.drawMultilineText(c, valueText, x, y,
                     new TextPaint(mValuePaint),
-                    new FSize(c.getWidth(), c.getHeight()), new MPPointF(0f, 0f), 0);
+                    new FSize(c.getWidth(), c.getHeight()), new MPPointF(0f, 0f), 0, Gravity.TOP);
         } else {
             c.drawText(valueText, x, y, mValuePaint);
         }

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/PieChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/PieChartRenderer.java
@@ -25,6 +25,7 @@ import com.github.mikephil.charting.formatter.ValueFormatter;
 import com.github.mikephil.charting.highlight.Highlight;
 import com.github.mikephil.charting.interfaces.datasets.IPieDataSet;
 import com.github.mikephil.charting.utils.ColorTemplate;
+import com.github.mikephil.charting.utils.FSize;
 import com.github.mikephil.charting.utils.MPPointF;
 import com.github.mikephil.charting.utils.Utils;
 import com.github.mikephil.charting.utils.ViewPortHandler;
@@ -653,7 +654,13 @@ public class PieChartRenderer extends DataRenderer {
     @Override
     public void drawValue(Canvas c, String valueText, float x, float y, int color) {
         mValuePaint.setColor(color);
-        c.drawText(valueText, x, y, mValuePaint);
+        if (Utils.isMultilineText(valueText)) {
+            Utils.drawMultilineText(c, valueText, x, y,
+                    new TextPaint(mValuePaint),
+                    new FSize(c.getWidth(), c.getHeight()), new MPPointF(0f, 0f), 0);
+        } else {
+            c.drawText(valueText, x, y, mValuePaint);
+        }
     }
 
     /**

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/RadarChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/RadarChartRenderer.java
@@ -6,6 +6,7 @@ import android.graphics.Paint;
 import android.graphics.Path;
 import android.graphics.drawable.Drawable;
 import android.text.TextPaint;
+import android.view.Gravity;
 
 import com.github.mikephil.charting.animation.ChartAnimator;
 import com.github.mikephil.charting.charts.RadarChart;
@@ -233,7 +234,7 @@ public class RadarChartRenderer extends LineRadarRenderer {
         if (Utils.isMultilineText(valueText)) {
             Utils.drawMultilineText(c, valueText, x, y,
                     new TextPaint(mValuePaint),
-                    new FSize(c.getWidth(), c.getHeight()), new MPPointF(0f, 0f), 0);
+                    new FSize(c.getWidth(), c.getHeight()), new MPPointF(0f, 0f), 0, Gravity.TOP);
         } else {
             c.drawText(valueText, x, y, mValuePaint);
         }

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/RadarChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/RadarChartRenderer.java
@@ -5,6 +5,7 @@ import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.Path;
 import android.graphics.drawable.Drawable;
+import android.text.TextPaint;
 
 import com.github.mikephil.charting.animation.ChartAnimator;
 import com.github.mikephil.charting.charts.RadarChart;
@@ -14,6 +15,7 @@ import com.github.mikephil.charting.formatter.ValueFormatter;
 import com.github.mikephil.charting.highlight.Highlight;
 import com.github.mikephil.charting.interfaces.datasets.IRadarDataSet;
 import com.github.mikephil.charting.utils.ColorTemplate;
+import com.github.mikephil.charting.utils.FSize;
 import com.github.mikephil.charting.utils.MPPointF;
 import com.github.mikephil.charting.utils.Utils;
 import com.github.mikephil.charting.utils.ViewPortHandler;
@@ -228,7 +230,13 @@ public class RadarChartRenderer extends LineRadarRenderer {
     @Override
     public void drawValue(Canvas c, String valueText, float x, float y, int color) {
         mValuePaint.setColor(color);
-        c.drawText(valueText, x, y, mValuePaint);
+        if (Utils.isMultilineText(valueText)) {
+            Utils.drawMultilineText(c, valueText, x, y,
+                    new TextPaint(mValuePaint),
+                    new FSize(c.getWidth(), c.getHeight()), new MPPointF(0f, 0f), 0);
+        } else {
+            c.drawText(valueText, x, y, mValuePaint);
+        }
     }
 
     @Override

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/ScatterChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/ScatterChartRenderer.java
@@ -2,6 +2,7 @@ package com.github.mikephil.charting.renderer;
 
 import android.graphics.Canvas;
 import android.graphics.drawable.Drawable;
+import android.text.TextPaint;
 import android.util.Log;
 
 import com.github.mikephil.charting.animation.ChartAnimator;
@@ -12,6 +13,7 @@ import com.github.mikephil.charting.highlight.Highlight;
 import com.github.mikephil.charting.interfaces.dataprovider.ScatterDataProvider;
 import com.github.mikephil.charting.interfaces.datasets.IScatterDataSet;
 import com.github.mikephil.charting.renderer.scatter.IShapeRenderer;
+import com.github.mikephil.charting.utils.FSize;
 import com.github.mikephil.charting.utils.MPPointD;
 import com.github.mikephil.charting.utils.MPPointF;
 import com.github.mikephil.charting.utils.Transformer;
@@ -162,7 +164,13 @@ public class ScatterChartRenderer extends LineScatterCandleRadarRenderer {
     @Override
     public void drawValue(Canvas c, String valueText, float x, float y, int color) {
         mValuePaint.setColor(color);
-        c.drawText(valueText, x, y, mValuePaint);
+        if (Utils.isMultilineText(valueText)) {
+            Utils.drawMultilineText(c, valueText, x, y,
+                    new TextPaint(mValuePaint),
+                    new FSize(c.getWidth(), c.getHeight()), new MPPointF(0f, 0f), 0);
+        } else {
+            c.drawText(valueText, x, y, mValuePaint);
+        }
     }
 
     @Override

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/ScatterChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/ScatterChartRenderer.java
@@ -4,6 +4,7 @@ import android.graphics.Canvas;
 import android.graphics.drawable.Drawable;
 import android.text.TextPaint;
 import android.util.Log;
+import android.view.Gravity;
 
 import com.github.mikephil.charting.animation.ChartAnimator;
 import com.github.mikephil.charting.data.Entry;
@@ -167,7 +168,7 @@ public class ScatterChartRenderer extends LineScatterCandleRadarRenderer {
         if (Utils.isMultilineText(valueText)) {
             Utils.drawMultilineText(c, valueText, x, y,
                     new TextPaint(mValuePaint),
-                    new FSize(c.getWidth(), c.getHeight()), new MPPointF(0f, 0f), 0);
+                    new FSize(c.getWidth(), c.getHeight()), new MPPointF(0f, 0f), 0, Gravity.TOP);
         } else {
             c.drawText(valueText, x, y, mValuePaint);
         }

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/utils/Utils.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/utils/Utils.java
@@ -665,23 +665,13 @@ public abstract class Utils {
 
         if (angleDegrees != 0.f) {
 
-            // Move the text drawing rect in a way that it always rotates around its center
-            drawOffsetX -= drawWidth * 0.5f;
-            drawOffsetY -= drawHeight * 0.5f;
-
             float translateX = x;
             float translateY = y;
 
-            // Move the "outer" rect relative to the anchor, assuming its centered
-            if (anchor.x != 0.5f || anchor.y != 0.5f) {
-                final FSize rotatedSize = getSizeOfRotatedRectangleByDegrees(
-                        drawWidth,
-                        drawHeight,
-                        angleDegrees);
+            if (anchor.x != 0.f || anchor.y != 0.f) {
 
-                translateX -= rotatedSize.width * (anchor.x - 0.5f);
-                translateY -= rotatedSize.height * (anchor.y - 0.5f);
-                FSize.recycleInstance(rotatedSize);
+                translateX -= anchor.x;
+                translateY -= anchor.y;
             }
 
             c.save();

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/utils/Utils.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/utils/Utils.java
@@ -11,6 +11,7 @@ import android.os.Build;
 import android.text.Layout;
 import android.text.StaticLayout;
 import android.text.TextPaint;
+import android.text.TextUtils;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.MotionEvent;
@@ -38,6 +39,8 @@ public abstract class Utils {
     private static int mMaximumFlingVelocity = 8000;
     public final static double DEG2RAD = (Math.PI / 180.0);
     public final static float FDEG2RAD = ((float) Math.PI / 180.f);
+
+    private static final String CHAR_NEW_LINE = "\n";
 
     @SuppressWarnings("unused")
     public final static double DOUBLE_EPSILON = Double.longBitsToDouble(1);
@@ -613,6 +616,14 @@ public abstract class Utils {
         }
 
         paint.setTextAlign(originalTextAlign);
+    }
+
+    public static boolean isMultilineText(String text) {
+        if (TextUtils.isEmpty(text)) {
+            return false;
+        }
+
+        return text.contains(CHAR_NEW_LINE);
     }
 
     public static void drawMultilineText(Canvas c, StaticLayout textLayout,


### PR DESCRIPTION
## PR Checklist:
- [x] I have tested this extensively and it does not break any existing behavior.
  - There is no impact if the user is not using "\n"
- [x] I have added/updated examples and tests for any new behavior.
  - Following screenshot. If need to add new ValueFormatter and option menu, I will add it.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: #1507 #1508 #1570

## PR Description
<!-- Describe Your PR Here! -->
Update drawMultilineText method to show multiline labels.

<!-- What does this add/ remove/ fix/ change? -->
- Fix `drawMultilineText` , add `isMultilineText` method.
- Change `drawValue` method following classes
  - BarChartRenderer
  - BubbleChartRenderer
  - CandleStickChartRenderer
  - HorizontalBarChartRenderer
  - LineChartRenderer
  - RadarChartRenderer
  - ScatterChartRenderer

<!-- WHY should this PR be merged into the main library? -->
- Now, we can't use multiline text. So, in the case of a long label, it will overlap the bar next to it.

ScreenShot

0 | 90
:---: | :---:
<img src="https://user-images.githubusercontent.com/17231507/77843809-93d1d400-71db-11ea-842f-ded8add19ce1.png" width="300"> | <img src="https://user-images.githubusercontent.com/17231507/77843806-8fa5b680-71db-11ea-8185-89801891a303.png" width="300"> 
