### PR TITLE
Fix Drawable LineChart Fill Bug

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/components/AxisBase.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/components/AxisBase.java
@@ -51,6 +51,11 @@ public abstract class AxisBase extends ComponentBase {
      * the number of decimal digits to use
      */
     public int mDecimals;
+    
+    /**
+     * if the user set a custom number of decimals
+     */
+    public boolean mHasCustomDecimals = false;
 
     /**
      * the number of label entries the axis should have, default 6
@@ -812,5 +817,14 @@ public abstract class AxisBase extends ComponentBase {
     public void setSpaceMax(float mSpaceMax)
     {
         this.mSpaceMax = mSpaceMax;
+    }
+    
+    /**
+     * Sets the number of decimals to use when formatting values on the axis
+     */
+    public void setDecimals(int mDecimals)
+    {
+        this.mDecimals = mDecimals;
+        this.mHasCustomDecimals = true;
     }
 }

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/AxisRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/AxisRenderer.java
@@ -243,10 +243,12 @@ public abstract class AxisRenderer extends Renderer {
         }
 
         // set decimals
-        if (interval < 1) {
-            mAxis.mDecimals = (int) Math.ceil(-Math.log10(interval));
-        } else {
-            mAxis.mDecimals = 0;
+        if (!mAxis.mHasCustomDecimals) {
+            if (interval < 1) {
+                mAxis.mDecimals = (int) Math.ceil(-Math.log10(interval));
+            } else {
+                mAxis.mDecimals = 0;
+            }
         }
 
         if (mAxis.isCenterAxisLabelsEnabled()) {

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineChartRenderer.java
@@ -471,7 +471,7 @@ public class LineChartRenderer extends LineRadarRenderer {
                 int endIndex = currentEndIndex;
 
                 // Add a little extra to the path for drawables, larger data sets were showing space between adjacent drawables
-                if (drawable != null) {
+                if (drawable != null && dataSet.getEntryCount() > 200) {
 
                     startIndex = Math.max(0, currentStartIndex - 1);
                     endIndex = Math.min(endingIndex, currentEndIndex + 1);

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineChartRenderer.java
@@ -462,14 +462,25 @@ public class LineChartRenderer extends LineRadarRenderer {
         do {
             currentStartIndex = startingIndex + (iterations * indexInterval);
             currentEndIndex = currentStartIndex + indexInterval;
-            currentEndIndex = currentEndIndex > endingIndex ? endingIndex : currentEndIndex;
+            currentEndIndex = Math.min(currentEndIndex, endingIndex);
 
             if (currentStartIndex <= currentEndIndex) {
-                generateFilledPath(dataSet, currentStartIndex, currentEndIndex, filled);
+                final Drawable drawable = dataSet.getFillDrawable();
+
+                int startIndex = currentStartIndex;
+                int endIndex = currentEndIndex;
+
+                // Add a little extra to the path for drawables, larger data sets were showing space between adjacent drawables
+                if (drawable != null) {
+
+                    startIndex = Math.max(0, currentStartIndex - 1);
+                    endIndex = Math.min(endingIndex, currentEndIndex + 1);
+                }
+
+                generateFilledPath(dataSet, startIndex, endIndex, filled);
 
                 trans.pathValueToPixel(filled);
 
-                final Drawable drawable = dataSet.getFillDrawable();
                 if (drawable != null) {
 
                     drawFilledPath(c, filled, drawable);


### PR DESCRIPTION
## PR Checklist:
- [x ] I have tested this extensively and it does not break any existing behavior.
- [x] I have added/updated examples and tests for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change, please
            create an issue to discuss those changes and gather
            feedback BEFORE submitting your PR. -->


## PR Description

The LineChart fill draws using intervals to avoid
memory issues, but with a larger data set and many
different (darker) colors Android does not draw the
drawable all the way to the edge of the interval.
This makes it look like there are spaces between the fill.
Draw a little beyond the existing interval so there are no gaps.

Here is what it looks like before my change, look closely at the white vertical lines at ~1/5 ~3/5 ~4/5 of the way across the X-axis.
![fill issue](https://user-images.githubusercontent.com/10697351/161335153-86c5dd7b-d9ca-48ec-ba45-f1947e3fd47a.png)

The same color with the fix no longer has gaps.
![fill fixed](https://user-images.githubusercontent.com/10697351/161335205-dbbdbaed-0745-49c9-a2ee-99bd627062e4.png)

