### PR TITLE
Support dynamically circle colors changes on LineChartRenderer

### DIFF
--- a/MPChartExample/src/main/java/com/xxmassdeveloper/mpchartexample/LineChartActivity1.java
+++ b/MPChartExample/src/main/java/com/xxmassdeveloper/mpchartexample/LineChartActivity1.java
@@ -442,13 +442,33 @@ public class LineChartActivity1 extends DemoBase implements OnSeekBarChangeListe
 
     @Override
     public void onValueSelected(Entry e, Highlight h) {
+        toggleCirclesColorOnGraphSelection(true);
         Log.i("Entry selected", e.toString());
-        Log.i("LOW HIGH", "low: " + chart.getLowestVisibleX() + ", high: " + chart.getHighestVisibleX());
-        Log.i("MIN MAX", "xMin: " + chart.getXChartMin() + ", xMax: " + chart.getXChartMax() + ", yMin: " + chart.getYChartMin() + ", yMax: " + chart.getYChartMax());
+        Log.i("LOW HIGH",
+                "low: " + chart.getLowestVisibleX() + ", high: " + chart.getHighestVisibleX());
+        Log.i("MIN MAX",
+                "xMin: " + chart.getXChartMin() + ", xMax: " + chart.getXChartMax() + ", yMin: "
+                        + chart.getYChartMin() + ", yMax: " + chart.getYChartMax());
     }
 
     @Override
     public void onNothingSelected() {
+        toggleCirclesColorOnGraphSelection(false);
         Log.i("Nothing selected", "Nothing selected.");
+    }
+
+    private void toggleCirclesColorOnGraphSelection(boolean isSelected) {
+        List<ILineDataSet> dataSets = chart.getData().getDataSets();
+        for (int i = 0; i < dataSets.size(); i++) {
+            ILineDataSet dataSet = dataSets.get(i);
+            if (dataSet instanceof LineDataSet) {
+                List<Integer> colors = new ArrayList<>();
+                for (int i1 = 0; i1 < dataSet.getEntryCount(); i1++) {
+                    colors.add(getResources().getColor(isSelected ? R.color.gray : R.color.black));
+                }
+                ((LineDataSet) dataSet).setCircleColors(colors);
+            }
+        }
+        chart.notifyDataSetChanged();
     }
 }

--- a/MPChartExample/src/main/res/values/colors.xml
+++ b/MPChartExample/src/main/res/values/colors.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="gray">#efefef</color>
+    <color name="black">#000</color>
+</resources>

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineChartRenderer.java
@@ -657,7 +657,7 @@ public class LineChartRenderer extends LineRadarRenderer {
             if (mImageCaches.containsKey(dataSet)) {
                 imageCache = mImageCaches.get(dataSet);
             } else {
-                imageCache = new DataSetImageCache(dataSet);
+                imageCache = new DataSetImageCache();
                 mImageCaches.put(dataSet, imageCache);
             }
 
@@ -765,16 +765,6 @@ public class LineChartRenderer extends LineRadarRenderer {
         private Bitmap[] circleBitmaps;
         private int[] circleColors;
 
-        DataSetImageCache(ILineDataSet set) {
-            int size = set.getCircleColorCount();
-
-            if (circleBitmaps == null) {
-                circleBitmaps = new Bitmap[size];
-            } else if (circleBitmaps.length != size) {
-                circleBitmaps = new Bitmap[size];
-            }
-        }
-
         /**
          * Fills the cache with bitmaps for the given dataset.
          *
@@ -782,8 +772,9 @@ public class LineChartRenderer extends LineRadarRenderer {
          * @param drawCircleHole
          * @param drawTransparentCircleHole
          */
-        protected void fill(ILineDataSet set, boolean drawCircleHole, boolean drawTransparentCircleHole) {
-
+        protected void fill(ILineDataSet set, boolean drawCircleHole,
+                boolean drawTransparentCircleHole) {
+            init(set);
             int colorCount = set.getCircleColorCount();
             float circleRadius = set.getCircleRadius();
             float circleHoleRadius = set.getCircleHoleRadius();
@@ -833,6 +824,16 @@ public class LineChartRenderer extends LineRadarRenderer {
                                 mCirclePaintInner);
                     }
                 }
+            }
+        }
+
+        private void init(ILineDataSet set) {
+            int size = set.getCircleColorCount();
+
+            if (circleBitmaps == null) {
+                circleBitmaps = new Bitmap[size];
+            } else if (circleBitmaps.length != size) {
+                circleBitmaps = new Bitmap[size];
             }
         }
 


### PR DESCRIPTION
## PR Checklist:
- [x] I have tested this extensively and it does not break any existing behavior.
- [x] I have added/updated examples and tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change, please
            create an issue to discuss those changes and gather
            feedback BEFORE submitting your PR. -->


## PR Description

Improve cache from circle image on LineChartRenderer
Changed mImageCache from HashMap to WeakHashMap to avoid OOM
Moved `DataSetImageCache.init` to be inside of `fill` method. The main idea is check if the color have been changed and update circle if it is true.
### Motivation:
I created this PR because I met one use case that I needed to use different colors from dots and changed it dinamically from a "hover" on graph. So I used the method setCircleColors, but when I call drawCircle it doesn’t works because the length of the circle array(`drawCircles:777`) have not been changed. So, in my use case the size keep the same only the color changed.

Selected:
<img width="316" alt="Screen Shot 2022-01-03 at 18 26 36" src="https://user-images.githubusercontent.com/5347606/147982235-6455568a-8696-4308-8e99-407962d3af37.png">
Unselected:
<img width="312" alt="Screen Shot 2022-01-03 at 18 26 22" src="https://user-images.githubusercontent.com/5347606/147982243-453615c1-7d9d-4a29-8388-3db81597a365.png">

