### PR TITLE
Fixed width/height bug for drawing images

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/utils/Utils.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/utils/Utils.java
@@ -537,7 +537,7 @@ public abstract class Utils {
                 mDrawableBoundsCache.left,
                 mDrawableBoundsCache.top,
                 mDrawableBoundsCache.left + width,
-                mDrawableBoundsCache.top + width);
+                mDrawableBoundsCache.top + height);
 
         int saveId = canvas.save();
         // translate to the correct position and draw


### PR DESCRIPTION
Bug was initially reported Sept 11, 2018: "Utils drawImage issue #4225". PhilJay wrote that he planned to fix it but it hasn't been incorporated yet. (https://github.com/PhilJay/MPAndroidChart/issues/4225)

## PR Checklist:
- [ ] I have tested this extensively and it does not break any existing behavior.
- [ ] I have added/updated examples and tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change, please
            create an issue to discuss those changes and gather
            feedback BEFORE submitting your PR. -->


## PR Description
<!-- Describe Your PR Here! -->

<!-- What does this add/ remove/ fix/ change? -->

<!-- WHY should this PR be merged into the main library? -->
