### PR TITLE
Display highlighted entry values on the axes

### DIFF
--- a/MPChartExample/src/main/java/com/xxmassdeveloper/mpchartexample/LineChartTime.java
+++ b/MPChartExample/src/main/java/com/xxmassdeveloper/mpchartexample/LineChartTime.java
@@ -92,6 +92,7 @@ public class LineChartTime extends DemoBase implements OnSeekBarChangeListener {
         xAxis.setTextColor(Color.rgb(255, 192, 56));
         xAxis.setCenterAxisLabels(true);
         xAxis.setGranularity(1f); // one hour
+        xAxis.setDrawHighlightLabelsEnabled(true);
         xAxis.setValueFormatter(new IAxisValueFormatter() {
 
             private final SimpleDateFormat mFormat = new SimpleDateFormat("dd MMM HH:mm", Locale.ENGLISH);
@@ -114,6 +115,7 @@ public class LineChartTime extends DemoBase implements OnSeekBarChangeListener {
         leftAxis.setAxisMaximum(170f);
         leftAxis.setYOffset(-9f);
         leftAxis.setTextColor(Color.rgb(255, 192, 56));
+        leftAxis.setDrawHighlightLabelsEnabled(true);
 
         YAxis rightAxis = chart.getAxisRight();
         rightAxis.setEnabled(false);

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/charts/BarLineChartBase.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/charts/BarLineChartBase.java
@@ -268,9 +268,9 @@ public abstract class BarLineChartBase<T extends BarLineScatterCandleBubbleData<
         if (mAxisRight.isEnabled() && !mAxisRight.isDrawLimitLinesBehindDataEnabled())
             mAxisRendererRight.renderLimitLines(canvas);
 
-        mXAxisRenderer.renderAxisLabels(canvas);
-        mAxisRendererLeft.renderAxisLabels(canvas);
-        mAxisRendererRight.renderAxisLabels(canvas);
+        mXAxisRenderer.renderAxisLabels(canvas, mIndicesToHighlight);
+        mAxisRendererLeft.renderAxisLabels(canvas, mIndicesToHighlight);
+        mAxisRendererRight.renderAxisLabels(canvas, mIndicesToHighlight);
 
         if (isClipValuesToContentEnabled()) {
             clipRestoreCount = canvas.save();

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/charts/RadarChart.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/charts/RadarChart.java
@@ -133,7 +133,7 @@ public class RadarChart extends PieRadarChartBase<RadarData> {
         if (mXAxis.isEnabled())
             mXAxisRenderer.computeAxis(mXAxis.mAxisMinimum, mXAxis.mAxisMaximum, false);
 
-        mXAxisRenderer.renderAxisLabels(canvas);
+        mXAxisRenderer.renderAxisLabels(canvas, mIndicesToHighlight);
 
         if (mDrawWeb)
             mRenderer.drawExtras(canvas);
@@ -149,7 +149,7 @@ public class RadarChart extends PieRadarChartBase<RadarData> {
         if (mYAxis.isEnabled() && !mYAxis.isDrawLimitLinesBehindDataEnabled())
             mYAxisRenderer.renderLimitLines(canvas);
 
-        mYAxisRenderer.renderAxisLabels(canvas);
+        mYAxisRenderer.renderAxisLabels(canvas, mIndicesToHighlight);
 
         mRenderer.drawValues(canvas);
 

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/components/AxisBase.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/components/AxisBase.java
@@ -3,6 +3,7 @@ package com.github.mikephil.charting.components;
 
 import android.graphics.Color;
 import android.graphics.DashPathEffect;
+import android.graphics.RectF;
 import android.util.Log;
 
 import com.github.mikephil.charting.formatter.DefaultAxisValueFormatter;
@@ -184,6 +185,26 @@ public abstract class AxisBase extends ComponentBase {
         if (labels > 0)
             mAxisMaxLabels = labels;
     }
+
+    /**
+     * If true, the highlight value label is rendered in front of the axis labels
+     */
+    protected boolean mDrawHighlightLabelsEnabled = false;
+
+    /**
+     * Color for the x-label highlight text.
+     */
+    protected int mHighlightTextColor = Color.BLACK;
+
+    /**
+     * Paint for the box surrounding the highlight label.
+     */
+    protected int mHighlightFillColor = Color.WHITE;
+
+    /**
+     * Additional padding for the highlight box
+     */
+    protected RectF mHighlightFillPadding = new RectF(10f, 10f, 10f, 10f);
 
     /**
      * default constructor
@@ -812,5 +833,77 @@ public abstract class AxisBase extends ComponentBase {
     public void setSpaceMax(float mSpaceMax)
     {
         this.mSpaceMax = mSpaceMax;
+    }
+
+    /**
+     * @return true if drawing highlight labels in front of the axis labels is enabled
+     */
+    public boolean isDrawHighlightLabelsEnabled() {
+        return mDrawHighlightLabelsEnabled;
+    }
+
+    /**
+     * Set to true if drawing highlight labels in front of the axis labels should be enabled
+     *
+     * @param enabled
+     */
+    public void setDrawHighlightLabelsEnabled(boolean enabled) {
+        mDrawHighlightLabelsEnabled = enabled;
+    }
+
+    /**
+     * @return highlight label text color
+     */
+    public int getHighlightTextColor() { return mHighlightTextColor; }
+
+    /**
+     * Set highlight label text color
+     *
+     * @param color
+     */
+    public void setHighlightTextColor(int color) {
+        mHighlightTextColor = color;
+    }
+
+    /**
+     * @return highlight label fill color
+     */
+    public int getHighlightFillColor() { return mHighlightFillColor; }
+
+    /**
+     * Sets highlight label fill color
+     *
+     * @param color
+     */
+    public void setHighlightFillColor(int color) {
+        mHighlightFillColor = color;
+    }
+
+    /**
+     * @return highlight label fill padding
+     */
+    public RectF getHighlightFillPadding() { return mHighlightFillPadding; }
+
+    /**
+     * Sets the highlight label fill padding.
+     * The fill rectangle is restricted to stay within ViewPortHandler content bounds
+     * for axis of INSIDE_CHART labelPosition type,
+     * and outside of the bounds for OUTSIDE_CHART axis.
+     * @param left
+     * @param top
+     * @param right
+     * @param bottom
+     */
+    public void setHighlightFillPadding(float left, float top, float right, float bottom) {
+        mHighlightFillPadding = new RectF(left, top, right, bottom);
+    }
+
+    /**
+     * Sets the highlight label fill padding.
+     *
+     * @param padding
+     */
+    public void setHighlightFillPadding(RectF padding) {
+        mHighlightFillPadding = padding;
     }
 }

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/AxisRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/AxisRenderer.java
@@ -7,6 +7,7 @@ import android.graphics.Paint;
 import android.graphics.Paint.Style;
 
 import com.github.mikephil.charting.components.AxisBase;
+import com.github.mikephil.charting.highlight.Highlight;
 import com.github.mikephil.charting.utils.MPPointD;
 import com.github.mikephil.charting.utils.Transformer;
 import com.github.mikephil.charting.utils.Utils;
@@ -268,7 +269,7 @@ public abstract class AxisRenderer extends Renderer {
      *
      * @param c
      */
-    public abstract void renderAxisLabels(Canvas c);
+    public abstract void renderAxisLabels(Canvas c, Highlight[] indicesToHighlight);
 
     /**
      * Draws the grid lines belonging to the axis.

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/XAxisRendererHorizontalBarChart.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/XAxisRendererHorizontalBarChart.java
@@ -11,6 +11,7 @@ import com.github.mikephil.charting.charts.BarChart;
 import com.github.mikephil.charting.components.LimitLine;
 import com.github.mikephil.charting.components.XAxis;
 import com.github.mikephil.charting.components.XAxis.XAxisPosition;
+import com.github.mikephil.charting.highlight.Highlight;
 import com.github.mikephil.charting.utils.FSize;
 import com.github.mikephil.charting.utils.MPPointF;
 import com.github.mikephil.charting.utils.MPPointD;
@@ -57,10 +58,10 @@ public class XAxisRendererHorizontalBarChart extends XAxisRenderer {
 
         computeAxisValues(min, max);
     }
-    
+
     @Override
     protected void computeSize() {
-        
+
         mAxisLabelPaint.setTypeface(mXAxis.getTypeface());
         mAxisLabelPaint.setTextSize(mXAxis.getTextSize());
 
@@ -85,7 +86,7 @@ public class XAxisRendererHorizontalBarChart extends XAxisRenderer {
     }
 
     @Override
-    public void renderAxisLabels(Canvas c) {
+    public void renderAxisLabels(Canvas c, Highlight[] indicesToHighlight) {
 
         if (!mXAxis.isEnabled() || !mXAxis.isDrawLabelsEnabled())
             return;

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/XAxisRendererRadarChart.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/XAxisRendererRadarChart.java
@@ -2,10 +2,10 @@
 package com.github.mikephil.charting.renderer;
 
 import android.graphics.Canvas;
-import android.graphics.PointF;
 
 import com.github.mikephil.charting.charts.RadarChart;
 import com.github.mikephil.charting.components.XAxis;
+import com.github.mikephil.charting.highlight.Highlight;
 import com.github.mikephil.charting.utils.MPPointF;
 import com.github.mikephil.charting.utils.Utils;
 import com.github.mikephil.charting.utils.ViewPortHandler;
@@ -21,7 +21,7 @@ public class XAxisRendererRadarChart extends XAxisRenderer {
     }
 
     @Override
-    public void renderAxisLabels(Canvas c) {
+    public void renderAxisLabels(Canvas c, Highlight[] indicesToHighlight) {
 
         if (!mXAxis.isEnabled() || !mXAxis.isDrawLabelsEnabled())
             return;

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/YAxisRendererHorizontalBarChart.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/YAxisRendererHorizontalBarChart.java
@@ -11,6 +11,7 @@ import com.github.mikephil.charting.components.LimitLine;
 import com.github.mikephil.charting.components.YAxis;
 import com.github.mikephil.charting.components.YAxis.AxisDependency;
 import com.github.mikephil.charting.components.YAxis.YAxisLabelPosition;
+import com.github.mikephil.charting.highlight.Highlight;
 import com.github.mikephil.charting.utils.MPPointD;
 import com.github.mikephil.charting.utils.Transformer;
 import com.github.mikephil.charting.utils.Utils;
@@ -64,7 +65,7 @@ public class YAxisRendererHorizontalBarChart extends YAxisRenderer {
      * draws the y-axis labels to the screen
      */
     @Override
-    public void renderAxisLabels(Canvas c) {
+    public void renderAxisLabels(Canvas c, Highlight[] indicesToHighlight) {
 
         if (!mYAxis.isEnabled() || !mYAxis.isDrawLabelsEnabled())
             return;

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/YAxisRendererRadarChart.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/YAxisRendererRadarChart.java
@@ -7,6 +7,7 @@ import android.graphics.PointF;
 import com.github.mikephil.charting.charts.RadarChart;
 import com.github.mikephil.charting.components.LimitLine;
 import com.github.mikephil.charting.components.YAxis;
+import com.github.mikephil.charting.highlight.Highlight;
 import com.github.mikephil.charting.utils.MPPointF;
 import com.github.mikephil.charting.utils.Utils;
 import com.github.mikephil.charting.utils.ViewPortHandler;
@@ -145,7 +146,7 @@ public class YAxisRendererRadarChart extends YAxisRenderer {
     }
 
     @Override
-    public void renderAxisLabels(Canvas c) {
+    public void renderAxisLabels(Canvas c, Highlight[] indicesToHighlight) {
 
         if (!mYAxis.isEnabled() || !mYAxis.isDrawLabelsEnabled())
             return;


### PR DESCRIPTION
Resolves #222, Resolves #3879, Resolves #3872, Resolves #3669, Resolves #3550, Resolves #3352, Resolves #3269.

If y-axis uses the default value formater then the highlighted label value will be of the same precision as the normal labels.
Highlighted labels width is not taken into account when the longest label is calculated. That means if an y-axis highlighted label is longer than the normal labels it will get out of the axis bounds.

XAxis offsets computation has been moved from `Utils.drawXAxisValue` into a separate function to make it accessable to `XAxisRender.drawHighlightLabels`.

Inspired by PR #4477.