### PR TITLE
Replace reflection-based object animators with properties

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/animation/ChartAnimator.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/animation/ChartAnimator.java
@@ -2,6 +2,8 @@ package com.github.mikephil.charting.animation;
 
 import android.animation.ObjectAnimator;
 import android.animation.ValueAnimator.AnimatorUpdateListener;
+import android.util.Property;
+
 import androidx.annotation.RequiresApi;
 
 import com.github.mikephil.charting.animation.Easing.EasingFunction;
@@ -35,7 +37,7 @@ public class ChartAnimator {
     @RequiresApi(11)
     private ObjectAnimator xAnimator(int duration, EasingFunction easing) {
 
-        ObjectAnimator animatorX = ObjectAnimator.ofFloat(this, "phaseX", 0f, 1f);
+        ObjectAnimator animatorX = ObjectAnimator.ofFloat(this, PHASE_X, 0f, 1f);
         animatorX.setInterpolator(easing);
         animatorX.setDuration(duration);
 
@@ -45,7 +47,7 @@ public class ChartAnimator {
     @RequiresApi(11)
     private ObjectAnimator yAnimator(int duration, EasingFunction easing) {
 
-        ObjectAnimator animatorY = ObjectAnimator.ofFloat(this, "phaseY", 0f, 1f);
+        ObjectAnimator animatorY = ObjectAnimator.ofFloat(this, PHASE_Y, 0f, 1f);
         animatorY.setInterpolator(easing);
         animatorY.setDuration(duration);
 
@@ -204,4 +206,28 @@ public class ChartAnimator {
         }
         mPhaseX = phase;
     }
+
+    private static final Property<ChartAnimator, Float> PHASE_X = new Property<ChartAnimator, Float>(Float.class, "phaseX") {
+        @Override
+        public Float get(ChartAnimator object) {
+            return object.getPhaseX();
+        }
+
+        @Override
+        public void set(ChartAnimator object, Float value) {
+            object.setPhaseX(value);
+        }
+    };
+
+    private static final Property<ChartAnimator, Float> PHASE_Y = new Property<ChartAnimator, Float>(Float.class, "phaseY") {
+        @Override
+        public Float get(ChartAnimator object) {
+            return object.getPhaseY();
+        }
+
+        @Override
+        public void set(ChartAnimator object, Float value) {
+            object.setPhaseY(value);
+        }
+    };
 }

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/charts/PieRadarChartBase.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/charts/PieRadarChartBase.java
@@ -9,6 +9,7 @@ import android.content.Context;
 import android.graphics.RectF;
 import android.util.AttributeSet;
 import android.util.Log;
+import android.util.Property;
 import android.view.MotionEvent;
 
 import com.github.mikephil.charting.animation.Easing;
@@ -482,7 +483,7 @@ public abstract class PieRadarChartBase<T extends ChartData<? extends IDataSet<?
 
         setRotationAngle(fromangle);
 
-        ObjectAnimator spinAnimator = ObjectAnimator.ofFloat(this, "rotationAngle", fromangle,
+        ObjectAnimator spinAnimator = ObjectAnimator.ofFloat(this, ROTATION_ANGLE, fromangle,
                 toangle);
         spinAnimator.setDuration(durationmillis);
         spinAnimator.setInterpolator(easing);
@@ -496,4 +497,16 @@ public abstract class PieRadarChartBase<T extends ChartData<? extends IDataSet<?
         });
         spinAnimator.start();
     }
+
+    private static final Property<PieRadarChartBase, Float> ROTATION_ANGLE = new Property<PieRadarChartBase, Float>(Float.class, "rotationAngle") {
+        @Override
+        public Float get(PieRadarChartBase object) {
+            return object.getRotationAngle();
+        }
+
+        @Override
+        public void set(PieRadarChartBase object, Float value) {
+            object.setRotationAngle(value);
+        }
+    };
 }

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/jobs/AnimatedViewPortJob.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/jobs/AnimatedViewPortJob.java
@@ -4,6 +4,7 @@ import android.animation.Animator;
 import android.animation.ObjectAnimator;
 import android.animation.ValueAnimator;
 import android.annotation.SuppressLint;
+import android.util.Property;
 import android.view.View;
 
 import com.github.mikephil.charting.utils.Transformer;
@@ -26,7 +27,7 @@ public abstract class AnimatedViewPortJob extends ViewPortJob implements ValueAn
         super(viewPortHandler, xValue, yValue, trans, v);
         this.xOrigin = xOrigin;
         this.yOrigin = yOrigin;
-        animator = ObjectAnimator.ofFloat(this, "phase", 0f, 1f);
+        animator = ObjectAnimator.ofFloat(this, PHASE, 0f, 1f);
         animator.setDuration(duration);
         animator.addUpdateListener(this);
         animator.addListener(this);
@@ -96,4 +97,16 @@ public abstract class AnimatedViewPortJob extends ViewPortJob implements ValueAn
     public void onAnimationUpdate(ValueAnimator animation) {
 
     }
+
+    private static final Property<AnimatedViewPortJob, Float> PHASE = new Property<AnimatedViewPortJob, Float>(Float.class, "phase") {
+        @Override
+        public Float get(AnimatedViewPortJob object) {
+            return object.getPhase();
+        }
+
+        @Override
+        public void set(AnimatedViewPortJob object, Float value) {
+            object.setPhase(value);
+        }
+    };
 }


### PR DESCRIPTION
## PR Checklist:
- [x] I have tested this extensively and it does not break any existing behavior.
- [x] I have added/updated examples and tests for any new behavior. N/A
- [X] If this is a significant change, an issue has already been created where the problem / solution was discussed: N/A

## PR Description

When you pass a string to creat an ObjectAnimator it uses reflection under the
hood. You can instead pass a property which is both faster and don't cause
issues with progurad.
