### PR TITLE
fixed y axis being drawn after screen is resized

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/YAxisRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/YAxisRenderer.java
@@ -205,6 +205,7 @@ public class YAxisRenderer extends AxisRenderer {
 
         for (int i = 0; i < positions.length; i += 2) {
             // only fill y values, x values are not needed for y-labels
+            positions[i] = 0;
             positions[i + 1] = mYAxis.mEntries[i / 2];
         }
 


### PR DESCRIPTION
This fixes issues of CombinedChartActivity when running on Windows and the window is resized: the matrix starts to produce NaN values in this array and all bubles stop from drawing.
- [x ] I have tested this extensively and it does not break any existing behavior.

The fix is not harmful and should be accepted.