### PR TITLE
Adding gradient to horizontal bar chart

### DIFF
--- a/MPChartExample/src/main/java/com/xxmassdeveloper/mpchartexample/BarChartActivity.java
+++ b/MPChartExample/src/main/java/com/xxmassdeveloper/mpchartexample/BarChartActivity.java
@@ -164,12 +164,6 @@ public class BarChartActivity extends DemoBase implements OnSeekBarChangeListene
 
             set1.setDrawIcons(false);
 
-//            set1.setColors(ColorTemplate.MATERIAL_COLORS);
-
-            /*int startColor = ContextCompat.getColor(this, android.R.color.holo_blue_dark);
-            int endColor = ContextCompat.getColor(this, android.R.color.holo_blue_bright);
-            set1.setGradientColor(startColor, endColor);*/
-
             int startColor1 = ContextCompat.getColor(this, android.R.color.holo_orange_light);
             int startColor2 = ContextCompat.getColor(this, android.R.color.holo_blue_light);
             int startColor3 = ContextCompat.getColor(this, android.R.color.holo_orange_light);

--- a/MPChartExample/src/main/java/com/xxmassdeveloper/mpchartexample/HorizontalBarChartActivity.java
+++ b/MPChartExample/src/main/java/com/xxmassdeveloper/mpchartexample/HorizontalBarChartActivity.java
@@ -4,6 +4,7 @@ package com.xxmassdeveloper.mpchartexample;
 import android.Manifest;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.graphics.Color;
 import android.graphics.RectF;
 import android.net.Uri;
 import android.os.Bundle;
@@ -28,6 +29,8 @@ import com.github.mikephil.charting.data.Entry;
 import com.github.mikephil.charting.highlight.Highlight;
 import com.github.mikephil.charting.interfaces.datasets.IBarDataSet;
 import com.github.mikephil.charting.listener.OnChartValueSelectedListener;
+import com.github.mikephil.charting.model.GradientColor;
+import com.github.mikephil.charting.utils.ColorTemplate;
 import com.github.mikephil.charting.utils.MPPointF;
 import com.xxmassdeveloper.mpchartexample.notimportant.DemoBase;
 
@@ -139,9 +142,44 @@ public class HorizontalBarChartActivity extends DemoBase implements OnSeekBarCha
             chart.getData().notifyDataChanged();
             chart.notifyDataSetChanged();
         } else {
+            /*set1 = new BarDataSet(values, "DataSet 1");
+
+            set1.setDrawIcons(false);
+            set1.setColors(ColorTemplate.VORDIPLOM_COLORS);
+//            set1.setGradientColor(Color.rgb(192, 255, 140), Color.rgb(255, 247, 140));
+
+            ArrayList<IBarDataSet> dataSets = new ArrayList<>();
+            dataSets.add(set1);
+
+            BarData data = new BarData(dataSets);
+            data.setValueTextSize(10f);
+            data.setValueTypeface(tfLight);
+            data.setBarWidth(barWidth);
+            chart.setData(data);*/
+
             set1 = new BarDataSet(values, "DataSet 1");
 
             set1.setDrawIcons(false);
+
+            int startColor1 = ContextCompat.getColor(this, android.R.color.holo_orange_light);
+            int startColor2 = ContextCompat.getColor(this, android.R.color.holo_blue_light);
+            int startColor3 = ContextCompat.getColor(this, android.R.color.holo_orange_light);
+            int startColor4 = ContextCompat.getColor(this, android.R.color.holo_green_light);
+            int startColor5 = ContextCompat.getColor(this, android.R.color.holo_red_light);
+            int endColor1 = ContextCompat.getColor(this, android.R.color.holo_blue_dark);
+            int endColor2 = ContextCompat.getColor(this, android.R.color.holo_purple);
+            int endColor3 = ContextCompat.getColor(this, android.R.color.holo_green_dark);
+            int endColor4 = ContextCompat.getColor(this, android.R.color.holo_red_dark);
+            int endColor5 = ContextCompat.getColor(this, android.R.color.holo_orange_dark);
+
+            List<GradientColor> gradientColors = new ArrayList<>();
+            gradientColors.add(new GradientColor(startColor1, endColor1));
+            gradientColors.add(new GradientColor(startColor2, endColor2));
+            gradientColors.add(new GradientColor(startColor3, endColor3));
+            gradientColors.add(new GradientColor(startColor4, endColor4));
+            gradientColors.add(new GradientColor(startColor5, endColor5));
+
+            set1.setGradientColors(gradientColors);
 
             ArrayList<IBarDataSet> dataSets = new ArrayList<>();
             dataSets.add(set1);

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/data/BaseDataSet.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/data/BaseDataSet.java
@@ -252,7 +252,7 @@ public abstract class BaseDataSet<T extends Entry> implements IDataSet<T> {
      * @param gradientColors
      */
     public void setGradientColors(List<GradientColor> gradientColors) {
-        this.mGradientColors = gradientColors;
+        mGradientColors = gradientColors;
     }
 
     /**

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/BarChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/BarChartRenderer.java
@@ -4,6 +4,7 @@ import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.RectF;
+import android.graphics.Shader.TileMode;
 import android.graphics.drawable.Drawable;
 
 import com.github.mikephil.charting.animation.ChartAnimator;
@@ -175,7 +176,7 @@ public class BarChartRenderer extends BarLineScatterCandleBubbleRenderer {
                         buffer.buffer[j + 1],
                         gradientColor.getStartColor(),
                         gradientColor.getEndColor(),
-                        android.graphics.Shader.TileMode.MIRROR));
+                        TileMode.MIRROR));
             }
 
             if (dataSet.getGradientColors() != null) {
@@ -187,7 +188,7 @@ public class BarChartRenderer extends BarLineScatterCandleBubbleRenderer {
                         buffer.buffer[j + 1],
                         dataSet.getGradientColor(j / 4).getStartColor(),
                         dataSet.getGradientColor(j / 4).getEndColor(),
-                        android.graphics.Shader.TileMode.MIRROR));
+                        TileMode.MIRROR));
             }
 
 

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/HorizontalBarChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/HorizontalBarChartRenderer.java
@@ -1,9 +1,13 @@
 package com.github.mikephil.charting.renderer;
 
 import android.graphics.Canvas;
+import android.graphics.LinearGradient;
+import android.graphics.Matrix;
 import android.graphics.Paint.Align;
 import android.graphics.RectF;
+import android.graphics.Shader.TileMode;
 import android.graphics.drawable.Drawable;
+import android.util.Log;
 
 import com.github.mikephil.charting.animation.ChartAnimator;
 import com.github.mikephil.charting.buffer.BarBuffer;
@@ -15,6 +19,7 @@ import com.github.mikephil.charting.highlight.Highlight;
 import com.github.mikephil.charting.interfaces.dataprovider.BarDataProvider;
 import com.github.mikephil.charting.interfaces.dataprovider.ChartInterface;
 import com.github.mikephil.charting.interfaces.datasets.IBarDataSet;
+import com.github.mikephil.charting.model.GradientColor;
 import com.github.mikephil.charting.utils.MPPointF;
 import com.github.mikephil.charting.utils.Transformer;
 import com.github.mikephil.charting.utils.Utils;
@@ -131,6 +136,31 @@ public class HorizontalBarChartRenderer extends BarChartRenderer {
                 mRenderPaint.setColor(dataSet.getColor(j / 4));
             }
 
+            if (dataSet.getGradientColor() != null) {
+                GradientColor gradientColor = dataSet.getGradientColor();
+                mRenderPaint.setShader(
+                    new LinearGradient(
+                        buffer.buffer[j],
+                        buffer.buffer[j + 3],
+                        buffer.buffer[j + 2],
+                        buffer.buffer[j + 3],
+                        gradientColor.getStartColor(),
+                        gradientColor.getEndColor(),
+                        TileMode.MIRROR));
+            }
+
+            if (dataSet.getGradientColors() != null) {
+
+                mRenderPaint.setShader(
+                    new LinearGradient(
+                        buffer.buffer[j],
+                        buffer.buffer[j + 3],
+                        buffer.buffer[j + 2],
+                        buffer.buffer[j + 3],
+                        dataSet.getGradientColor(j / 4).getStartColor(),
+                        dataSet.getGradientColor(j / 4).getEndColor(),
+                        TileMode.MIRROR));
+            }
             c.drawRect(buffer.buffer[j], buffer.buffer[j + 1], buffer.buffer[j + 2],
                     buffer.buffer[j + 3], mRenderPaint);
 


### PR DESCRIPTION
## PR Checklist:
- [X] I have tested this extensively and it does not break any existing behavior.
- [X] I have added/updated examples and tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change, please
            create an issue to discuss those changes and gather
            feedback BEFORE submitting your PR. -->


## PR Description
- Make gradient for a horizontal bar chart. Currently, Gradient was available on the Vertical bar chart only.
![Screenshot_1577410549](https://user-images.githubusercontent.com/20433424/71496134-29c82c80-2884-11ea-9729-ba59a1848082.png)

- Implemented gradient logic in Horizontal Barchart. Because old gradient logic was working on superclass of BarchartRenderer but Horizontal Barchart was not access gradient logic in a superclass. So we need to add gradient logic for horizontal again and change a little logic(Buffer) for render in a horizontal way especially. 

<!-- WHY should this PR be merged into the main library? -->
- Some developer need this feature but now available in a Vertical bar chart only.
