### PR TITLE
New method for manual label positioning in PieCharts.

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/charts/PieChart.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/charts/PieChart.java
@@ -793,6 +793,13 @@ public class PieChart extends PieRadarChartBase<PieData> {
         this.mMinAngleForSlices = minAngle;
     }
 
+    /**
+     * Method that sets the label radius
+     */
+    public void setLabelRadius(float labelRadius){
+        ((PieChartRenderer) mRenderer).setLabelRadius(labelRadius);
+    }
+
     @Override
     protected void onDetachedFromWindow() {
         // releases the bitmap in the renderer to avoid oom error

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/PieChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/PieChartRenderer.java
@@ -60,6 +60,7 @@ public class PieChartRenderer extends DataRenderer {
     private RectF mCenterTextLastBounds = new RectF();
     private RectF[] mRectBuffer = {new RectF(), new RectF(), new RectF()};
 
+    private float labelRadius = 0f;
     /**
      * Bitmap for drawing the center hole
      */
@@ -112,6 +113,10 @@ public class PieChartRenderer extends DataRenderer {
 
     public Paint getPaintEntryLabels() {
         return mEntryLabelsPaint;
+    }
+
+    public void setLabelRadius(float labelRadius){
+        this.labelRadius = labelRadius;
     }
 
     @Override
@@ -429,8 +434,10 @@ public class PieChartRenderer extends DataRenderer {
                 rotationAngle += roundedRadius * 360 / (Math.PI * 2 * radius);
             }
         }
-
-        final float labelRadius = radius - labelRadiusOffset;
+        // if labelRadius is not setup or has value greater than radius take default value
+        if(labelRadius == 0f || labelRadius > radius){
+            labelRadius = radius - labelRadiusOffset;
+        }
 
         PieData data = mChart.getData();
         List<IPieDataSet> dataSets = data.getDataSets();


### PR DESCRIPTION
Added setLabelRadius to PieChart class so that users can manually set the label position (if labelRadius greater than pie chart radius or is not setup we use the default one). Also added a setLabelRadius method in PieChartRenderer for this to work properly and pass the value. Tested with current example for both basicPieChart and halfPieChart and works fine.


Added method to enable users to position labels in PieCharts wherever they want within the PieChart radius.
#2537 issue states the desire to be able to move the label values closer to the center.
#2248 issue states that the label value can be positioned according to the user within the radius limit of the Pie Chart .
Gives users the option to manually position the label of the PieChart to where they want.