### PR TITLE
fixed bubbles disappearing after screen resizes

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/BubbleChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/BubbleChartRenderer.java
@@ -77,6 +77,7 @@ public class BubbleChartRenderer extends BarLineScatterCandleBubbleRenderer {
         mXBounds.set(mChart, dataSet);
 
         sizeBuffer[0] = 0f;
+        sizeBuffer[1] = sizeBuffer[3] = 0f;
         sizeBuffer[2] = 1f;
 
         trans.pointValuesToPixel(sizeBuffer);


### PR DESCRIPTION
This fixes issues of CombinedChartActivity when running on Windows and the window is resized: the matrix starts to produce NaN values in this array and all bubles stop from drawing.
- [x ] I have tested this extensively and it does not break any existing behavior.

The fix is not harmful and should be accepted.