### PR TITLE
Update Utils.java

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/utils/Utils.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/utils/Utils.java
@@ -352,15 +352,15 @@ public abstract class Utils {
      * @param number
      * @return
      */
-    public static float roundToNextSignificant(double number) {
-        if (Double.isInfinite(number) || 
-            Double.isNaN(number) || 
+    public static double roundToNextSignificant(double number) {
+        if (Double.isInfinite(number) ||
+            Double.isNaN(number) ||
             number == 0.0)
             return 0;
-        
-        final float d = (float) Math.ceil((float) Math.log10(number < 0 ? -number : number));
+
+        final double d = Math.ceil(Math.log10(number < 0 ? -number : number));
         final int pw = 1 - (int) d;
-        final float magnitude = (float) Math.pow(10, pw);
+        final double magnitude = Math.pow(10, pw);
         final long shifted = Math.round(number * magnitude);
         return shifted / magnitude;
     }
@@ -374,11 +374,11 @@ public abstract class Utils {
      */
     public static int getDecimals(float number) {
 
-        float i = roundToNextSignificant(number);
-        
-        if (Float.isInfinite(i))
+        double i = roundToNextSignificant(number);
+
+        if (Double.isInfinite(i))
             return 0;
-        
+
         return (int) Math.ceil(-Math.log10(i)) + 2;
     }
 


### PR DESCRIPTION
Use double-s instead of float-s to minimize rounding errors that can lead to axis labels saying e.g. "9999.999" instead of "10000". There's really no excuse for using float-s here, and probably throughout much of the rest of the code, too. Maybe this remark could be taken into consideration to prevent similar problems in the future.
