### PR TITLE
fix after call setMinMaxScaleX, when scaleX to bound value, chart wil…

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/listener/BarLineChartTouchListener.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/listener/BarLineChartTouchListener.java
@@ -74,6 +74,10 @@ public class BarLineChartTouchListener extends ChartTouchListener<BarLineChartBa
      */
     private float mMinScalePointerDistance;
 
+
+    private final float[] matrixBuffer = new float[9];
+    private final Matrix tempMatrix = new Matrix();
+
     /**
      * Constructor with initialization parameters.
      *
@@ -378,9 +382,8 @@ public class BarLineChartTouchListener extends ChartTouchListener<BarLineChartBa
                     float scaleY = (mChart.isScaleYEnabled()) ? scale : 1f;
 
                     if (canZoomMoreY || canZoomMoreX) {
-
                         mMatrix.set(mSavedMatrix);
-                        mMatrix.postScale(scaleX, scaleY, t.x, t.y);
+                        mMatrix.postScale(getLimitedScaleX(scaleX, t), getLimitedScaleY(scaleY, t), t.x, t.y);
 
                         if (l != null)
                             l.onChartScale(event, scaleX, scaleY);
@@ -399,9 +402,8 @@ public class BarLineChartTouchListener extends ChartTouchListener<BarLineChartBa
                             h.canZoomInMoreX();
 
                     if (canZoomMoreX) {
-
                         mMatrix.set(mSavedMatrix);
-                        mMatrix.postScale(scaleX, 1f, t.x, t.y);
+                        mMatrix.postScale(getLimitedScaleX(scaleX, t), 1f, t.x, t.y);
 
                         if (l != null)
                             l.onChartScale(event, scaleX, 1f);
@@ -420,9 +422,8 @@ public class BarLineChartTouchListener extends ChartTouchListener<BarLineChartBa
                             h.canZoomInMoreY();
 
                     if (canZoomMoreY) {
-
                         mMatrix.set(mSavedMatrix);
-                        mMatrix.postScale(1f, scaleY, t.x, t.y);
+                        mMatrix.postScale(1f, getLimitedScaleY(scaleY, t), t.x, t.y);
 
                         if (l != null)
                             l.onChartScale(event, 1f, scaleY);
@@ -432,6 +433,59 @@ public class BarLineChartTouchListener extends ChartTouchListener<BarLineChartBa
                 MPPointF.recycleInstance(t);
             }
         }
+    }
+
+    /**
+     * limit scaleX range
+     * @param scaleX
+     * @param t
+     * @return
+     */
+    private float getLimitedScaleX(float scaleX, MPPointF t) {
+        ViewPortHandler h = mChart.getViewPortHandler();
+        tempMatrix.postScale(scaleX, 1f, t.x, t.y);
+
+        mSavedMatrix.getValues(matrixBuffer);
+        float lastScaleX = matrixBuffer[Matrix.MSCALE_X];
+
+        tempMatrix.getValues(matrixBuffer);
+        float calScaleX = matrixBuffer[Matrix.MSCALE_X];
+
+        float resultScaleX = scaleX;
+
+        if (calScaleX < h.getMinScaleX()) {
+            resultScaleX = h.getMinScaleX() / lastScaleX;
+        } else if (calScaleX > h.getMaxScaleX()) {
+            resultScaleX = h.getMaxScaleX() / lastScaleX;
+        }
+        return resultScaleX;
+    }
+
+    /**
+     * limit scaleY range
+     * @param scaleY
+     * @param t
+     * @return
+     */
+    private float getLimitedScaleY(float scaleY, MPPointF t) {
+        ViewPortHandler h = mChart.getViewPortHandler();
+        tempMatrix.set(mSavedMatrix);
+        tempMatrix.postScale(1f, scaleY, t.x, t.y);
+
+        mSavedMatrix.getValues(matrixBuffer);
+        float lastScaleY = matrixBuffer[Matrix.MSCALE_Y];
+
+        tempMatrix.getValues(matrixBuffer);
+        float calScaleY = matrixBuffer[Matrix.MSCALE_Y];
+
+        float resultScaleY = scaleY;
+
+        if (calScaleY < h.getMinScaleY()) {
+            resultScaleY = h.getMinScaleX() / lastScaleY;
+        } else if (calScaleY > h.getMaxScaleY()) {
+            resultScaleY = h.getMaxScaleX() / lastScaleY;
+        }
+        return resultScaleY;
     }
 
     /**

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/listener/BarLineChartTouchListener.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/listener/BarLineChartTouchListener.java
@@ -481,9 +481,9 @@ public class BarLineChartTouchListener extends ChartTouchListener<BarLineChartBa
         float resultScaleY = scaleY;
 
         if (calScaleY < h.getMinScaleY()) {
-            resultScaleY = h.getMinScaleX() / lastScaleY;
+            resultScaleY = h.getMinScaleY() / lastScaleY;
         } else if (calScaleY > h.getMaxScaleY()) {
-            resultScaleY = h.getMaxScaleX() / lastScaleY;
+            resultScaleY = h.getMaxScaleY() / lastScaleY;
         }
         return resultScaleY;
     }


### PR DESCRIPTION
After call setMinMaxScaleX, when operate chart zoom, while scaleX or scaleY scale to max value or min value, the chart will jump.

## PR Checklist:
- [x] I have tested this extensively and it does not break any existing behavior.
- [ ] I have added/updated examples and tests for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       #4489


## PR Description
In default BarLineChartTouchListener file, when handle zoom event, source code just post scaleX or scaleY, no check after call postScale the scaleX or scaleY value is valid.

This change limit scale to minScale or maxScale when zoom.
