### PR TITLE
add radar layer custom color support

### DIFF
--- a/.idea/runConfigurations/MPChartExample.xml
+++ b/.idea/runConfigurations/MPChartExample.xml
@@ -1,10 +1,13 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="MPChartExample" type="AndroidRunConfigurationType" factoryName="Android App" activateToolWindowBeforeRun="false">
-    <module name="MPChartExample" />
+    <module name="MPAndroidChart.MPChartExample" />
     <option name="DEPLOY" value="true" />
     <option name="DEPLOY_APK_FROM_BUNDLE" value="false" />
+    <option name="DEPLOY_AS_INSTANT" value="false" />
     <option name="ARTIFACT_NAME" value="" />
     <option name="PM_INSTALL_OPTIONS" value="" />
+    <option name="ALL_USERS" value="false" />
+    <option name="ALWAYS_INSTALL_WITH_PM" value="false" />
     <option name="DYNAMIC_FEATURES_DISABLED_LIST" value="" />
     <option name="ACTIVITY_EXTRA_FLAGS" value="" />
     <option name="MODE" value="default_activity" />
@@ -12,9 +15,8 @@
     <option name="SHOW_LOGCAT_AUTOMATICALLY" value="false" />
     <option name="SKIP_NOOP_APK_INSTALLATIONS" value="true" />
     <option name="FORCE_STOP_RUNNING_APP" value="true" />
+    <option name="INSPECTION_WITHOUT_ACTIVITY_RESTART" value="false" />
     <option name="TARGET_SELECTION_MODE" value="SHOW_DIALOG" />
-    <option name="USE_LAST_SELECTED_DEVICE" value="false" />
-    <option name="PREFERRED_AVD" value="" />
     <option name="SELECTED_CLOUD_MATRIX_CONFIGURATION_ID" value="-1" />
     <option name="SELECTED_CLOUD_MATRIX_PROJECT_ID" value="" />
     <option name="DEBUGGER_TYPE" value="Auto" />
@@ -42,11 +44,18 @@
     </Native>
     <Profilers>
       <option name="ADVANCED_PROFILING_ENABLED" value="false" />
+      <option name="STARTUP_PROFILING_ENABLED" value="false" />
       <option name="STARTUP_CPU_PROFILING_ENABLED" value="false" />
       <option name="STARTUP_CPU_PROFILING_CONFIGURATION_NAME" value="Sampled (Java)" />
+      <option name="STARTUP_NATIVE_MEMORY_PROFILING_ENABLED" value="false" />
+      <option name="NATIVE_MEMORY_SAMPLE_RATE_BYTES" value="2048" />
     </Profilers>
     <option name="DEEP_LINK" value="" />
     <option name="ACTIVITY_CLASS" value="" />
-    <method />
+    <option name="SEARCH_ACTIVITY_IN_GLOBAL_SCOPE" value="false" />
+    <option name="SKIP_ACTIVITY_VALIDATION" value="false" />
+    <method v="2">
+      <option name="Android.Gradle.BeforeRunTask" enabled="true" />
+    </method>
   </configuration>
 </component>

--- a/MPChartExample/src/main/java/com/xxmassdeveloper/mpchartexample/RadarChartActivity.java
+++ b/MPChartExample/src/main/java/com/xxmassdeveloper/mpchartexample/RadarChartActivity.java
@@ -29,6 +29,7 @@ import com.xxmassdeveloper.mpchartexample.custom.RadarMarkerView;
 import com.xxmassdeveloper.mpchartexample.notimportant.DemoBase;
 
 import java.util.ArrayList;
+import java.util.List;
 
 public class RadarChartActivity extends DemoBase {
 
@@ -147,6 +148,13 @@ public class RadarChartActivity extends DemoBase {
         data.setValueTextColor(Color.WHITE);
 
         chart.setData(data);
+        List<Integer> colorList = new ArrayList<>();
+        colorList.add(Color.rgb(222, 166, 111));
+        colorList.add(Color.rgb(220, 206, 138));
+        colorList.add(Color.rgb(243, 255, 192));
+        colorList.add(Color.rgb(240, 255, 240));
+        colorList.add(Color.rgb(250, 255, 250));
+        chart.setLayerColorList(colorList);
         chart.invalidate();
     }
 

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/charts/RadarChart.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/charts/RadarChart.java
@@ -16,6 +16,8 @@ import com.github.mikephil.charting.renderer.XAxisRendererRadarChart;
 import com.github.mikephil.charting.renderer.YAxisRendererRadarChart;
 import com.github.mikephil.charting.utils.Utils;
 
+import java.util.List;
+
 /**
  * Implementation of the RadarChart, a "spidernet"-like chart. It works best
  * when displaying 5-10 entries per DataSet.
@@ -63,6 +65,8 @@ public class RadarChart extends PieRadarChartBase<RadarData> {
      * the object reprsenting the y-axis labels
      */
     private YAxis mYAxis;
+
+    private List<Integer> colorList;
 
     protected YAxisRendererRadarChart mYAxisRenderer;
     protected XAxisRendererRadarChart mXAxisRenderer;
@@ -177,6 +181,25 @@ public class RadarChart extends PieRadarChartBase<RadarData> {
      */
     public float getSliceAngle() {
         return 360f / (float) mData.getMaxEntryCountSet().getEntryCount();
+    }
+
+
+    public void setLayerColorList(List<Integer> colorList) {
+        if (colorList == null || colorList.size() == 0) {
+            return;
+        }
+        this.colorList = colorList;
+    }
+
+    public boolean isCustomLayerColorEnable() {
+        if (mData == null) {
+            return false;
+        }
+        return colorList != null && colorList.size() == mData.getEntryCount();
+    }
+
+    public List<Integer> getLayerColorList() {
+        return colorList;
     }
 
     @Override

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/charts/RadarChart.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/charts/RadarChart.java
@@ -195,7 +195,7 @@ public class RadarChart extends PieRadarChartBase<RadarData> {
         if (mData == null) {
             return false;
         }
-        return colorList != null && colorList.size() == mData.getEntryCount();
+        return colorList != null && colorList.size() == getYAxis().mEntryCount;
     }
 
     public List<Integer> getLayerColorList() {

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/RadarChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/RadarChartRenderer.java
@@ -28,6 +28,12 @@ public class RadarChartRenderer extends LineRadarRenderer {
     protected Paint mWebPaint;
     protected Paint mHighlightCirclePaint;
 
+    private Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG);
+    private Path previousPath = new Path();
+    private Path innerArea = new Path();
+    private Path temp = new Path();
+
+
     public RadarChartRenderer(RadarChart chart, ChartAnimator animator,
                               ViewPortHandler viewPortHandler) {
         super(animator, viewPortHandler);
@@ -37,6 +43,10 @@ public class RadarChartRenderer extends LineRadarRenderer {
         mHighlightPaint.setStyle(Paint.Style.STROKE);
         mHighlightPaint.setStrokeWidth(2f);
         mHighlightPaint.setColor(Color.rgb(255, 187, 115));
+
+        paint.setStyle(Paint.Style.FILL);
+        paint.setStrokeWidth(2f);
+        paint.setColor(Color.RED);
 
         mWebPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
         mWebPaint.setStyle(Paint.Style.STROKE);
@@ -70,6 +80,7 @@ public class RadarChartRenderer extends LineRadarRenderer {
     }
 
     protected Path mDrawDataSetSurfacePathBuffer = new Path();
+
     /**
      * Draws the RadarDataSet
      *
@@ -89,7 +100,7 @@ public class RadarChartRenderer extends LineRadarRenderer {
         float factor = mChart.getFactor();
 
         MPPointF center = mChart.getCenterOffsets();
-        MPPointF pOut = MPPointF.getInstance(0,0);
+        MPPointF pOut = MPPointF.getInstance(0, 0);
         Path surface = mDrawDataSetSurfacePathBuffer;
         surface.reset();
 
@@ -159,8 +170,8 @@ public class RadarChartRenderer extends LineRadarRenderer {
         float factor = mChart.getFactor();
 
         MPPointF center = mChart.getCenterOffsets();
-        MPPointF pOut = MPPointF.getInstance(0,0);
-        MPPointF pIcon = MPPointF.getInstance(0,0);
+        MPPointF pOut = MPPointF.getInstance(0, 0);
+        MPPointF pIcon = MPPointF.getInstance(0, 0);
 
         float yoffset = Utils.convertDpToPixel(5f);
 
@@ -182,11 +193,11 @@ public class RadarChartRenderer extends LineRadarRenderer {
 
                 RadarEntry entry = dataSet.getEntryForIndex(j);
 
-                 Utils.getPosition(
-                         center,
-                         (entry.getY() - mChart.getYChartMin()) * factor * phaseY,
-                         sliceangle * j * phaseX + mChart.getRotationAngle(),
-                         pOut);
+                Utils.getPosition(
+                        center,
+                        (entry.getY() - mChart.getYChartMin()) * factor * phaseY,
+                        sliceangle * j * phaseX + mChart.getRotationAngle(),
+                        pOut);
 
                 if (dataSet.isDrawValuesEnabled()) {
                     drawValue(c,
@@ -216,8 +227,8 @@ public class RadarChartRenderer extends LineRadarRenderer {
                     Utils.drawImage(
                             c,
                             icon,
-                            (int)pIcon.x,
-                            (int)pIcon.y,
+                            (int) pIcon.x,
+                            (int) pIcon.y,
                             icon.getIntrinsicWidth(),
                             icon.getIntrinsicHeight());
                 }
@@ -255,7 +266,7 @@ public class RadarChartRenderer extends LineRadarRenderer {
         final int xIncrements = 1 + mChart.getSkipWebLineCount();
         int maxEntryCount = mChart.getData().getMaxEntryCountSet().getEntryCount();
 
-        MPPointF p = MPPointF.getInstance(0,0);
+        MPPointF p = MPPointF.getInstance(0, 0);
         for (int i = 0; i < maxEntryCount; i += xIncrements) {
 
             Utils.getPosition(
@@ -275,20 +286,43 @@ public class RadarChartRenderer extends LineRadarRenderer {
 
         int labelCount = mChart.getYAxis().mEntryCount;
 
-        MPPointF p1out = MPPointF.getInstance(0,0);
-        MPPointF p2out = MPPointF.getInstance(0,0);
+        MPPointF p1out = MPPointF.getInstance(0, 0);
+        MPPointF p2out = MPPointF.getInstance(0, 0);
+
         for (int j = 0; j < labelCount; j++) {
-
+            if (mChart.isCustomLayerColorEnable()) {
+                innerArea.rewind();
+                paint.setColor(mChart.getLayerColorList().get(j));
+            }
             for (int i = 0; i < mChart.getData().getEntryCount(); i++) {
-
                 float r = (mChart.getYAxis().mEntries[j] - mChart.getYChartMin()) * factor;
 
                 Utils.getPosition(center, r, sliceangle * i + rotationangle, p1out);
                 Utils.getPosition(center, r, sliceangle * (i + 1) + rotationangle, p2out);
 
                 c.drawLine(p1out.x, p1out.y, p2out.x, p2out.y, mWebPaint);
+                if (mChart.isCustomLayerColorEnable()) {
+                    if (p1out.x != p2out.x) {
+                        if (i == 0) {
+                            innerArea.moveTo(p1out.x, p1out.y);
+                        } else {
+                            innerArea.lineTo(p1out.x, p1out.y);
+                        }
+                        innerArea.lineTo(p2out.x, p2out.y);
+                    }
+                }
 
 
+            }
+            if (mChart.isCustomLayerColorEnable()) {
+                temp.set(innerArea);
+                if (!innerArea.isEmpty()) {
+                    boolean result = innerArea.op(previousPath, Path.Op.DIFFERENCE);
+                    if (result) {
+                        c.drawPath(innerArea, paint);
+                    }
+                }
+                previousPath.set(temp);
             }
         }
         MPPointF.recycleInstance(p1out);
@@ -305,7 +339,7 @@ public class RadarChartRenderer extends LineRadarRenderer {
         float factor = mChart.getFactor();
 
         MPPointF center = mChart.getCenterOffsets();
-        MPPointF pOut = MPPointF.getInstance(0,0);
+        MPPointF pOut = MPPointF.getInstance(0, 0);
 
         RadarData radarData = mChart.getData();
 
@@ -362,6 +396,7 @@ public class RadarChartRenderer extends LineRadarRenderer {
     }
 
     protected Path mDrawHighlightCirclePathBuffer = new Path();
+
     public void drawHighlightCircle(Canvas c,
                                     MPPointF point,
                                     float innerRadius,


### PR DESCRIPTION
## PR Checklist:
- [x] I have tested this extensively and it does not break any existing behavior.
- [x] I have added/updated examples and tests for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change, please
            create an issue to discuss those changes and gather
            feedback BEFORE submitting your PR. -->


## PR Description
<!-- Describe Your PR Here! -->
before the pr, radar chart cannot custom the chart layer background, like this:
![Screenshot_20220303_192335](https://user-images.githubusercontent.com/1454424/156556271-bcebcdca-7375-4646-83a2-b9354175240c.png)

before the pr, radar chart can  custom the chart layer background by a new api, like this:
![Screenshot_20220303_192240](https://user-images.githubusercontent.com/1454424/156556587-7e42c786-10bd-4360-a2a5-e4500140b48c.png)

<!-- What does this add/ remove/ fix/ change? -->
radar chart can  custom the chart layer background by a new api

<!-- WHY should this PR be merged into the main library? -->

reference by this:[https://stackoverflow.com/questions/71331675/how-to-fill-color-layer-yaxis-in-mpandroidchart-radar-chart/](url)