### PR TITLE
Fix x-axis labels overlapping

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/components/XAxis.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/components/XAxis.java
@@ -48,6 +48,11 @@ public class XAxis extends AxisBase {
     private boolean mAvoidFirstLastClipping = false;
 
     /**
+     * minimum spacing between labels in pixels
+     */
+    protected float mSpaceBetweenLabelsMin = 0;
+
+    /**
      * the position of the x-labels relative to the chart
      */
     private XAxisPosition mPosition = XAxisPosition.TOP;
@@ -63,6 +68,19 @@ public class XAxis extends AxisBase {
         super();
 
         mYOffset = Utils.convertDpToPixel(4.f); // -3
+    }
+
+    /**
+     * Returns minimum spacing between labels in pixels
+     */
+    public float getSpaceBetweenLabelsMin() { return mSpaceBetweenLabelsMin; }
+
+    /**
+     * Sets minimum spacing between labels in pixels
+     */
+    public void setSpaceBetweenLabelsMin(float space)
+    {
+        mSpaceBetweenLabelsMin = space;
     }
 
     /**

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/XAxisRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/XAxisRenderer.java
@@ -45,7 +45,7 @@ public class XAxisRenderer extends AxisRenderer {
 
         // calculate the starting and entry point of the y-labels (depending on
         // zoom / contentrect bounds)
-        if (mViewPortHandler.contentWidth() > 10 && !mViewPortHandler.isFullyZoomedOutX()) {
+        if (mViewPortHandler != null && mViewPortHandler.contentWidth() > 10 && !mViewPortHandler.isFullyZoomedOutX()) {
 
             MPPointD p1 = mTrans.getValuesByTouchPoint(mViewPortHandler.contentLeft(), mViewPortHandler.contentTop());
             MPPointD p2 = mTrans.getValuesByTouchPoint(mViewPortHandler.contentRight(), mViewPortHandler.contentTop());
@@ -64,14 +64,59 @@ public class XAxisRenderer extends AxisRenderer {
             MPPointD.recycleInstance(p2);
         }
 
-        computeAxisValues(min, max);
+        computeAxisInterval(min, max);
     }
 
     @Override
-    protected void computeAxisValues(float min, float max) {
-        super.computeAxisValues(min, max);
+    protected void computeAxisInterval(float min, float max) {
 
+        // Compute the longest label width first
         computeSize();
+
+        int labelCount = mXAxis.getLabelCount();
+        double range = Math.abs(max - min);
+
+        if (labelCount == 0 || range <= 0 || Double.isInfinite(range)) {
+            mXAxis.mEntries = new float[]{};
+            mXAxis.mCenteredEntries = new float[]{};
+            mXAxis.mEntryCount = 0;
+            return;
+        }
+
+        // Find out how much spacing (in x value space) between axis values
+        double rawInterval = range / labelCount;
+        double interval = Utils.roundToNextSignificant(rawInterval);
+
+        // Do not allow the interval go below the label width with spacing.
+        double labelMaxWidth = (mXAxis.mLabelRotatedWidth + mXAxis.getSpaceBetweenLabelsMin()) * range /  mViewPortHandler.contentWidth();
+        if (interval < labelMaxWidth)
+            interval = labelMaxWidth;
+
+        // If granularity is enabled, then do not allow the interval to go below specified granularity.
+        // This is used to avoid repeated values when rounding values for display.
+        if (mXAxis.isGranularityEnabled())
+            interval = interval < mXAxis.getGranularity() ? mXAxis.getGranularity() : interval;
+
+        // Perform rounding once again after interval was probably adjusted by label width and/or granularity checks.
+        rawInterval = interval;
+        interval = Utils.roundToNextSignificant(rawInterval);
+
+        // Normalize interval
+        double intervalMagnitude = Utils.roundToNextSignificant(Math.pow(10, (int) Math.log10(interval)));
+        int intervalSigDigit = (int) (interval / intervalMagnitude);
+        if (intervalSigDigit > 5) {
+            // Use one order of magnitude higher, to avoid intervals like 0.9 or 90
+            // if it's 0.0 after floor(), we use the old value
+            interval = Math.floor(10.0 * intervalMagnitude) == 0.0
+                    ? interval
+                    : Math.floor(10.0 * intervalMagnitude);
+
+            // If rounded down to current significant, round up to avoid label overlapping
+        } else if (interval < rawInterval) {
+            interval = (intervalSigDigit + 1) * intervalMagnitude;
+        }
+
+        computeAxisValues(min, max, labelCount, range, interval);
     }
 
     protected void computeSize() {
@@ -90,7 +135,6 @@ public class XAxisRenderer extends AxisRenderer {
                 labelWidth,
                 labelHeight,
                 mXAxis.getLabelRotationAngle());
-
 
         mXAxis.mLabelWidth = Math.round(labelWidth);
         mXAxis.mLabelHeight = Math.round(labelHeight);

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/XAxisRendererHorizontalBarChart.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/XAxisRendererHorizontalBarChart.java
@@ -55,7 +55,7 @@ public class XAxisRendererHorizontalBarChart extends XAxisRenderer {
             MPPointD.recycleInstance(p2);
         }
 
-        computeAxisValues(min, max);
+        computeAxisInterval(min, max);
     }
     
     @Override

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/YAxisRendererHorizontalBarChart.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/YAxisRendererHorizontalBarChart.java
@@ -57,7 +57,7 @@ public class YAxisRendererHorizontalBarChart extends YAxisRenderer {
             MPPointD.recycleInstance(p2);
         }
 
-        computeAxisValues(yMin, yMax);
+        computeAxisInterval(yMin, yMax);
     }
 
     /**

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/YAxisRendererRadarChart.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/YAxisRendererRadarChart.java
@@ -2,7 +2,6 @@ package com.github.mikephil.charting.renderer;
 
 import android.graphics.Canvas;
 import android.graphics.Path;
-import android.graphics.PointF;
 
 import com.github.mikephil.charting.charts.RadarChart;
 import com.github.mikephil.charting.components.LimitLine;
@@ -24,123 +23,11 @@ public class YAxisRendererRadarChart extends YAxisRenderer {
     }
 
     @Override
-    protected void computeAxisValues(float min, float max) {
-
-        float yMin = min;
-        float yMax = max;
-
-        int labelCount = mAxis.getLabelCount();
-        double range = Math.abs(yMax - yMin);
-
-        if (labelCount == 0 || range <= 0 || Double.isInfinite(range)) {
-            mAxis.mEntries = new float[]{};
-            mAxis.mCenteredEntries = new float[]{};
-            mAxis.mEntryCount = 0;
-            return;
-        }
-
-        // Find out how much spacing (in y value space) between axis values
-        double rawInterval = range / labelCount;
-        double interval = Utils.roundToNextSignificant(rawInterval);
-
-        // If granularity is enabled, then do not allow the interval to go below specified granularity.
-        // This is used to avoid repeated values when rounding values for display.
-        if (mAxis.isGranularityEnabled())
-            interval = interval < mAxis.getGranularity() ? mAxis.getGranularity() : interval;
-
-        // Normalize interval
-        double intervalMagnitude = Utils.roundToNextSignificant(Math.pow(10, (int) Math.log10(interval)));
-        int intervalSigDigit = (int) (interval / intervalMagnitude);
-        if (intervalSigDigit > 5) {
-            // Use one order of magnitude higher, to avoid intervals like 0.9 or 90
-            // if it's 0.0 after floor(), we use the old value
-            interval = Math.floor(10.0 * intervalMagnitude) == 0.0
-                    ? interval
-                    : Math.floor(10.0 * intervalMagnitude);
-        }
-
-        boolean centeringEnabled = mAxis.isCenterAxisLabelsEnabled();
-        int n = centeringEnabled ? 1 : 0;
-
-        // force label count
-        if (mAxis.isForceLabelsEnabled()) {
-
-            float step = (float) range / (float) (labelCount - 1);
-            mAxis.mEntryCount = labelCount;
-
-            if (mAxis.mEntries.length < labelCount) {
-                // Ensure stops contains at least numStops elements.
-                mAxis.mEntries = new float[labelCount];
-            }
-
-            float v = min;
-
-            for (int i = 0; i < labelCount; i++) {
-                mAxis.mEntries[i] = v;
-                v += step;
-            }
-
-            n = labelCount;
-
-            // no forced count
-        } else {
-
-            double first = interval == 0.0 ? 0.0 : Math.ceil(yMin / interval) * interval;
-            if (centeringEnabled) {
-                first -= interval;
-            }
-
-            double last = interval == 0.0 ? 0.0 : Utils.nextUp(Math.floor(yMax / interval) * interval);
-
-            double f;
-            int i;
-
-            if (interval != 0.0) {
-                for (f = first; f <= last; f += interval) {
-                    ++n;
-                }
-            }
-
-            n++;
-
-            mAxis.mEntryCount = n;
-
-            if (mAxis.mEntries.length < n) {
-                // Ensure stops contains at least numStops elements.
-                mAxis.mEntries = new float[n];
-            }
-
-            for (f = first, i = 0; i < n; f += interval, ++i) {
-
-                if (f == 0.0) // Fix for negative zero case (Where value == -0.0, and 0.0 == -0.0)
-                    f = 0.0;
-
-                mAxis.mEntries[i] = (float) f;
-            }
-        }
-
-        // set decimals
-        if (interval < 1) {
-            mAxis.mDecimals = (int) Math.ceil(-Math.log10(interval));
-        } else {
-            mAxis.mDecimals = 0;
-        }
-
-        if (centeringEnabled) {
-
-            if (mAxis.mCenteredEntries.length < n) {
-                mAxis.mCenteredEntries = new float[n];
-            }
-
-            float offset = (mAxis.mEntries[1] - mAxis.mEntries[0]) / 2f;
-
-            for (int i = 0; i < n; i++) {
-                mAxis.mCenteredEntries[i] = mAxis.mEntries[i] + offset;
-            }
-        }
+    protected void computeAxisInterval(float min, float max) {
+        super.computeAxisInterval(min, max);
 
         mAxis.mAxisMinimum = mAxis.mEntries[0];
-        mAxis.mAxisMaximum = mAxis.mEntries[n-1];
+        mAxis.mAxisMaximum = mAxis.mEntries[mAxis.mEntries.length-1];
         mAxis.mAxisRange = Math.abs(mAxis.mAxisMaximum - mAxis.mAxisMinimum);
     }
 


### PR DESCRIPTION
Fixes #3298, Fixes #2980, Fixes #4640, Fixes #4557,  Fixes #3673.

For those who are looking for a workaround solution, have posted one into #3298.

The fix required modification of `AxisRender.ComputeAxisValues` just for `XAxis`.
In order to avoid code duplication, the following refactoring was done.
`ComputeAxisValues` was split into `CompleteAxisInterval` (the part which differs for X and Y axis) and `ComputeAxisValues` (the common part). The resulting workflow is `X/YAxisRenderer.ComputeAxis` -> `X/YAxisRenderer.CompleteAxisInterval` -> `AxisRender.ComputeAxisValues`.