### PR TITLE
Fixes issue #4334 where zoomAndCenterAnimated did not center

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/jobs/AnimatedZoomJob.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/jobs/AnimatedZoomJob.java
@@ -35,6 +35,10 @@ public class AnimatedZoomJob extends AnimatedViewPortJob implements Animator.Ani
         result.yOrigin = yOrigin;
         result.yAxis = axis;
         result.xAxisRange = xAxisRange;
+        result.zoomCenterX = zoomCenterX;
+        result.zoomCenterY = zoomCenterY;
+        result.zoomOriginX = zoomOriginX;
+        result.zoomOriginY = zoomOriginY;
         result.resetAnimator();
         result.animator.setDuration(duration);
         return result;


### PR DESCRIPTION
## PR Checklist:
- [x] I have tested this extensively and it does not break any existing behavior.
- [ ] I have added/updated examples and tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [#4334]
       <!-- If you'd like to suggest a significant change, please
            create an issue to discuss those changes and gather
            feedback BEFORE submitting your PR. -->


## PR Description
Fixes issue with zoomAndCenterAnimated do not center but zooms to the start of the graph. See issue #4334

In static method AnimatedZoomJob:getInstance added the assignment of the parameters zoomCenterX, zoomCenterY, zoomOriginX, zoomOriginY.

This is a tiny fix to this excellent library. The solution was suggested 4 years ago but noone created a PR. Please merge so me and others don't have to compile from source.