### PR TITLE
Fix ArrayIndexOutOfBoundsException exception in BarChartRenderer.java from bug #4984

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/BarChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/BarChartRenderer.java
@@ -463,9 +463,17 @@ public class BarChartRenderer extends BarLineScatterCandleBubbleRenderer {
                     y2 = -e.getNegativeSum();
 
                 } else {
+                    Range range;
+                    try {
+                        range = e.getRanges()[high.getStackIndex()];
+                    }
+                    catch (Exception ex) {
+                        Log.e("BarChartRenderer", ex.getMessage());
+                        ex.printStackTrace();
 
-                    Range range = e.getRanges()[high.getStackIndex()];
-
+                        return;
+                    }
+                    
                     y1 = range.from;
                     y2 = range.to;
                 }


### PR DESCRIPTION
ArrayIndexOutOfBoundsException is thrown and whole app crashes if a a marked BarCharts get outside of the visible range.
The exception can be caught and logged without a disadvantage.

## PR Checklist:
- [X] I have tested this extensively and it does not break any existing behavior.
- [ ] I have added/updated examples and tests for any new behavior.
- [X] If this is a significant change, an issue has already been created where the problem / solution was discussed: https://github.com/PhilJay/MPAndroidChart/issues/4984

## PR Description
<!-- Describe Your PR Here! -->
The "e.getRanges()[high.getStackIndex()]" gets surrounded with a try - catch. If an exception is thrown, the method returns without any change.

<!-- What does this add/ remove/ fix/ change? -->
Catches exception if a marked BarChart gets outside of the visible chart area.

<!-- WHY should this PR be merged into the main library? -->
The whole app crashes if this exception is not caught.
