### PR TITLE
Fix Scatter Chart duplicate color bug

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/ScatterChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/ScatterChartRenderer.java
@@ -84,7 +84,7 @@ public class ScatterChartRenderer extends LineScatterCandleRadarRenderer {
                     || !viewPortHandler.isInBoundsY(mPixelBuffer[1]))
                 continue;
 
-            mRenderPaint.setColor(dataSet.getColor(i / 2));
+            mRenderPaint.setColor(dataSet.getColor(i));
             renderer.renderShape(
                     c, dataSet, mViewPortHandler,
                     mPixelBuffer[0], mPixelBuffer[1],


### PR DESCRIPTION
Closes #4571 and closes #4483

When setting colors for each entry of a dataSet, this code was skipping every odd color value. This resulted in only half of the colors being applied, with the other half of points getting duplicate values. When trying to set custom colors for each point, this presented an issue.

## PR Checklist:
- [X] I have tested this extensively and it does not break any existing behavior.
- [X] I have added/updated examples and tests for any new behavior.
- [X] If this is a significant change, an issue has already been created where the problem / solution was discussed: N/A


## PR Description
<!-- Describe Your PR Here! -->
Bug fix for Scatter Chart color setting

<!-- What does this add/ remove/ fix/ change? -->
Fix bug of colors not being set on Scatter Chart data properly. This ensures that each color
value corresponds to exactly one Entry.

<!-- WHY should this PR be merged into the main library? -->
Because the current main library is not implementing coloring properly on Scatter Charts, and this PR fixes that.