### PR TITLE
Render x-axis limit line label with a set font.

### DIFF
--- a/MPChartExample/src/main/java/com/xxmassdeveloper/mpchartexample/LineChartActivity1.java
+++ b/MPChartExample/src/main/java/com/xxmassdeveloper/mpchartexample/LineChartActivity1.java
@@ -6,6 +6,7 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.graphics.Color;
 import android.graphics.DashPathEffect;
+import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Bundle;
@@ -137,7 +138,8 @@ public class LineChartActivity1 extends DemoBase implements OnSeekBarChangeListe
             llXAxis.enableDashedLine(10f, 10f, 0f);
             llXAxis.setLabelPosition(LimitLabelPosition.RIGHT_BOTTOM);
             llXAxis.setTextSize(10f);
-            llXAxis.setTypeface(tfRegular);
+            Typeface tfBold = Typeface.createFromAsset(getAssets(), "OpenSans-Bold.ttf");
+            llXAxis.setTypeface(tfBold);
 
             LimitLine ll1 = new LimitLine(150f, "Upper Limit");
             ll1.setLineWidth(4f);
@@ -160,7 +162,7 @@ public class LineChartActivity1 extends DemoBase implements OnSeekBarChangeListe
             // add limit lines
             yAxis.addLimitLine(ll1);
             yAxis.addLimitLine(ll2);
-            //xAxis.addLimitLine(llXAxis);
+            xAxis.addLimitLine(llXAxis);
         }
 
         // add data

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/XAxisRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/XAxisRenderer.java
@@ -366,6 +366,7 @@ public class XAxisRenderer extends AxisRenderer {
             mLimitLinePaint.setStyle(limitLine.getTextStyle());
             mLimitLinePaint.setPathEffect(null);
             mLimitLinePaint.setColor(limitLine.getTextColor());
+            mLimitLinePaint.setTypeface(limitLine.getTypeface());
             mLimitLinePaint.setStrokeWidth(0.5f);
             mLimitLinePaint.setTextSize(limitLine.getTextSize());
 


### PR DESCRIPTION
## PR Checklist:
- [ ] I have tested this extensively and it does not break any existing behavior.
- [ ] I have added/updated examples and tests for any new behavior.

## PR Description
The set font wasn't used for rendering the label of the limit line of the x-axis, only for the y-axis.
This PR fixes that issue.
Without this fix, one has to override XAxisRenderer:

```
public class TypefaceAwareXAxisRenderer extends XAxisRenderer {

    public TypefaceAwareXAxisRenderer(ViewPortHandler viewPortHandler, XAxis xAxis, Transformer trans) {
        super(viewPortHandler, xAxis, trans);
    }

    @Override
    public void renderLimitLineLabel(Canvas c, LimitLine limitLine, float[] position, float yOffset) {
        if (limitLine != null) {
            mLimitLinePaint.setTypeface(limitLine.getTypeface());
        }
        super.renderLimitLineLabel(c, limitLine, position, yOffset);
    }
}
```

