### PR TITLE
Support border color and border width for pie chart slices

### DIFF
--- a/MPChartExample/src/main/java/com/xxmassdeveloper/mpchartexample/PieChartActivity.java
+++ b/MPChartExample/src/main/java/com/xxmassdeveloper/mpchartexample/PieChartActivity.java
@@ -31,6 +31,7 @@ import com.github.mikephil.charting.data.PieEntry;
 import com.github.mikephil.charting.formatter.PercentFormatter;
 import com.github.mikephil.charting.highlight.Highlight;
 import com.github.mikephil.charting.interfaces.datasets.IDataSet;
+import com.github.mikephil.charting.interfaces.datasets.IPieDataSet;
 import com.github.mikephil.charting.listener.OnChartValueSelectedListener;
 import com.github.mikephil.charting.utils.ColorTemplate;
 import com.github.mikephil.charting.utils.MPPointF;
@@ -271,6 +272,12 @@ public class PieChartActivity extends DemoBase implements OnSeekBarChangeListene
                 } else {
                     requestStoragePermission(chart);
                 }
+                break;
+            }
+            case R.id.actionToggleSliceBorders: {
+                for (IPieDataSet set : chart.getData().getDataSets())
+                    ((PieDataSet) set).setSliceBorderWidth(set.getSliceBorderWidth() == 1.f ? 0.f : 1.f);
+                chart.invalidate();
                 break;
             }
         }

--- a/MPChartExample/src/main/res/menu/pie.xml
+++ b/MPChartExample/src/main/res/menu/pie.xml
@@ -57,5 +57,9 @@
         android:id="@+id/actionSave"
         android:title="@string/actionSave">
     </item>
+    <item
+        android:id="@+id/actionToggleSliceBorders"
+        android:title="@string/actionToggleSliceBorders">
+    </item>
 
 </menu>

--- a/MPChartExample/src/main/res/values/strings.xml
+++ b/MPChartExample/src/main/res/values/strings.xml
@@ -27,6 +27,7 @@
     <string name="actionToggleFilled">Toggle Filled</string>
     <string name="actionToggleCircles">Toggle Circles</string>
     <string name="actionToggleCandleShadow">Toggle Shadow Color</string>
+    <string name="actionToggleSliceBorders">Toggle Slice Borders</string>
 
     <string name="actionToggleCubic">Toggle Cubic</string>
     <string name="actionToggleStepped">Toggle Stepped</string>

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/data/PieDataSet.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/data/PieDataSet.java
@@ -7,6 +7,8 @@ import com.github.mikephil.charting.utils.Utils;
 import java.util.ArrayList;
 import java.util.List;
 
+import android.graphics.Color;
+
 public class PieDataSet extends DataSet<PieEntry> implements IPieDataSet {
 
     /**
@@ -14,6 +16,8 @@ public class PieDataSet extends DataSet<PieEntry> implements IPieDataSet {
      */
     private float mSliceSpace = 0f;
     private boolean mAutomaticallyDisableSliceSpacing;
+    private float mSliceBorderWidth = 0f;
+    private int mSliceBorderColor = Color.BLACK;
 
     /**
      * indicates the selection distance of a pie slice
@@ -78,6 +82,34 @@ public class PieDataSet extends DataSet<PieEntry> implements IPieDataSet {
     @Override
     public float getSliceSpace() {
         return mSliceSpace;
+    }
+
+    @Override
+    public float getSliceBorderWidth() {
+        return mSliceBorderWidth;
+    }
+
+    /**
+     * Sets the border width for the piechart-slices in dp.
+     * Default: 0 --> no slice border
+     *
+     * @param widthDp
+     */
+    public void setSliceBorderWidth(float widthDp) {
+        if (widthDp < 0) {
+            widthDp = 0f;
+        }
+
+        mSliceBorderWidth = widthDp;
+    }
+
+    @Override
+    public int getSliceBorderColor() {
+        return mSliceBorderColor;
+    }
+
+    public void setSliceBorderColor(int sliceBorderColor) {
+        this.mSliceBorderColor = sliceBorderColor;
     }
 
     /**

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/interfaces/datasets/IPieDataSet.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/interfaces/datasets/IPieDataSet.java
@@ -70,5 +70,14 @@ public interface IPieDataSet extends IDataSet<PieEntry> {
      * */
     boolean isValueLineVariableLength();
 
+    /**
+     * The width used for drawing borders around the slices.
+     */
+    float getSliceBorderWidth();
+
+    /**
+     * The color drawing borders around the slices.
+     */
+    int getSliceBorderColor();
 }
 

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/PieChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/PieChartRenderer.java
@@ -43,6 +43,7 @@ public class PieChartRenderer extends DataRenderer {
     protected Paint mHolePaint;
     protected Paint mTransparentCirclePaint;
     protected Paint mValueLinePaint;
+    protected Paint mStrokePaint;
 
     /**
      * paint object for the text that can be displayed in the center of the
@@ -96,6 +97,9 @@ public class PieChartRenderer extends DataRenderer {
 
         mValueLinePaint = new Paint(Paint.ANTI_ALIAS_FLAG);
         mValueLinePaint.setStyle(Style.STROKE);
+
+        mStrokePaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+        mStrokePaint.setStyle(Style.STROKE);
     }
 
     public Paint getPaintHole() {
@@ -244,6 +248,14 @@ public class PieChartRenderer extends DataRenderer {
 
         final float sliceSpace = visibleAngleCount <= 1 ? 0.f : getSliceSpace(dataSet);
 
+        float sliceBorderWidth = dataSet.getSliceBorderWidth();
+        boolean drawSliceBorder = sliceBorderWidth > 0f;
+
+        if (drawSliceBorder) {
+            mStrokePaint.setColor(dataSet.getSliceBorderColor());
+            mStrokePaint.setStrokeWidth(Utils.convertDpToPixel(dataSet.getSliceBorderWidth()));
+        }
+
         for (int j = 0; j < entryCount; j++) {
 
             float sliceAngle = drawAngles[j];
@@ -390,12 +402,15 @@ public class PieChartRenderer extends DataRenderer {
                                 center.y);
                     }
                 }
-
             }
 
             mPathBuffer.close();
 
             mBitmapCanvas.drawPath(mPathBuffer, mRenderPaint);
+
+            if (drawSliceBorder) {
+                mBitmapCanvas.drawPath(mPathBuffer, mStrokePaint);
+            }
 
             angle += sliceAngle * phaseX;
         }


### PR DESCRIPTION
## PR Checklist:

![Screenshot_20191014-140125](https://user-images.githubusercontent.com/4340321/66746857-b1a8b800-ee8b-11e9-8368-76a4008193f5.png)

- [x] I have tested this extensively and it does not break any existing behavior.
- [x] I have added/updated examples and tests for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: N/A
       <!-- If you'd like to suggest a significant change, please
            create an issue to discuss those changes and gather
            feedback BEFORE submitting your PR. -->


## PR Description
Support border color and border width for pie chart slices

Add support for displaying borders around the pie chart slices (custom border width and color, similar to Bar charts).

It looks like there are other people who need this functionality (see for example the discussion from https://stackoverflow.com/questions/38758885/border-around-pie-chart-in-mpchart)
