### PR TITLE
Fixes #405 - added isFlingEnabled setting

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/charts/BarLineChartBase.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/charts/BarLineChartBase.java
@@ -81,6 +81,11 @@ public abstract class BarLineChartBase<T extends BarLineScatterCandleBubbleData<
     private boolean mDragXEnabled = true;
     private boolean mDragYEnabled = true;
 
+    /**
+     * if true, fling gesture is enabled for the chart
+     */
+    private boolean mFlingEnabled = false;
+
     private boolean mScaleXEnabled = true;
     private boolean mScaleYEnabled = true;
 
@@ -1146,6 +1151,22 @@ public abstract class BarLineChartBase<T extends BarLineScatterCandleBubbleData<
      */
     public boolean isDragYEnabled() {
         return mDragYEnabled;
+    }
+
+    /**
+     * Set this to true to enable fling gesture for the chart
+     *
+     * @param enabled
+     */
+    public void setFlingEnabled(boolean enabled) { this.mFlingEnabled = enabled; }
+
+    /**
+     * Returns true if fling gesture is enabled for the chart, false if not.
+     *
+     * @return
+     */
+    public boolean isFlingEnabled() {
+        return mFlingEnabled;
     }
 
     /**

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/listener/BarLineChartTouchListener.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/listener/BarLineChartTouchListener.java
@@ -108,7 +108,7 @@ public class BarLineChartTouchListener extends ChartTouchListener<BarLineChartBa
             }
         }
 
-        if (mTouchMode == NONE) {
+        if (mChart.isFlingEnabled()) {
             mGestureDetector.onTouchEvent(event);
         }
 


### PR DESCRIPTION
## PR Checklist:
- [x] I have tested this extensively and it does not break any existing behavior.
- [x] I have added/updated examples and tests for any new behavior (there are no tests/examples for similar things e.g. `isDragEnabled` so I didn't add mine too).
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

This adds `isFlingEnabled` setting so `onChartFling` can work properly.
Fixes https://github.com/PhilJay/MPAndroidChart/issues/405