### PR TITLE
Fix scatter shape size bug

### DIFF
--- a/MPChartExample/src/main/java/com/xxmassdeveloper/mpchartexample/custom/CustomScatterShapeRenderer.java
+++ b/MPChartExample/src/main/java/com/xxmassdeveloper/mpchartexample/custom/CustomScatterShapeRenderer.java
@@ -5,6 +5,7 @@ import android.graphics.Paint;
 
 import com.github.mikephil.charting.interfaces.datasets.IScatterDataSet;
 import com.github.mikephil.charting.renderer.scatter.IShapeRenderer;
+import com.github.mikephil.charting.utils.Utils;
 import com.github.mikephil.charting.utils.ViewPortHandler;
 
 /**
@@ -18,7 +19,7 @@ public class CustomScatterShapeRenderer implements IShapeRenderer
     public void renderShape(Canvas c, IScatterDataSet dataSet, ViewPortHandler viewPortHandler,
                             float posX, float posY, Paint renderPaint) {
 
-        final float shapeHalf = dataSet.getScatterShapeSize() / 2f;
+        final float shapeHalf = Utils.convertDpToPixel(dataSet.getScatterShapeSize()) / 2f;
 
         c.drawLine(
                 posX - shapeHalf,

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/scatter/ChevronDownShapeRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/scatter/ChevronDownShapeRenderer.java
@@ -19,7 +19,7 @@ public class ChevronDownShapeRenderer implements IShapeRenderer
     public void renderShape(Canvas c, IScatterDataSet dataSet, ViewPortHandler viewPortHandler,
                      float posX, float posY, Paint renderPaint) {
 
-        final float shapeHalf = dataSet.getScatterShapeSize() / 2f;
+        final float shapeHalf = Utils.convertDpToPixel(dataSet.getScatterShapeSize()) / 2f;
 
         renderPaint.setStyle(Paint.Style.STROKE);
         renderPaint.setStrokeWidth(Utils.convertDpToPixel(1f));

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/scatter/ChevronUpShapeRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/scatter/ChevronUpShapeRenderer.java
@@ -19,7 +19,7 @@ public class ChevronUpShapeRenderer implements IShapeRenderer
     public void renderShape(Canvas c, IScatterDataSet dataSet, ViewPortHandler viewPortHandler,
                             float posX, float posY, Paint renderPaint) {
 
-        final float shapeHalf = dataSet.getScatterShapeSize() / 2f;
+        final float shapeHalf = Utils.convertDpToPixel(dataSet.getScatterShapeSize()) / 2f;
 
         renderPaint.setStyle(Paint.Style.STROKE);
         renderPaint.setStrokeWidth(Utils.convertDpToPixel(1f));

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/scatter/CircleShapeRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/scatter/CircleShapeRenderer.java
@@ -19,7 +19,7 @@ public class CircleShapeRenderer implements IShapeRenderer
     public void renderShape(Canvas c, IScatterDataSet dataSet, ViewPortHandler viewPortHandler,
                             float posX, float posY, Paint renderPaint) {
 
-        final float shapeSize = dataSet.getScatterShapeSize();
+        final float shapeSize = Utils.convertDpToPixel(dataSet.getScatterShapeSize());
         final float shapeHalf = shapeSize / 2f;
         final float shapeHoleSizeHalf = Utils.convertDpToPixel(dataSet.getScatterShapeHoleRadius());
         final float shapeHoleSize = shapeHoleSizeHalf * 2.f;

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/scatter/CrossShapeRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/scatter/CrossShapeRenderer.java
@@ -19,7 +19,7 @@ public class CrossShapeRenderer implements IShapeRenderer
     public void renderShape(Canvas c, IScatterDataSet dataSet, ViewPortHandler viewPortHandler,
                             float posX, float posY, Paint renderPaint) {
 
-        final float shapeHalf = dataSet.getScatterShapeSize() / 2f;
+        final float shapeHalf = Utils.convertDpToPixel(dataSet.getScatterShapeSize()) / 2f;
 
         renderPaint.setStyle(Paint.Style.STROKE);
         renderPaint.setStrokeWidth(Utils.convertDpToPixel(1f));

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/scatter/SquareShapeRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/scatter/SquareShapeRenderer.java
@@ -20,7 +20,7 @@ public class SquareShapeRenderer implements IShapeRenderer
     public void renderShape(Canvas c, IScatterDataSet dataSet, ViewPortHandler viewPortHandler,
                             float posX, float posY, Paint renderPaint) {
 
-        final float shapeSize = dataSet.getScatterShapeSize();
+        final float shapeSize = Utils.convertDpToPixel(dataSet.getScatterShapeSize());
         final float shapeHalf = shapeSize / 2f;
         final float shapeHoleSizeHalf = Utils.convertDpToPixel(dataSet.getScatterShapeHoleRadius());
         final float shapeHoleSize = shapeHoleSizeHalf * 2.f;

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/scatter/TriangleShapeRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/scatter/TriangleShapeRenderer.java
@@ -22,7 +22,7 @@ public class TriangleShapeRenderer implements IShapeRenderer
     public void renderShape(Canvas c, IScatterDataSet dataSet, ViewPortHandler viewPortHandler,
                             float posX, float posY, Paint renderPaint) {
 
-        final float shapeSize = dataSet.getScatterShapeSize();
+        final float shapeSize = Utils.convertDpToPixel(dataSet.getScatterShapeSize());
         final float shapeHalf = shapeSize / 2f;
         final float shapeHoleSizeHalf = Utils.convertDpToPixel(dataSet.getScatterShapeHoleRadius());
         final float shapeHoleSize = shapeHoleSizeHalf * 2.f;

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/scatter/XShapeRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/scatter/XShapeRenderer.java
@@ -19,7 +19,7 @@ public class XShapeRenderer implements IShapeRenderer
     public void renderShape(Canvas c, IScatterDataSet dataSet, ViewPortHandler viewPortHandler,
                             float posX, float posY, Paint renderPaint) {
 
-        final float shapeHalf = dataSet.getScatterShapeSize() / 2f;
+        final float shapeHalf = Utils.convertDpToPixel(dataSet.getScatterShapeSize()) / 2f;
 
         renderPaint.setStyle(Paint.Style.STROKE);
         renderPaint.setStrokeWidth(Utils.convertDpToPixel(1f));


### PR DESCRIPTION
Scatter shape sizes were not converted from dp to pixels in the shape renderers so they were drawn at inconsistent size on different density screens.

## PR Checklist:
- [x] I have tested this extensively and it does not break any existing behavior.
- [x] I have added/updated examples and tests for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: [[issue link](https://github.com/PhilJay/MPAndroidChart/issues/5370)]
       <!-- If you'd like to suggest a significant change, please
            create an issue to discuss those changes and gather
            feedback BEFORE submitting your PR. -->


## PR Description
<!-- Describe Your PR Here! -->
Scatter shape size was treated as pixels instead of dp. This is a bug and leads to inconsistent appearance on different density screens. This is also inconsistent with other places (e.g. scatter hole size or line chart marker size) where values were properly treated as dp.

<!-- What does this add/ remove/ fix/ change? -->
This change fixes the scatter shape renderers so they scale the user-specified size from dp to pixels before drawing the marker.

<!-- WHY should this PR be merged into the main library? -->
Using pixels in just one place is a bug. This may cause existing chart markers to change size - and users who were pre-scaling this one dimension by density manually will have to remove that.
