### PR TITLE
Fix bug #2071, alpha issue of DataSets

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineChartRenderer.java
@@ -101,7 +101,7 @@ public class LineChartRenderer extends LineRadarRenderer {
                 drawDataSet(c, set);
         }
 
-        c.drawBitmap(drawBitmap, 0, 0, mRenderPaint);
+        c.drawBitmap(drawBitmap, 0, 0, null);
     }
 
     protected void drawDataSet(Canvas c, ILineDataSet dataSet) {


### PR DESCRIPTION
## PR Checklist:
- [x] I have tested this extensively and it does not break any existing behavior.
- [ ] I have added/updated examples and tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change, please
            create an issue to discuss those changes and gather
            feedback BEFORE submitting your PR. -->


## PR Description
<!-- Describe Your PR Here! -->
Issue #2071 has marked closed at 2018 but actually it still open.

<!-- What does this add/ remove/ fix/ change? -->

<!-- WHY should this PR be merged into the main library? -->
LineChartRenderer calls c.drawBitmap with the mRenderPaint , which still contains the alpha from the last drawn dataset.