### PR TITLE
If granularity and the number of labels (with force = true) are set, …

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/AxisRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/AxisRenderer.java
@@ -188,6 +188,11 @@ public abstract class AxisRenderer extends Renderer {
         if (mAxis.isForceLabelsEnabled()) {
 
             interval = (float) range / (float) (labelCount - 1);
+            // If granularity is enabled, then do not allow the interval to go below specified granularity.
+            // This is used to avoid repeated values when rounding values for display.
+            if (mAxis.isGranularityEnabled())
+                interval = interval < mAxis.getGranularity() ? mAxis.getGranularity() : interval;
+
             mAxis.mEntryCount = labelCount;
 
             if (mAxis.mEntries.length < labelCount) {


### PR DESCRIPTION
…granularity setting is ignored.

## PR Checklist:
- [ ] I have tested this extensively and it does not break any existing behavior.
- [ ] I have added/updated examples and tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description
If granularity is set and the number of labels with force = true is set, granularity setting is ignored.
Now that this and this are set, the values on the axis do not become less granulaity


