### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,10 @@
 ### Gradle Setup
 
 ```gradle
-repositories {
-    maven { url 'https://jitpack.io' }
+allprojects {
+    repositories {
+        maven { url 'https://jitpack.io' }
+    }
 }
 
 dependencies {


### PR DESCRIPTION
## PR Checklist:
- [x] I have tested this.

Other checklist items are not relevant.
       <!-- If you'd like to suggest a significant change, please
            create an issue to discuss those changes and gather
            feedback BEFORE submitting your PR. -->


## PR Description
<!-- Describe Your PR Here! -->
`maven { url 'https://jitpack.io' }` line should be added to `repositories` in `allprojects` and not in `repositories` in `buildscript`.
See [https://jitpack.io](https://jitpack.io)

<!-- What does this add/ remove/ fix/ change? -->
Just a small change in Readme.

<!-- WHY should this PR be merged into the main library? -->
It's necessary, if we don't add `allprojects`, it may mislead users (like me) sometimes to put the line in `repositories` in `buildscript` which doesn't work in the latest Android Studio.
