### PR TITLE
fix unable to drag highlight when zoomed into line chart

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/listener/BarLineChartTouchListener.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/listener/BarLineChartTouchListener.java
@@ -213,6 +213,13 @@ public class BarLineChartTouchListener extends ChartTouchListener<BarLineChartBa
                             }
                         }
 
+                    }else{
+                        if (mChart.isHighlightPerDragEnabled()) {
+                            mLastGesture = ChartGesture.DRAG;
+
+                            if (mChart.isHighlightPerDragEnabled())
+                                performHighlightDrag(event);
+                        }
                     }
 
                 }


### PR DESCRIPTION
## PR Checklist:
-  I have tested this extensively and it does not break any existing behavior.
-  I have added/updated examples and tests for any new behavior.
-  If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change, please
            create an issue to discuss those changes and gather
            feedback BEFORE submitting your PR. -->


## PR Description
1.This PR fix the issue that unable to drag highlight when zoomed into line chart related to #3388 .
2.When chart is zoomed, you can drag highlight after chart's `dragEnabled` is set to false.
(In my code, I set `dragEnabled` to false in `onChartLongPressed` callback,then set it to true back in `onChartGestureEnd` callback ).
