### PR TITLE
Added Accessibility Support for Screenreaders

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/charts/BarChart.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/charts/BarChart.java
@@ -15,6 +15,8 @@ import com.github.mikephil.charting.interfaces.dataprovider.BarDataProvider;
 import com.github.mikephil.charting.interfaces.datasets.IBarDataSet;
 import com.github.mikephil.charting.renderer.BarChartRenderer;
 
+import java.util.Locale;
+
 /**
  * Chart that draws bars.
  *
@@ -269,13 +271,19 @@ public class BarChart extends BarLineChartBase<BarData> implements BarDataProvid
         String minVal = yAxisValueFormmater.getFormattedValue(barData.getYMin());
         String maxVal = yAxisValueFormmater.getFormattedValue(barData.getYMax());
 
+        // Data range...
+        ValueFormatter xAxisValueFormatter = getXAxis().getValueFormatter();
+        String minRange = xAxisValueFormatter.getFormattedValue(barData.getXMin());
+        String maxRange = xAxisValueFormatter.getFormattedValue(barData.getXMax());
+
         String entries = entryCount == 1 ? "entry" : "entries";
 
         // Format the values of min and max; to recite them back
 
-        String description = String.format("The bar chart has %d %s. " +
-                        "The minimum value is %s and maximum value is %s",
-                entryCount, entries, minVal, maxVal);
+        String description = String.format(Locale.getDefault(), "The bar chart has %d %s. " +
+                        "The minimum value is %s and maximum value is %s." +
+                        "Data ranges from %s to %s.",
+                entryCount, entries, minVal, maxVal, minRange, maxRange);
 
         return description;
     }

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/charts/BarChart.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/charts/BarChart.java
@@ -262,7 +262,7 @@ public class BarChart extends BarLineChartBase<BarData> implements BarDataProvid
 
         BarData barData = getBarData();
 
-        int entryCount = barData.getDataSetCount();
+        int entryCount = barData.getEntryCount();
 
         // Find the min and max index
         ValueFormatter yAxisValueFormmater = getAxisLeft().getValueFormatter();

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/charts/BarChart.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/charts/BarChart.java
@@ -8,6 +8,7 @@ import android.util.Log;
 import com.github.mikephil.charting.components.YAxis;
 import com.github.mikephil.charting.data.BarData;
 import com.github.mikephil.charting.data.BarEntry;
+import com.github.mikephil.charting.formatter.ValueFormatter;
 import com.github.mikephil.charting.highlight.BarHighlighter;
 import com.github.mikephil.charting.highlight.Highlight;
 import com.github.mikephil.charting.interfaces.dataprovider.BarDataProvider;
@@ -258,6 +259,24 @@ public class BarChart extends BarLineChartBase<BarData> implements BarDataProvid
 
     @Override
     public String getAccessibilityDescription() {
-        return "This is a bar chart";
+
+        BarData barData = getBarData();
+
+        int entryCount = barData.getDataSetCount();
+
+        // Find the min and max index
+        ValueFormatter yAxisValueFormmater = getAxisLeft().getValueFormatter();
+        String minVal = yAxisValueFormmater.getFormattedValue(barData.getYMin());
+        String maxVal = yAxisValueFormmater.getFormattedValue(barData.getYMax());
+
+        String entries = entryCount == 1 ? "entry" : "entries";
+
+        // Format the values of min and max; to recite them back
+
+        String description = String.format("The bar chart has %d %s. " +
+                        "The minimum value is %s and maximum value is %s",
+                entryCount, entries, minVal, maxVal);
+
+        return description;
     }
 }

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/charts/BarChart.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/charts/BarChart.java
@@ -255,4 +255,9 @@ public class BarChart extends BarLineChartBase<BarData> implements BarDataProvid
             notifyDataSetChanged();
         }
     }
+
+    @Override
+    public String getAccessibilityDescription() {
+        return "This is a bar chart";
+    }
 }

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/charts/BubbleChart.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/charts/BubbleChart.java
@@ -40,4 +40,9 @@ public class BubbleChart extends BarLineChartBase<BubbleData> implements BubbleD
     public BubbleData getBubbleData() {
         return mData;
     }
+
+    @Override
+    public String getAccessibilityDescription() {
+        return "This is bubble chart";
+    }
 }

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/charts/CandleStickChart.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/charts/CandleStickChart.java
@@ -41,4 +41,9 @@ public class CandleStickChart extends BarLineChartBase<CandleData> implements Ca
     public CandleData getCandleData() {
         return mData;
     }
+
+    @Override
+    public String getAccessibilityDescription() {
+        return "This is a candlestick";
+    }
 }

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/charts/Chart.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/charts/Chart.java
@@ -237,6 +237,9 @@ public abstract class Chart<T extends ChartData<? extends IDataSet<? extends Ent
 
         if (mLogEnabled)
             Log.i("", "Chart.init()");
+
+        // enable being detected by ScreenReader
+        setFocusable(true);
     }
 
     // public void initWithDummyData() {
@@ -1818,4 +1821,9 @@ public abstract class Chart<T extends ChartData<? extends IDataSet<? extends Ent
     public void setUnbindEnabled(boolean enabled) {
         this.mUnbind = enabled;
     }
+
+    // region accessibility
+
+
+    // endregion
 }

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/charts/Chart.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/charts/Chart.java
@@ -23,6 +23,7 @@ import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewParent;
+import android.view.accessibility.AccessibilityEvent;
 
 import com.github.mikephil.charting.animation.ChartAnimator;
 import com.github.mikephil.charting.animation.Easing;
@@ -175,6 +176,11 @@ public abstract class Chart<T extends ChartData<? extends IDataSet<? extends Ent
             mExtraRightOffset = 0.f,
             mExtraBottomOffset = 0.f,
             mExtraLeftOffset = 0.f;
+
+    /**
+     * Tag for logging accessibility related content
+     */
+    private String TAG = "abilityTag";
 
     /**
      * default constructor for initialization in code
@@ -1824,6 +1830,22 @@ public abstract class Chart<T extends ChartData<? extends IDataSet<? extends Ent
 
     // region accessibility
 
+    /**
+     *
+     * @return accessibility description must be created for each chart
+     */
+    public abstract String getAccessibilityDescription();
+
+    @Override
+    public boolean dispatchPopulateAccessibilityEvent(AccessibilityEvent event) {
+
+        boolean completed = super.dispatchPopulateAccessibilityEvent(event);
+        Log.d(TAG, "Dispatch called for Chart <View> and completed as " + completed);
+
+        event.getText().add(getAccessibilityDescription());
+
+        return true;
+    }
 
     // endregion
 }

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/charts/Chart.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/charts/Chart.java
@@ -183,6 +183,11 @@ public abstract class Chart<T extends ChartData<? extends IDataSet<? extends Ent
     private String TAG = "abilityTag";
 
     /**
+     * Additional data on top of dynamically generated description. This can be set by the user.
+     */
+    private String accessibilitySummaryDescription = "";
+
+    /**
      * default constructor for initialization in code
      */
     public Chart(Context context) {
@@ -1836,6 +1841,14 @@ public abstract class Chart<T extends ChartData<? extends IDataSet<? extends Ent
      */
     public abstract String getAccessibilityDescription();
 
+    public String getAccessibilitySummaryDescription() {
+        return accessibilitySummaryDescription;
+    }
+
+    public void setAccessibilitySummaryDescription(String accessibilitySummaryDescription) {
+        this.accessibilitySummaryDescription = accessibilitySummaryDescription;
+    }
+
     @Override
     public boolean dispatchPopulateAccessibilityEvent(AccessibilityEvent event) {
 
@@ -1843,6 +1856,11 @@ public abstract class Chart<T extends ChartData<? extends IDataSet<? extends Ent
         Log.d(TAG, "Dispatch called for Chart <View> and completed as " + completed);
 
         event.getText().add(getAccessibilityDescription());
+
+        // Add the user generated summary after the dynamic summary is complete.
+        if (!TextUtils.isEmpty(this.getAccessibilitySummaryDescription())) {
+            event.getText().add(this.getAccessibilitySummaryDescription());
+        }
 
         return true;
     }

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/charts/CombinedChart.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/charts/CombinedChart.java
@@ -269,4 +269,8 @@ public class CombinedChart extends BarLineChartBase<CombinedData> implements Com
         }
     }
 
+    @Override
+    public String getAccessibilityDescription() {
+        return "This is a combined chart";
+    }
 }

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/charts/LineChart.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/charts/LineChart.java
@@ -47,4 +47,9 @@ public class LineChart extends BarLineChartBase<LineData> implements LineDataPro
         }
         super.onDetachedFromWindow();
     }
+
+    @Override
+    public String getAccessibilityDescription() {
+        return "This is a line chart";
+    }
 }

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/charts/LineChart.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/charts/LineChart.java
@@ -5,8 +5,11 @@ import android.content.Context;
 import android.util.AttributeSet;
 
 import com.github.mikephil.charting.data.LineData;
+import com.github.mikephil.charting.formatter.ValueFormatter;
 import com.github.mikephil.charting.interfaces.dataprovider.LineDataProvider;
 import com.github.mikephil.charting.renderer.LineChartRenderer;
+
+import java.util.Locale;
 
 /**
  * Chart that draws lines, surfaces, circles, ...
@@ -50,6 +53,29 @@ public class LineChart extends BarLineChartBase<LineData> implements LineDataPro
 
     @Override
     public String getAccessibilityDescription() {
-        return "This is a line chart";
+
+        LineData lineData = getLineData();
+
+        int numberOfPoints = lineData.getEntryCount();
+
+        // Min and max values...
+        ValueFormatter yAxisValueFormmater = getAxisLeft().getValueFormatter();
+        String minVal = yAxisValueFormmater.getFormattedValue(lineData.getYMin());
+        String maxVal = yAxisValueFormmater.getFormattedValue(lineData.getYMax());
+
+        // Data range...
+        ValueFormatter xAxisValueFormatter = getXAxis().getValueFormatter();
+        String minRange = xAxisValueFormatter.getFormattedValue(lineData.getXMin());
+        String maxRange = xAxisValueFormatter.getFormattedValue(lineData.getXMax());
+
+        String entries = numberOfPoints == 1 ? "entry" : "entries";
+
+        String description = String.format(Locale.getDefault(), "The line chart has %d %s. " +
+                        "The minimum value is %s and maximum value is %s." +
+                        "Data ranges from %s to %s.",
+                numberOfPoints, entries, minVal, maxVal, minRange, maxRange);
+
+
+        return description;
     }
 }

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/charts/PieChart.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/charts/PieChart.java
@@ -801,4 +801,9 @@ public class PieChart extends PieRadarChartBase<PieData> {
         }
         super.onDetachedFromWindow();
     }
+
+    @Override
+    public String getAccessibilityDescription() {
+        return "This is a pie chart";
+    }
 }

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/charts/PieChart.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/charts/PieChart.java
@@ -6,10 +6,13 @@ import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.RectF;
 import android.graphics.Typeface;
+import android.text.TextUtils;
 import android.util.AttributeSet;
 
 import com.github.mikephil.charting.components.XAxis;
 import com.github.mikephil.charting.data.PieData;
+import com.github.mikephil.charting.data.PieEntry;
+import com.github.mikephil.charting.formatter.ValueFormatter;
 import com.github.mikephil.charting.highlight.Highlight;
 import com.github.mikephil.charting.highlight.PieHighlighter;
 import com.github.mikephil.charting.interfaces.datasets.IPieDataSet;
@@ -17,7 +20,9 @@ import com.github.mikephil.charting.renderer.PieChartRenderer;
 import com.github.mikephil.charting.utils.MPPointF;
 import com.github.mikephil.charting.utils.Utils;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * View that represents a pie chart. Draws cake like slices.
@@ -804,6 +809,24 @@ public class PieChart extends PieRadarChartBase<PieData> {
 
     @Override
     public String getAccessibilityDescription() {
-        return "This is a pie chart";
+
+        PieData pieData = getData();
+
+        int entryCount = pieData.getEntryCount();
+
+        StringBuilder builder = new StringBuilder();
+
+        builder.append(String.format(Locale.getDefault(), "The pie chart has %d entries.",
+                entryCount));
+
+        for (int i = 0; i < entryCount; i++) {
+            PieEntry entry = pieData.getDataSet().getEntryForIndex(i);
+            float percentage = (entry.getValue() / pieData.getYValueSum()) * 100;
+            builder.append(String.format(Locale.getDefault(), "%s has %.2f percent pie taken",
+                    (TextUtils.isEmpty(entry.getLabel()) ? "No Label" : entry.getLabel()),
+                    percentage));
+        }
+
+        return builder.toString();
     }
 }

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/charts/RadarChart.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/charts/RadarChart.java
@@ -359,4 +359,9 @@ public class RadarChart extends PieRadarChartBase<RadarData> {
     public float getYRange() {
         return mYAxis.mAxisRange;
     }
+
+    @Override
+    public String getAccessibilityDescription() {
+        return "This is a Radar chart";
+    }
 }

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/charts/ScatterChart.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/charts/ScatterChart.java
@@ -74,4 +74,9 @@ public class ScatterChart extends BarLineChartBase<ScatterData> implements Scatt
             return new ScatterShape[]{SQUARE, CIRCLE, TRIANGLE, CROSS, X, CHEVRON_UP, CHEVRON_DOWN};
         }
     }
+
+    @Override
+    public String getAccessibilityDescription() {
+        return "This is scatter chart";
+    }
 }


### PR DESCRIPTION
## PR Checklist:
- [X] I have tested this extensively and it does not break any existing behavior.
- [X] I have added/updated examples and tests for any new behavior.
- [X] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change, please
            create an issue to discuss those changes and gather
            feedback BEFORE submitting your PR. -->


## PR Description
<!-- Describe Your PR Here! -->
The PR adds support for screen-readers. The chart can now be detected and a description is generated dynamically for bar, line and pie charts common use case scenarios.

Previously, the charts were just ignored by the screen-reader. This is a major improvement and paves the way forward for better accessibility implementation for this amazing library. 

<!-- What does this add/ remove/ fix/ change? -->
Adds autogenerated description for screenreader as well as the ability for the user to add accessibility description which will be read out when the screen-reader focuses on the chart. 

`chart.setAccessibilitySummaryDescription("This is a customizable description on user end");`

<!-- WHY should this PR be merged into the main library? -->
Accessibility is really important, 2.2 billion users have some sort of vision-impairment according to the WHO. This enables access for those sets of users who cannot see and makes the library charts accessible. 
