### PR TITLE
Improve DefaultValueFormatter performance

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/charts/Chart.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/charts/Chart.java
@@ -370,7 +370,7 @@ public abstract class Chart<T extends ChartData<? extends IDataSet<? extends Ent
      */
     protected void setupDefaultFormatter(float min, float max) {
 
-        float reference = 0f;
+        float reference;
 
         if (mData == null || mData.getEntryCount() < 2) {
 

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/formatter/DefaultValueFormatter.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/formatter/DefaultValueFormatter.java
@@ -38,17 +38,18 @@ public class DefaultValueFormatter implements IValueFormatter
      * @param digits
      */
     public void setup(int digits) {
+        if (this.mDecimalDigits != digits) {
+            this.mDecimalDigits = digits;
 
-        this.mDecimalDigits = digits;
+            StringBuffer b = new StringBuffer();
+            for (int i = 0; i < digits; i++) {
+                if (i == 0)
+                    b.append(".");
+                b.append("0");
+            }
 
-        StringBuffer b = new StringBuffer();
-        for (int i = 0; i < digits; i++) {
-            if (i == 0)
-                b.append(".");
-            b.append("0");
+            mFormat = new DecimalFormat("###,###,###,##0" + b.toString());
         }
-
-        mFormat = new DecimalFormat("###,###,###,##0" + b.toString());
     }
 
     @Override


### PR DESCRIPTION
## PR Checklist:
- [x] I have tested this extensively and it does not break any existing behavior.
- [x] I have added/updated examples and tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change, please
            create an issue to discuss those changes and gather
            feedback BEFORE submitting your PR. -->


## PR Description
<!-- Describe Your PR Here! -->
Improve DefaultValueFormatter performance

<!-- What does this add/ remove/ fix/ change? -->
If the calculated number of digits has not changed, the DecimalFormat will not be reinitialized

<!-- WHY should this PR be merged into the main library? -->
As in https://github.com/PhilJay/MPAndroidChart/issues/5217 describe,  the DefaultValueFormatter will be calculated repeatedly and the DecimalFormat will be initialized. If there are a large number of icons on the interface, this will cause serious performance problems. 