### PR TITLE
Test for null in entry.getRanges()

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/highlight/BarHighlighter.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/highlight/BarHighlighter.java
@@ -65,7 +65,7 @@ public class BarHighlighter extends ChartHighlighter<BarDataProvider> {
         } else {
             Range[] ranges = entry.getRanges();
 
-            if (ranges.length > 0) {
+            if (ranges != null && ranges.length > 0) {
                 int stackIndex = getClosestStackIndex(ranges, yVal);
 
                 MPPointD pixels = mChart.getTransformer(set.getAxisDependency()).getPixelForValues(high.getX(), ranges[stackIndex].to);


### PR DESCRIPTION
If a BarChart has no printed values, the method entry.getRanges() returns null and the method ranges.length throws an exception (null.length).
This can simply be prevented by asking the ranges to be not null before asking for length.

## PR Checklist:
- [X] I have tested this extensively and it does not break any existing behavior.
- [ ] I have added/updated examples and tests for any new behavior.
- [X] If this is a significant change, an issue has already been created where the problem / solution was discussed: [https://github.com/PhilJay/MPAndroidChart/issues/5054]

## PR Description
Check array to be not null before accessing a property of null. 

The BarChart does not crash if it has empty values.

It prevents a crash of the app.
